### PR TITLE
Turn on orchestrated dace:cpu on acoustics substep translate test

### DIFF
--- a/.github/workflows/translate.yml
+++ b/.github/workflows/translate.yml
@@ -32,6 +32,7 @@ jobs:
           run: |
             cd test_data
             wget https://portal.nccs.nasa.gov/datashare/astg/smt/pace-regression-data/8.1.3_c12_6_ranks_standard.FvTp2d.tar.gz
+            tar -xzvf 8.1.3_c12_6_ranks_standard.FvTp2d.tar.gz
             cd -
             pytest \
               -v -s --data_path=./test_data/8.1.3/c12_6ranks_standard/dycore \

--- a/.github/workflows/translate.yml
+++ b/.github/workflows/translate.yml
@@ -25,19 +25,14 @@ jobs:
           run: |
             python -m pip install --upgrade pip setuptools wheel
             pip install .[ndsl,test]
-        - name: Download data
+        - name: Prepare test_data
           run: |
             mkdir -p test_data
-            cd test_data
-            wget https://portal.nccs.nasa.gov/datashare/astg/smt/pace-regression-data/8.1.3_c12_6_ranks_standard.FvTp2d.tar.gz
-            tar -xzvf 8.1.3_c12_6_ranks_standard.FvTp2d.tar.gz
-            wget https://portal.nccs.nasa.gov/datashare/astg/smt/pace-regression-data/8.1.3_c12_6_ranks_standard.D_SW.tar.gz
-            tar -xzvf 8.1.3_c12_6_ranks_standard.D_SW.tar.gz
-            wget https://portal.nccs.nasa.gov/datashare/astg/smt/pace-regression-data/8.1.3_c12_6_ranks_standard.Remapping.tar.gz
-            tar -xzvf 8.1.3_c12_6_ranks_standard.Remapping.tar.gz
-            cd -
         - name: Numpy FvTp2d
           run: |
+            cd test_data
+            wget https://portal.nccs.nasa.gov/datashare/astg/smt/pace-regression-data/8.1.3_c12_6_ranks_standard.FvTp2d.tar.gz
+            cd -
             pytest \
               -v -s --data_path=./test_data/8.1.3/c12_6ranks_standard/dycore \
               --backend=numpy \
@@ -46,6 +41,10 @@ jobs:
               ./tests/savepoint
         - name: Numpy D_SW
           run: |
+            cd test_data
+            wget https://portal.nccs.nasa.gov/datashare/astg/smt/pace-regression-data/8.1.3_c12_6_ranks_standard.D_SW.tar.gz
+            tar -xzvf 8.1.3_c12_6_ranks_standard.D_SW.tar.gz
+            cd -
             pytest \
               -v -s --data_path=./test_data/8.1.3/c12_6ranks_standard/dycore \
               --backend=numpy \
@@ -54,9 +53,31 @@ jobs:
               ./tests/savepoint
         - name: Numpy Remapping
           run: |
+            cd test_data
+            wget https://portal.nccs.nasa.gov/datashare/astg/smt/pace-regression-data/8.1.3_c12_6_ranks_standard.Remapping.tar.gz
+            tar -xzvf 8.1.3_c12_6_ranks_standard.Remapping.tar.gz
+            cd -
             pytest \
               -v -s --data_path=./test_data/8.1.3/c12_6ranks_standard/dycore \
               --backend=numpy \
               --which_modules=Remapping \
+              --threshold_overrides_file=./tests/savepoint/translate/overrides/standard.yaml \
+              ./tests/savepoint
+        - name: Orchestrated dace:cpu FVDynamics
+          run: |
+            cd test_data
+            wget https://portal.nccs.nasa.gov/datashare/astg/smt/pace-regression-data/8.1.3_c12_6_ranks_standard.FVDynamics.tar.gz
+            tar -xzvf 8.1.3_c12_6_ranks_standard.FVDynamics.tar.gz
+            cd -
+            export FV3_DACEMODE=BuildAndRun
+            export PACE_FLOAT_PRECISION=64
+            export PACE_TEST_N_THRESHOLD_SAMPLES=0
+            export OMP_NUM_THREADS=1
+            export PACE_LOGLEVEL=Debug
+            mpirun -np 6 --oversubscribe pytest \
+              -v -s --data_path=./test_data/8.1.3/c12_6ranks_standard/dycore \
+              --backend=dace:cpu \
+              -m parallel \
+              --which_modules=FVDynamics \
               --threshold_overrides_file=./tests/savepoint/translate/overrides/standard.yaml \
               ./tests/savepoint

--- a/.github/workflows/translate.yml
+++ b/.github/workflows/translate.yml
@@ -79,6 +79,7 @@ jobs:
               -v -s --data_path=./test_data/8.1.3/c12_6ranks_standard/dycore \
               --backend=dace:cpu \
               -m parallel \
+              --which_rank=0 \
               --which_modules=FVDynamics \
               --threshold_overrides_file=./tests/savepoint/translate/overrides/standard.yaml \
               ./tests/savepoint

--- a/.github/workflows/translate.yml
+++ b/.github/workflows/translate.yml
@@ -64,11 +64,11 @@ jobs:
               --which_modules=Remapping \
               --threshold_overrides_file=./tests/savepoint/translate/overrides/standard.yaml \
               ./tests/savepoint
-        - name: Orchestrated dace:cpu FVDynamics
+        - name: Orchestrated dace:cpu Acoustics
           run: |
             cd test_data
-            wget https://portal.nccs.nasa.gov/datashare/astg/smt/pace-regression-data/8.1.3_c12_6_ranks_standard.FVDynamics.tar.gz
-            tar -xzvf 8.1.3_c12_6_ranks_standard.FVDynamics.tar.gz
+            wget https://portal.nccs.nasa.gov/datashare/astg/smt/pace-regression-data/8.1.3_c12_6_ranks_standard.DynCore.tar.gz
+            tar -xzvf 8.1.3_c12_6_ranks_standard.DynCore.tar.gz
             cd -
             export FV3_DACEMODE=BuildAndRun
             export PACE_FLOAT_PRECISION=64
@@ -80,6 +80,6 @@ jobs:
               --backend=dace:cpu \
               -m parallel \
               --which_rank=0 \
-              --which_modules=FVDynamics \
+              --which_modules=DynCore \
               --threshold_overrides_file=./tests/savepoint/translate/overrides/standard.yaml \
               ./tests/savepoint

--- a/.github/workflows/translate.yml
+++ b/.github/workflows/translate.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python: [3.11.7]
+        python: [3.8.12]
     steps:
         - name: Checkout repository
           uses: actions/checkout@v3.5.2
@@ -75,7 +75,7 @@ jobs:
             export PACE_TEST_N_THRESHOLD_SAMPLES=0
             export OMP_NUM_THREADS=1
             export PACE_LOGLEVEL=Debug
-            mpirun -np 6 --oversubscribe pytest \
+            mpirun -mca orte_abort_on_non_zero_status 1 -np 6 --oversubscribe pytest \
               -v -s --data_path=./test_data/8.1.3/c12_6ranks_standard/dycore \
               --backend=dace:cpu \
               -m parallel \


### PR DESCRIPTION
- `DynCore` translate test run with orchestrated `dace:cpu` on 6 oversubscribed processes
- We limit the `DynCore` test to a single rank check to keep unit test timing reasonable
- Move download/untar next to execution to relax bandwidth needs on the datashare server