### PR TITLE
[Feature] `delnflux` all nord

### DIFF
--- a/pyFV3/stencils/d_sw.py
+++ b/pyFV3/stencils/d_sw.py
@@ -12,13 +12,11 @@ from gt4py.cartesian.gtscript import (
 
 import pyFV3.stencils.delnflux as delnflux
 from ndsl.constants import (
-    CONST_VERSION,
     X_DIM,
     X_INTERFACE_DIM,
     Y_DIM,
     Y_INTERFACE_DIM,
     Z_DIM,
-    ConstantVersions,
 )
 from ndsl.dsl.dace.orchestration import orchestrate
 from ndsl.dsl.stencil import StencilFactory
@@ -34,6 +32,7 @@ from pyFV3.stencils.fvtp2d import FiniteVolumeTransport
 from pyFV3.stencils.fxadv import FiniteVolumeFluxPrep
 from pyFV3.stencils.xtp_u import advect_u_along_x
 from pyFV3.stencils.ytp_v import advect_v_along_y
+from pyFV3.version import IS_GEOS
 
 
 dcon_threshold = 1e-5
@@ -706,7 +705,7 @@ def get_column_namelist(
         if config.d2_bg_k2 > 0.05:
             col["d2_divg"].view[2] = max(config.d2_bg, 0.2 * config.d2_bg_k2)
             set_low_kvals(col, 2)
-            if CONST_VERSION == ConstantVersions.GEOS:
+            if IS_GEOS:
                 # In GEOS the column values are set after K==3 up until the sponge
                 # layer top, defined in config
                 for n in range(3, config.n_sponge):

--- a/pyFV3/stencils/d_sw.py
+++ b/pyFV3/stencils/d_sw.py
@@ -3,9 +3,7 @@ from typing import Dict, Mapping
 import gt4py.cartesian.gtscript as gtscript
 from gt4py.cartesian.gtscript import (
     __INLINED,
-    CONST_VERSION,
     PARALLEL,
-    ConstantVersions,
     computation,
     horizontal,
     interval,
@@ -13,7 +11,15 @@ from gt4py.cartesian.gtscript import (
 )
 
 import pyFV3.stencils.delnflux as delnflux
-from ndsl.constants import X_DIM, X_INTERFACE_DIM, Y_DIM, Y_INTERFACE_DIM, Z_DIM
+from ndsl.constants import (
+    X_DIM,
+    X_INTERFACE_DIM,
+    Y_DIM,
+    Y_INTERFACE_DIM,
+    Z_DIM,
+    CONST_VERSION,
+    ConstantVersions,
+)
 from ndsl.dsl.dace.orchestration import orchestrate
 from ndsl.dsl.stencil import StencilFactory
 from ndsl.dsl.typing import Float, FloatField, FloatFieldIJ, FloatFieldK

--- a/pyFV3/stencils/d_sw.py
+++ b/pyFV3/stencils/d_sw.py
@@ -688,7 +688,10 @@ def get_column_namelist(
         col[name].view[:] = getattr(config, name)
 
     col["d2_divg"].view[:] = min(0.2, config.d2_bg)
-    col["nord_v"].view[:] = min(2, config.nord)
+    nord = min(2, config.nord)
+    col["nord_v"].view[:] = nord
+    col["nord_w"].view[:] = nord
+    col["nord_t"].view[:] = nord
     if config.do_vort_damp:
         col["damp_vt"].view[:] = config.vtdm4
     else:
@@ -715,8 +718,6 @@ def get_column_namelist(
                 for n in range(3, config.n_sponge):
                     col["d2_divg"].view[n] = max(config.d2_bg, 0.2 * config.d2_bg_k2)
                     set_low_kvals(col, n)
-    col["nord_w"].view[:] = col["nord_v"].view[:]
-    col["nord_t"].view[:] = col["nord_v"].view[:]
 
     # Checks for the column calculations
     # Those checks are expected in the rest of the code. DO NOT REMOVE even if the

--- a/pyFV3/stencils/d_sw.py
+++ b/pyFV3/stencils/d_sw.py
@@ -689,8 +689,6 @@ def get_column_namelist(
 
     col["d2_divg"].view[:] = min(0.2, config.d2_bg)
     col["nord_v"].view[:] = min(2, config.nord)
-    col["nord_w"].view[:] = col["nord_v"].view[0]
-    col["nord_t"].view[:] = col["nord_v"].view[0]
     if config.do_vort_damp:
         col["damp_vt"].view[:] = config.vtdm4
     else:
@@ -717,6 +715,8 @@ def get_column_namelist(
                 for n in range(3, config.n_sponge):
                     col["d2_divg"].view[n] = max(config.d2_bg, 0.2 * config.d2_bg_k2)
                     set_low_kvals(col, n)
+    col["nord_w"].view[:] = col["nord_v"].view[:]
+    col["nord_t"].view[:] = col["nord_v"].view[:]
 
     # Checks for the column calculations
     # Those checks are expected in the rest of the code. DO NOT REMOVE even if the

--- a/pyFV3/stencils/d_sw.py
+++ b/pyFV3/stencils/d_sw.py
@@ -11,13 +11,7 @@ from gt4py.cartesian.gtscript import (
 )
 
 import pyFV3.stencils.delnflux as delnflux
-from ndsl.constants import (
-    X_DIM,
-    X_INTERFACE_DIM,
-    Y_DIM,
-    Y_INTERFACE_DIM,
-    Z_DIM,
-)
+from ndsl.constants import X_DIM, X_INTERFACE_DIM, Y_DIM, Y_INTERFACE_DIM, Z_DIM
 from ndsl.dsl.dace.orchestration import orchestrate
 from ndsl.dsl.stencil import StencilFactory
 from ndsl.dsl.typing import Float, FloatField, FloatFieldIJ, FloatFieldK

--- a/pyFV3/stencils/d_sw.py
+++ b/pyFV3/stencils/d_sw.py
@@ -3,13 +3,13 @@ from typing import Dict, Mapping
 import gt4py.cartesian.gtscript as gtscript
 from gt4py.cartesian.gtscript import (
     __INLINED,
+    CONST_VERSION,
     PARALLEL,
+    ConstantVersions,
     computation,
     horizontal,
     interval,
     region,
-    CONST_VERSION,
-    ConstantVersions,
 )
 
 import pyFV3.stencils.delnflux as delnflux

--- a/pyFV3/stencils/d_sw.py
+++ b/pyFV3/stencils/d_sw.py
@@ -12,12 +12,12 @@ from gt4py.cartesian.gtscript import (
 
 import pyFV3.stencils.delnflux as delnflux
 from ndsl.constants import (
+    CONST_VERSION,
     X_DIM,
     X_INTERFACE_DIM,
     Y_DIM,
     Y_INTERFACE_DIM,
     Z_DIM,
-    CONST_VERSION,
     ConstantVersions,
 )
 from ndsl.dsl.dace.orchestration import orchestrate

--- a/pyFV3/stencils/delnflux.py
+++ b/pyFV3/stencils/delnflux.py
@@ -3,13 +3,7 @@ from typing import Optional
 import gt4py.cartesian.gtscript as gtscript
 from gt4py.cartesian.gtscript import PARALLEL, computation, horizontal, interval, region
 
-from ndsl.constants import (
-    X_DIM,
-    X_INTERFACE_DIM,
-    Y_DIM,
-    Y_INTERFACE_DIM,
-    Z_DIM,
-)
+from ndsl.constants import X_DIM, X_INTERFACE_DIM, Y_DIM, Y_INTERFACE_DIM, Z_DIM
 from ndsl.dsl.dace.orchestration import orchestrate
 from ndsl.dsl.stencil import StencilFactory, get_stencils_with_varied_bounds
 from ndsl.dsl.typing import Float, FloatField, FloatFieldIJ, FloatFieldK

--- a/pyFV3/stencils/delnflux.py
+++ b/pyFV3/stencils/delnflux.py
@@ -10,7 +10,6 @@ from ndsl.dsl.typing import Float, FloatField, FloatFieldIJ, FloatFieldK
 from ndsl.grid import DampingCoefficients
 from ndsl.initialization.allocator import QuantityFactory
 from ndsl.quantity import Quantity
-from pyFV3.version import IS_GEOS
 
 
 def calc_damp(damp_c: Quantity, da_min: Float, nord: Quantity) -> Quantity:

--- a/pyFV3/stencils/delnflux.py
+++ b/pyFV3/stencils/delnflux.py
@@ -4,13 +4,11 @@ import gt4py.cartesian.gtscript as gtscript
 from gt4py.cartesian.gtscript import PARALLEL, computation, horizontal, interval, region
 
 from ndsl.constants import (
-    CONST_VERSION,
     X_DIM,
     X_INTERFACE_DIM,
     Y_DIM,
     Y_INTERFACE_DIM,
     Z_DIM,
-    ConstantVersions,
 )
 from ndsl.dsl.dace.orchestration import orchestrate
 from ndsl.dsl.stencil import StencilFactory, get_stencils_with_varied_bounds
@@ -18,6 +16,7 @@ from ndsl.dsl.typing import Float, FloatField, FloatFieldIJ, FloatFieldK
 from ndsl.grid import DampingCoefficients
 from ndsl.initialization.allocator import QuantityFactory
 from ndsl.quantity import Quantity
+from pyFV3.version import IS_GEOS
 
 
 def calc_damp(damp_c: Quantity, da_min: Float, nord: Quantity) -> Quantity:
@@ -146,13 +145,11 @@ def d2_highorder_stencil_GEOS(
             d2 = ((fx - fx[1, 0, 0]) + (fy - fy[0, 1, 0])) * rarea
 
 
-def _get_highorder_stencil(key: ConstantVersions):
-    if key == ConstantVersions.GFS or key == ConstantVersions.GFDL:
-        return d2_highorder_stencil_FV3GFS
-    elif key == ConstantVersions.GEOS:
+def _get_highorder_stencil():
+    if IS_GEOS:
         return d2_highorder_stencil_GEOS
     else:
-        raise NotImplementedError(f"Ambiguous code for DelnFlux with constant {key}")
+        return d2_highorder_stencil_FV3GFS
 
 
 def d2_damp_interval(
@@ -602,7 +599,7 @@ class DelnFluxNoSG:
         )
 
         self._d2_stencil = get_stencils_with_varied_bounds(
-            _get_highorder_stencil(CONST_VERSION),
+            _get_highorder_stencil,
             origins_d2,
             domains_d2,
             stencil_factory=stencil_factory,

--- a/pyFV3/stencils/delnflux.py
+++ b/pyFV3/stencils/delnflux.py
@@ -1,16 +1,17 @@
 from typing import Optional
 
 import gt4py.cartesian.gtscript as gtscript
-from gt4py.cartesian.gtscript import (
-    __INLINED,
-    PARALLEL,
-    computation,
-    horizontal,
-    interval,
-    region,
-)
+from gt4py.cartesian.gtscript import PARALLEL, computation, horizontal, interval, region
 
-from ndsl.constants import X_DIM, X_INTERFACE_DIM, Y_DIM, Y_INTERFACE_DIM, Z_DIM
+from ndsl.constants import (
+    CONST_VERSION,
+    X_DIM,
+    X_INTERFACE_DIM,
+    Y_DIM,
+    Y_INTERFACE_DIM,
+    Z_DIM,
+    ConstantVersions,
+)
 from ndsl.dsl.dace.orchestration import orchestrate
 from ndsl.dsl.stencil import StencilFactory, get_stencils_with_varied_bounds
 from ndsl.dsl.typing import Float, FloatField, FloatFieldIJ, FloatFieldK
@@ -37,125 +38,65 @@ def calc_damp(damp_c: Quantity, da_min: Float, nord: Quantity) -> Quantity:
     )
 
 
-def fx_calc_stencil_nord(q: FloatField, del6_v: FloatFieldIJ, fx: FloatField):
+def fx_calc_stencil_nord(
+    q: FloatField, del6_v: FloatFieldIJ, fx: FloatField, nord: FloatFieldK
+):
     """
     Args:
         q (in):
         del6_v (in):
         fx (out):
     """
-    from __externals__ import (
-        local_ie,
-        local_is,
-        local_je,
-        local_js,
-        nord0,
-        nord1,
-        nord2,
-        nord3,
-    )
+    from __externals__ import local_ie, local_is, local_je, local_js
 
-    with computation(PARALLEL), interval(0, 1):
-        if __INLINED(nord0 == 0):
-            with horizontal(region[local_is : local_ie + 2, local_js : local_je + 1]):
-                fx = fx_calculation(q, del6_v)
-        else:
-            fx = fx_calculation(q, del6_v)
-    with computation(PARALLEL), interval(1, 2):
-        if __INLINED(nord1 == 0):
-            with horizontal(region[local_is : local_ie + 2, local_js : local_je + 1]):
-                fx = fx_calculation(q, del6_v)
-        else:
-            fx = fx_calculation(q, del6_v)
-    with computation(PARALLEL), interval(2, 3):
-        if __INLINED(nord2 == 0):
-            with horizontal(region[local_is : local_ie + 2, local_js : local_je + 1]):
-                fx = fx_calculation(q, del6_v)
-        else:
-            fx = fx_calculation(q, del6_v)
-    with computation(PARALLEL), interval(3, None):
-        if __INLINED(nord3 == 0):
+    with computation(PARALLEL), interval(...):
+        if nord == 0:
             with horizontal(region[local_is : local_ie + 2, local_js : local_je + 1]):
                 fx = fx_calculation(q, del6_v)
         else:
             fx = fx_calculation(q, del6_v)
 
 
-def fy_calc_stencil_nord(q: FloatField, del6_u: FloatFieldIJ, fy: FloatField):
+def fy_calc_stencil_nord(
+    q: FloatField, del6_u: FloatFieldIJ, fy: FloatField, nord: FloatFieldK
+):
     """
     Args:
         q (in):
         del6_u (in):
         fy (out):
     """
-    from __externals__ import (
-        local_ie,
-        local_is,
-        local_je,
-        local_js,
-        nord0,
-        nord1,
-        nord2,
-        nord3,
-    )
+    from __externals__ import local_ie, local_is, local_je, local_js
 
-    with computation(PARALLEL), interval(0, 1):
-        if __INLINED(nord0 == 0):
-            with horizontal(region[local_is : local_ie + 1, local_js : local_je + 2]):
-                fy = fy_calculation(q, del6_u)
-        else:
-            fy = fy_calculation(q, del6_u)
-    with computation(PARALLEL), interval(1, 2):
-        if __INLINED(nord1 == 0):
-            with horizontal(region[local_is : local_ie + 1, local_js : local_je + 2]):
-                fy = fy_calculation(q, del6_u)
-        else:
-            fy = fy_calculation(q, del6_u)
-    with computation(PARALLEL), interval(2, 3):
-        if __INLINED(nord2 == 0):
-            with horizontal(region[local_is : local_ie + 1, local_js : local_je + 2]):
-                fy = fy_calculation(q, del6_u)
-        else:
-            fy = fy_calculation(q, del6_u)
-    with computation(PARALLEL), interval(3, None):
-        if __INLINED(nord3 == 0):
+    with computation(PARALLEL), interval(...):
+        if nord == 0:
             with horizontal(region[local_is : local_ie + 1, local_js : local_je + 2]):
                 fy = fy_calculation(q, del6_u)
         else:
             fy = fy_calculation(q, del6_u)
 
 
-def fx_calc_stencil_column(q: FloatField, del6_v: FloatFieldIJ, fx: FloatField):
-    from __externals__ import nord0, nord1, nord2, nord3
-
-    with computation(PARALLEL), interval(0, 1):
-        if __INLINED(nord0 > 0):
-            fx = fx_calculation_neg(q, del6_v)
-    with computation(PARALLEL), interval(1, 2):
-        if __INLINED(nord1 > 0):
-            fx = fx_calculation_neg(q, del6_v)
-    with computation(PARALLEL), interval(2, 3):
-        if __INLINED(nord2 > 0):
-            fx = fx_calculation_neg(q, del6_v)
-    with computation(PARALLEL), interval(3, None):
-        if __INLINED(nord3 > 0):
+def fx_calc_stencil_column(
+    q: FloatField,
+    del6_v: FloatFieldIJ,
+    fx: FloatField,
+    nord: FloatFieldK,
+    current_nord: int,
+):
+    with computation(PARALLEL), interval(...):
+        if nord > current_nord:
             fx = fx_calculation_neg(q, del6_v)
 
 
-def fy_calc_stencil_column(q: FloatField, del6_u: FloatFieldIJ, fy: FloatField):
-    from __externals__ import nord0, nord1, nord2, nord3
-
-    with computation(PARALLEL), interval(0, 1):
-        if __INLINED(nord0 > 0):
-            fy = fy_calculation_neg(q, del6_u)
-    with computation(PARALLEL), interval(1, 2):
-        if __INLINED(nord1 > 0):
-            fy = fy_calculation_neg(q, del6_u)
-    with computation(PARALLEL), interval(2, 3):
-        if __INLINED(nord2 > 0):
-            fy = fy_calculation_neg(q, del6_u)
-    with computation(PARALLEL), interval(3, None):
-        if __INLINED(nord3 > 0):
+def fy_calc_stencil_column(
+    q: FloatField,
+    del6_u: FloatFieldIJ,
+    fy: FloatField,
+    nord: FloatFieldK,
+    current_nord: int,
+):
+    with computation(PARALLEL), interval(...):
+        if nord > current_nord:
             fy = fy_calculation_neg(q, del6_u)
 
 
@@ -179,74 +120,53 @@ def fy_calculation_neg(q: FloatField, del6_u: FloatField):
     return -del6_u * (q[0, -1, 0] - q)
 
 
-def d2_highorder_stencil(
-    fx: FloatField, fy: FloatField, rarea: FloatFieldIJ, d2: FloatField
+def d2_highorder_stencil_FV3GFS(
+    fx: FloatField,
+    fy: FloatField,
+    rarea: FloatFieldIJ,
+    nord: FloatFieldK,
+    d2: FloatField,
+    current_nord: int,
 ):
-    from __externals__ import nord0, nord1, nord2, nord3
-
-    with computation(PARALLEL), interval(0, 1):
-        if __INLINED(nord0 > 0):
-            d2 = d2_highorder(fx, fy, rarea)
-    with computation(PARALLEL), interval(1, 2):
-        if __INLINED(nord1 > 0):
-            d2 = d2_highorder(fx, fy, rarea)
-    with computation(PARALLEL), interval(2, 3):
-        if __INLINED(nord2 > 0):
-            d2 = d2_highorder(fx, fy, rarea)
-    with computation(PARALLEL), interval(3, None):
-        if __INLINED(nord3 > 0):
-            d2 = d2_highorder(fx, fy, rarea)
+    with computation(PARALLEL), interval(...):
+        if nord > current_nord:
+            d2 = (fx - fx[1, 0, 0] + fy - fy[0, 1, 0]) * rarea
 
 
-@gtscript.function
-def d2_highorder(fx: FloatField, fy: FloatField, rarea: FloatField):
-    d2 = (fx - fx[1, 0, 0] + fy - fy[0, 1, 0]) * rarea
-    return d2
+def d2_highorder_stencil_GEOS(
+    fx: FloatField,
+    fy: FloatField,
+    rarea: FloatFieldIJ,
+    nord: FloatFieldK,
+    d2: FloatField,
+    current_nord: int,
+):
+    with computation(PARALLEL), interval(...):
+        if nord > current_nord:
+            d2 = ((fx - fx[1, 0, 0]) + (fy - fy[0, 1, 0])) * rarea
 
 
-def d2_damp_interval(q: FloatField, d2: FloatField, damp: FloatFieldK):
+def _get_highorder_stencil(key: ConstantVersions):
+    if key == ConstantVersions.GFS or key == ConstantVersions.GFDL:
+        return d2_highorder_stencil_FV3GFS
+    elif key == ConstantVersions.GEOS:
+        return d2_highorder_stencil_GEOS
+    else:
+        raise NotImplementedError(f"Ambiguous code for DelnFlux with constant {key}")
+
+
+def d2_damp_interval(
+    q: FloatField, d2: FloatField, damp: FloatFieldK, nord: FloatFieldK
+):
     """
     q (in):
     d2 (out):
     damp (in):
     """
-    from __externals__ import (
-        local_ie,
-        local_is,
-        local_je,
-        local_js,
-        nord0,
-        nord1,
-        nord2,
-        nord3,
-    )
+    from __externals__ import local_ie, local_is, local_je, local_js
 
-    with computation(PARALLEL), interval(0, 1):
-        if __INLINED(nord0 == 0):
-            with horizontal(
-                region[local_is - 1 : local_ie + 2, local_js - 1 : local_je + 2]
-            ):
-                d2 = damp * q
-        else:
-            d2 = damp * q
-    with computation(PARALLEL), interval(1, 2):
-        if __INLINED(nord1 == 0):
-            with horizontal(
-                region[local_is - 1 : local_ie + 2, local_js - 1 : local_je + 2]
-            ):
-                d2 = damp * q
-        else:
-            d2 = damp * q
-    with computation(PARALLEL), interval(2, 3):
-        if __INLINED(nord2 == 0):
-            with horizontal(
-                region[local_is - 1 : local_ie + 2, local_js - 1 : local_je + 2]
-            ):
-                d2 = damp * q
-        else:
-            d2 = damp * q
-    with computation(PARALLEL), interval(3, None):
-        if __INLINED(nord3 == 0):
+    with computation(PARALLEL), interval(...):
+        if nord == 0:
             with horizontal(
                 region[local_is - 1 : local_ie + 2, local_js - 1 : local_je + 2]
             ):
@@ -255,49 +175,16 @@ def d2_damp_interval(q: FloatField, d2: FloatField, damp: FloatFieldK):
             d2 = damp * q
 
 
-def copy_stencil_interval(q_in: FloatField, q_out: FloatField):
+def copy_stencil_interval(q_in: FloatField, q_out: FloatField, nord: FloatFieldK):
     """
     Args:
         q_in (in):
         q_out (out):
     """
-    from __externals__ import (
-        local_ie,
-        local_is,
-        local_je,
-        local_js,
-        nord0,
-        nord1,
-        nord2,
-        nord3,
-    )
+    from __externals__ import local_ie, local_is, local_je, local_js
 
-    with computation(PARALLEL), interval(0, 1):
-        if __INLINED(nord0 == 0):
-            with horizontal(
-                region[local_is - 1 : local_ie + 2, local_js - 1 : local_je + 2]
-            ):
-                q_out = q_in
-        else:
-            q_out = q_in
-    with computation(PARALLEL), interval(1, 2):
-        if __INLINED(nord1 == 0):
-            with horizontal(
-                region[local_is - 1 : local_ie + 2, local_js - 1 : local_je + 2]
-            ):
-                q_out = q_in
-        else:
-            q_out = q_in
-    with computation(PARALLEL), interval(2, 3):
-        if __INLINED(nord2 == 0):
-            with horizontal(
-                region[local_is - 1 : local_ie + 2, local_js - 1 : local_je + 2]
-            ):
-                q_out = q_in
-        else:
-            q_out = q_in
-    with computation(PARALLEL), interval(3, None):
-        if __INLINED(nord3 == 0):
+    with computation(PARALLEL), interval(...):
+        if nord == 0:
             with horizontal(
                 region[local_is - 1 : local_ie + 2, local_js - 1 : local_je + 2]
             ):
@@ -327,239 +214,18 @@ def diffusive_damp(
         fy = fy + 0.5 * damp * (mass[0, -1, 0] + mass) * fy2
 
 
-def copy_corners_y_nord(q_in: FloatField, q_out: FloatField):
+def copy_corners_y_nord(
+    q_in: FloatField, q_out: FloatField, nord: FloatFieldK, current_nord: int
+):
     """
     Args:
         q_in (in):
         q_out (out):
     """
-    from __externals__ import i_end, i_start, j_end, j_start, nord0, nord1, nord2, nord3
+    from __externals__ import i_end, i_start, j_end, j_start
 
-    with computation(PARALLEL), interval(0, 1):
-        if __INLINED(nord0 > 0):
-            with horizontal(
-                region[i_start - 3, j_start - 3], region[i_start - 3, j_end + 3]
-            ):
-                q_out = q_in[5, 0, 0]
-            with horizontal(
-                region[i_start - 2, j_start - 3], region[i_start - 3, j_end + 2]
-            ):
-                q_out = q_in[4, 1, 0]
-            with horizontal(
-                region[i_start - 1, j_start - 3], region[i_start - 3, j_end + 1]
-            ):
-                q_out = q_in[3, 2, 0]
-            with horizontal(
-                region[i_start - 3, j_start - 2], region[i_start - 2, j_end + 3]
-            ):
-                q_out = q_in[4, -1, 0]
-            with horizontal(
-                region[i_start - 2, j_start - 2], region[i_start - 2, j_end + 2]
-            ):
-                q_out = q_in[3, 0, 0]
-            with horizontal(
-                region[i_start - 1, j_start - 2], region[i_start - 2, j_end + 1]
-            ):
-                q_out = q_in[2, 1, 0]
-            with horizontal(
-                region[i_start - 3, j_start - 1], region[i_start - 1, j_end + 3]
-            ):
-                q_out = q_in[3, -2, 0]
-            with horizontal(
-                region[i_start - 2, j_start - 1], region[i_start - 1, j_end + 2]
-            ):
-                q_out = q_in[2, -1, 0]
-            with horizontal(
-                region[i_start - 1, j_start - 1], region[i_start - 1, j_end + 1]
-            ):
-                q_out = q_in[1, 0, 0]
-            with horizontal(
-                region[i_end + 1, j_start - 3], region[i_end + 3, j_end + 1]
-            ):
-                q_out = q_in[-3, 2, 0]
-            with horizontal(
-                region[i_end + 2, j_start - 3], region[i_end + 3, j_end + 2]
-            ):
-                q_out = q_in[-4, 1, 0]
-            with horizontal(
-                region[i_end + 3, j_start - 3], region[i_end + 3, j_end + 3]
-            ):
-                q_out = q_in[-5, 0, 0]
-            with horizontal(
-                region[i_end + 1, j_start - 2], region[i_end + 2, j_end + 1]
-            ):
-                q_out = q_in[-2, 1, 0]
-            with horizontal(
-                region[i_end + 2, j_start - 2], region[i_end + 2, j_end + 2]
-            ):
-                q_out = q_in[-3, 0, 0]
-            with horizontal(
-                region[i_end + 3, j_start - 2], region[i_end + 2, j_end + 3]
-            ):
-                q_out = q_in[-4, -1, 0]
-            with horizontal(
-                region[i_end + 1, j_start - 1], region[i_end + 1, j_end + 1]
-            ):
-                q_out = q_in[-1, 0, 0]
-            with horizontal(
-                region[i_end + 2, j_start - 1], region[i_end + 1, j_end + 2]
-            ):
-                q_out = q_in[-2, -1, 0]
-            with horizontal(
-                region[i_end + 3, j_start - 1], region[i_end + 1, j_end + 3]
-            ):
-                q_out = q_in[-3, -2, 0]
-    with computation(PARALLEL), interval(1, 2):
-        if __INLINED(nord1 > 0):
-            with horizontal(
-                region[i_start - 3, j_start - 3], region[i_start - 3, j_end + 3]
-            ):
-                q_out = q_in[5, 0, 0]
-            with horizontal(
-                region[i_start - 2, j_start - 3], region[i_start - 3, j_end + 2]
-            ):
-                q_out = q_in[4, 1, 0]
-            with horizontal(
-                region[i_start - 1, j_start - 3], region[i_start - 3, j_end + 1]
-            ):
-                q_out = q_in[3, 2, 0]
-            with horizontal(
-                region[i_start - 3, j_start - 2], region[i_start - 2, j_end + 3]
-            ):
-                q_out = q_in[4, -1, 0]
-            with horizontal(
-                region[i_start - 2, j_start - 2], region[i_start - 2, j_end + 2]
-            ):
-                q_out = q_in[3, 0, 0]
-            with horizontal(
-                region[i_start - 1, j_start - 2], region[i_start - 2, j_end + 1]
-            ):
-                q_out = q_in[2, 1, 0]
-            with horizontal(
-                region[i_start - 3, j_start - 1], region[i_start - 1, j_end + 3]
-            ):
-                q_out = q_in[3, -2, 0]
-            with horizontal(
-                region[i_start - 2, j_start - 1], region[i_start - 1, j_end + 2]
-            ):
-                q_out = q_in[2, -1, 0]
-            with horizontal(
-                region[i_start - 1, j_start - 1], region[i_start - 1, j_end + 1]
-            ):
-                q_out = q_in[1, 0, 0]
-            with horizontal(
-                region[i_end + 1, j_start - 3], region[i_end + 3, j_end + 1]
-            ):
-                q_out = q_in[-3, 2, 0]
-            with horizontal(
-                region[i_end + 2, j_start - 3], region[i_end + 3, j_end + 2]
-            ):
-                q_out = q_in[-4, 1, 0]
-            with horizontal(
-                region[i_end + 3, j_start - 3], region[i_end + 3, j_end + 3]
-            ):
-                q_out = q_in[-5, 0, 0]
-            with horizontal(
-                region[i_end + 1, j_start - 2], region[i_end + 2, j_end + 1]
-            ):
-                q_out = q_in[-2, 1, 0]
-            with horizontal(
-                region[i_end + 2, j_start - 2], region[i_end + 2, j_end + 2]
-            ):
-                q_out = q_in[-3, 0, 0]
-            with horizontal(
-                region[i_end + 3, j_start - 2], region[i_end + 2, j_end + 3]
-            ):
-                q_out = q_in[-4, -1, 0]
-            with horizontal(
-                region[i_end + 1, j_start - 1], region[i_end + 1, j_end + 1]
-            ):
-                q_out = q_in[-1, 0, 0]
-            with horizontal(
-                region[i_end + 2, j_start - 1], region[i_end + 1, j_end + 2]
-            ):
-                q_out = q_in[-2, -1, 0]
-            with horizontal(
-                region[i_end + 3, j_start - 1], region[i_end + 1, j_end + 3]
-            ):
-                q_out = q_in[-3, -2, 0]
-
-    with computation(PARALLEL), interval(2, 3):
-        if __INLINED(nord2 > 0):
-            with horizontal(
-                region[i_start - 3, j_start - 3], region[i_start - 3, j_end + 3]
-            ):
-                q_out = q_in[5, 0, 0]
-            with horizontal(
-                region[i_start - 2, j_start - 3], region[i_start - 3, j_end + 2]
-            ):
-                q_out = q_in[4, 1, 0]
-            with horizontal(
-                region[i_start - 1, j_start - 3], region[i_start - 3, j_end + 1]
-            ):
-                q_out = q_in[3, 2, 0]
-            with horizontal(
-                region[i_start - 3, j_start - 2], region[i_start - 2, j_end + 3]
-            ):
-                q_out = q_in[4, -1, 0]
-            with horizontal(
-                region[i_start - 2, j_start - 2], region[i_start - 2, j_end + 2]
-            ):
-                q_out = q_in[3, 0, 0]
-            with horizontal(
-                region[i_start - 1, j_start - 2], region[i_start - 2, j_end + 1]
-            ):
-                q_out = q_in[2, 1, 0]
-            with horizontal(
-                region[i_start - 3, j_start - 1], region[i_start - 1, j_end + 3]
-            ):
-                q_out = q_in[3, -2, 0]
-            with horizontal(
-                region[i_start - 2, j_start - 1], region[i_start - 1, j_end + 2]
-            ):
-                q_out = q_in[2, -1, 0]
-            with horizontal(
-                region[i_start - 1, j_start - 1], region[i_start - 1, j_end + 1]
-            ):
-                q_out = q_in[1, 0, 0]
-            with horizontal(
-                region[i_end + 1, j_start - 3], region[i_end + 3, j_end + 1]
-            ):
-                q_out = q_in[-3, 2, 0]
-            with horizontal(
-                region[i_end + 2, j_start - 3], region[i_end + 3, j_end + 2]
-            ):
-                q_out = q_in[-4, 1, 0]
-            with horizontal(
-                region[i_end + 3, j_start - 3], region[i_end + 3, j_end + 3]
-            ):
-                q_out = q_in[-5, 0, 0]
-            with horizontal(
-                region[i_end + 1, j_start - 2], region[i_end + 2, j_end + 1]
-            ):
-                q_out = q_in[-2, 1, 0]
-            with horizontal(
-                region[i_end + 2, j_start - 2], region[i_end + 2, j_end + 2]
-            ):
-                q_out = q_in[-3, 0, 0]
-            with horizontal(
-                region[i_end + 3, j_start - 2], region[i_end + 2, j_end + 3]
-            ):
-                q_out = q_in[-4, -1, 0]
-            with horizontal(
-                region[i_end + 1, j_start - 1], region[i_end + 1, j_end + 1]
-            ):
-                q_out = q_in[-1, 0, 0]
-            with horizontal(
-                region[i_end + 2, j_start - 1], region[i_end + 1, j_end + 2]
-            ):
-                q_out = q_in[-2, -1, 0]
-            with horizontal(
-                region[i_end + 3, j_start - 1], region[i_end + 1, j_end + 3]
-            ):
-                q_out = q_in[-3, -2, 0]
-    with computation(PARALLEL), interval(3, None):
-        if __INLINED(nord3 > 0):
+    with computation(PARALLEL), interval(...):
+        if nord > current_nord:
             with horizontal(
                 region[i_start - 3, j_start - 3], region[i_start - 3, j_end + 3]
             ):
@@ -634,239 +300,18 @@ def copy_corners_y_nord(q_in: FloatField, q_out: FloatField):
                 q_out = q_in[-3, -2, 0]
 
 
-def copy_corners_x_nord(q_in: FloatField, q_out: FloatField):
+def copy_corners_x_nord(
+    q_in: FloatField, q_out: FloatField, nord: FloatFieldK, current_nord: int
+):
     """
     Args:
         q_in (in):
         q_out (out):
     """
-    from __externals__ import i_end, i_start, j_end, j_start, nord0, nord1, nord2, nord3
+    from __externals__ import i_end, i_start, j_end, j_start
 
-    with computation(PARALLEL), interval(0, 1):
-        if __INLINED(nord0 > 0):
-            with horizontal(
-                region[i_start - 3, j_start - 3], region[i_end + 3, j_start - 3]
-            ):
-                q_out = q_in[0, 5, 0]
-            with horizontal(
-                region[i_start - 2, j_start - 3], region[i_end + 3, j_start - 2]
-            ):
-                q_out = q_in[-1, 4, 0]
-            with horizontal(
-                region[i_start - 1, j_start - 3], region[i_end + 3, j_start - 1]
-            ):
-                q_out = q_in[-2, 3, 0]
-            with horizontal(
-                region[i_start - 3, j_start - 2], region[i_end + 2, j_start - 3]
-            ):
-                q_out = q_in[1, 4, 0]
-            with horizontal(
-                region[i_start - 2, j_start - 2], region[i_end + 2, j_start - 2]
-            ):
-                q_out = q_in[0, 3, 0]
-            with horizontal(
-                region[i_start - 1, j_start - 2], region[i_end + 2, j_start - 1]
-            ):
-                q_out = q_in[-1, 2, 0]
-            with horizontal(
-                region[i_start - 3, j_start - 1], region[i_end + 1, j_start - 3]
-            ):
-                q_out = q_in[2, 3, 0]
-            with horizontal(
-                region[i_start - 2, j_start - 1], region[i_end + 1, j_start - 2]
-            ):
-                q_out = q_in[1, 2, 0]
-            with horizontal(
-                region[i_start - 1, j_start - 1], region[i_end + 1, j_start - 1]
-            ):
-                q_out = q_in[0, 1, 0]
-            with horizontal(
-                region[i_start - 3, j_end + 1], region[i_end + 1, j_end + 3]
-            ):
-                q_out = q_in[2, -3, 0]
-            with horizontal(
-                region[i_start - 2, j_end + 1], region[i_end + 1, j_end + 2]
-            ):
-                q_out = q_in[1, -2, 0]
-            with horizontal(
-                region[i_start - 1, j_end + 1], region[i_end + 1, j_end + 1]
-            ):
-                q_out = q_in[0, -1, 0]
-            with horizontal(
-                region[i_start - 3, j_end + 2], region[i_end + 2, j_end + 3]
-            ):
-                q_out = q_in[1, -4, 0]
-            with horizontal(
-                region[i_start - 2, j_end + 2], region[i_end + 2, j_end + 2]
-            ):
-                q_out = q_in[0, -3, 0]
-            with horizontal(
-                region[i_start - 1, j_end + 2], region[i_end + 2, j_end + 1]
-            ):
-                q_out = q_in[-1, -2, 0]
-            with horizontal(
-                region[i_start - 3, j_end + 3], region[i_end + 3, j_end + 3]
-            ):
-                q_out = q_in[0, -5, 0]
-            with horizontal(
-                region[i_start - 2, j_end + 3], region[i_end + 3, j_end + 2]
-            ):
-                q_out = q_in[-1, -4, 0]
-            with horizontal(
-                region[i_start - 1, j_end + 3], region[i_end + 3, j_end + 1]
-            ):
-                q_out = q_in[-2, -3, 0]
-    with computation(PARALLEL), interval(1, 2):
-        if __INLINED(nord1 > 0):
-            with horizontal(
-                region[i_start - 3, j_start - 3], region[i_end + 3, j_start - 3]
-            ):
-                q_out = q_in[0, 5, 0]
-            with horizontal(
-                region[i_start - 2, j_start - 3], region[i_end + 3, j_start - 2]
-            ):
-                q_out = q_in[-1, 4, 0]
-            with horizontal(
-                region[i_start - 1, j_start - 3], region[i_end + 3, j_start - 1]
-            ):
-                q_out = q_in[-2, 3, 0]
-            with horizontal(
-                region[i_start - 3, j_start - 2], region[i_end + 2, j_start - 3]
-            ):
-                q_out = q_in[1, 4, 0]
-            with horizontal(
-                region[i_start - 2, j_start - 2], region[i_end + 2, j_start - 2]
-            ):
-                q_out = q_in[0, 3, 0]
-            with horizontal(
-                region[i_start - 1, j_start - 2], region[i_end + 2, j_start - 1]
-            ):
-                q_out = q_in[-1, 2, 0]
-            with horizontal(
-                region[i_start - 3, j_start - 1], region[i_end + 1, j_start - 3]
-            ):
-                q_out = q_in[2, 3, 0]
-            with horizontal(
-                region[i_start - 2, j_start - 1], region[i_end + 1, j_start - 2]
-            ):
-                q_out = q_in[1, 2, 0]
-            with horizontal(
-                region[i_start - 1, j_start - 1], region[i_end + 1, j_start - 1]
-            ):
-                q_out = q_in[0, 1, 0]
-            with horizontal(
-                region[i_start - 3, j_end + 1], region[i_end + 1, j_end + 3]
-            ):
-                q_out = q_in[2, -3, 0]
-            with horizontal(
-                region[i_start - 2, j_end + 1], region[i_end + 1, j_end + 2]
-            ):
-                q_out = q_in[1, -2, 0]
-            with horizontal(
-                region[i_start - 1, j_end + 1], region[i_end + 1, j_end + 1]
-            ):
-                q_out = q_in[0, -1, 0]
-            with horizontal(
-                region[i_start - 3, j_end + 2], region[i_end + 2, j_end + 3]
-            ):
-                q_out = q_in[1, -4, 0]
-            with horizontal(
-                region[i_start - 2, j_end + 2], region[i_end + 2, j_end + 2]
-            ):
-                q_out = q_in[0, -3, 0]
-            with horizontal(
-                region[i_start - 1, j_end + 2], region[i_end + 2, j_end + 1]
-            ):
-                q_out = q_in[-1, -2, 0]
-            with horizontal(
-                region[i_start - 3, j_end + 3], region[i_end + 3, j_end + 3]
-            ):
-                q_out = q_in[0, -5, 0]
-            with horizontal(
-                region[i_start - 2, j_end + 3], region[i_end + 3, j_end + 2]
-            ):
-                q_out = q_in[-1, -4, 0]
-            with horizontal(
-                region[i_start - 1, j_end + 3], region[i_end + 3, j_end + 1]
-            ):
-                q_out = q_in[-2, -3, 0]
-
-    with computation(PARALLEL), interval(2, 3):
-        if __INLINED(nord2 > 0):
-            with horizontal(
-                region[i_start - 3, j_start - 3], region[i_end + 3, j_start - 3]
-            ):
-                q_out = q_in[0, 5, 0]
-            with horizontal(
-                region[i_start - 2, j_start - 3], region[i_end + 3, j_start - 2]
-            ):
-                q_out = q_in[-1, 4, 0]
-            with horizontal(
-                region[i_start - 1, j_start - 3], region[i_end + 3, j_start - 1]
-            ):
-                q_out = q_in[-2, 3, 0]
-            with horizontal(
-                region[i_start - 3, j_start - 2], region[i_end + 2, j_start - 3]
-            ):
-                q_out = q_in[1, 4, 0]
-            with horizontal(
-                region[i_start - 2, j_start - 2], region[i_end + 2, j_start - 2]
-            ):
-                q_out = q_in[0, 3, 0]
-            with horizontal(
-                region[i_start - 1, j_start - 2], region[i_end + 2, j_start - 1]
-            ):
-                q_out = q_in[-1, 2, 0]
-            with horizontal(
-                region[i_start - 3, j_start - 1], region[i_end + 1, j_start - 3]
-            ):
-                q_out = q_in[2, 3, 0]
-            with horizontal(
-                region[i_start - 2, j_start - 1], region[i_end + 1, j_start - 2]
-            ):
-                q_out = q_in[1, 2, 0]
-            with horizontal(
-                region[i_start - 1, j_start - 1], region[i_end + 1, j_start - 1]
-            ):
-                q_out = q_in[0, 1, 0]
-            with horizontal(
-                region[i_start - 3, j_end + 1], region[i_end + 1, j_end + 3]
-            ):
-                q_out = q_in[2, -3, 0]
-            with horizontal(
-                region[i_start - 2, j_end + 1], region[i_end + 1, j_end + 2]
-            ):
-                q_out = q_in[1, -2, 0]
-            with horizontal(
-                region[i_start - 1, j_end + 1], region[i_end + 1, j_end + 1]
-            ):
-                q_out = q_in[0, -1, 0]
-            with horizontal(
-                region[i_start - 3, j_end + 2], region[i_end + 2, j_end + 3]
-            ):
-                q_out = q_in[1, -4, 0]
-            with horizontal(
-                region[i_start - 2, j_end + 2], region[i_end + 2, j_end + 2]
-            ):
-                q_out = q_in[0, -3, 0]
-            with horizontal(
-                region[i_start - 1, j_end + 2], region[i_end + 2, j_end + 1]
-            ):
-                q_out = q_in[-1, -2, 0]
-            with horizontal(
-                region[i_start - 3, j_end + 3], region[i_end + 3, j_end + 3]
-            ):
-                q_out = q_in[0, -5, 0]
-            with horizontal(
-                region[i_start - 2, j_end + 3], region[i_end + 3, j_end + 2]
-            ):
-                q_out = q_in[-1, -4, 0]
-            with horizontal(
-                region[i_start - 1, j_end + 3], region[i_end + 3, j_end + 1]
-            ):
-                q_out = q_in[-2, -3, 0]
-    with computation(PARALLEL), interval(3, None):
-        if __INLINED(nord3 > 0):
+    with computation(PARALLEL), interval(...):
+        if nord > current_nord:
             with horizontal(
                 region[i_start - 3, j_start - 3], region[i_end + 3, j_start - 3]
             ):
@@ -1138,21 +583,9 @@ class DelnFluxNoSG:
             domains_fx.append((nt_nx - 1, nt_ny - 2, nk))
             domains_fy.append((nt_nx - 2, nt_ny - 1, nk))
 
-        nord_dictionary = {
-            "nord0": float(nord.view[0]),
-            "nord1": float(nord.view[1]),
-            "nord2": float(nord.view[2]),
-            "nord3": float(nord.view[3]),
-        }
-        nord_dictionary["nord0"] = Float(nord_dictionary["nord0"])
-        nord_dictionary["nord1"] = Float(nord_dictionary["nord1"])
-        nord_dictionary["nord2"] = Float(nord_dictionary["nord2"])
-        nord_dictionary["nord3"] = Float(nord_dictionary["nord3"])
-
         self._d2_damp = stencil_factory.from_origin_domain(
             d2_damp_interval,
             externals={
-                **nord_dictionary,
                 **preamble_ax_offsets,
             },
             origin=origin_d2,
@@ -1162,7 +595,6 @@ class DelnFluxNoSG:
         self._copy_stencil_interval = stencil_factory.from_origin_domain(
             copy_stencil_interval,
             externals={
-                **nord_dictionary,
                 **preamble_ax_offsets,
             },
             origin=origin_d2,
@@ -1170,35 +602,32 @@ class DelnFluxNoSG:
         )
 
         self._d2_stencil = get_stencils_with_varied_bounds(
-            d2_highorder_stencil,
+            _get_highorder_stencil(CONST_VERSION),
             origins_d2,
             domains_d2,
             stencil_factory=stencil_factory,
-            externals={**nord_dictionary},
         )
         self._column_conditional_fx_calculation = get_stencils_with_varied_bounds(
             fx_calc_stencil_column,
             origins_flux,
             domains_fx,
             stencil_factory=stencil_factory,
-            externals={**nord_dictionary},
         )
         self._column_conditional_fy_calculation = get_stencils_with_varied_bounds(
             fy_calc_stencil_column,
             origins_flux,
             domains_fy,
             stencil_factory=stencil_factory,
-            externals={**nord_dictionary},
         )
         self._fx_calc_stencil = stencil_factory.from_origin_domain(
             fx_calc_stencil_nord,
-            externals={**fx_ax_offsets, **nord_dictionary},
+            externals={**fx_ax_offsets},
             origin=fx_origin,
             domain=(f1_nx, f1_ny, nk),
         )
         self._fy_calc_stencil = stencil_factory.from_origin_domain(
             fy_calc_stencil_nord,
-            externals={**fy_ax_offsets, **nord_dictionary},
+            externals={**fy_ax_offsets},
             origin=fx_origin,
             domain=(f1_nx - 1, f1_ny + 1, nk),
         )
@@ -1211,13 +640,13 @@ class DelnFluxNoSG:
 
         self._copy_corners_x_nord = stencil_factory.from_origin_domain(
             copy_corners_x_nord,
-            externals={**corner_axis_offsets, **nord_dictionary},
+            externals={**corner_axis_offsets},
             origin=corner_origin,
             domain=corner_domain,
         )
         self._copy_corners_y_nord = stencil_factory.from_origin_domain(
             copy_corners_y_nord,
-            externals={**corner_axis_offsets, **nord_dictionary},
+            externals={**corner_axis_offsets},
             origin=corner_origin,
             domain=corner_domain,
         )
@@ -1240,38 +669,40 @@ class DelnFluxNoSG:
         """
 
         if mass is None:
-            self._d2_damp(q, d2, damp_c)
+            self._d2_damp(q=q, d2=d2, damp=damp_c, nord=self._nord)
         else:
-            self._copy_stencil_interval(q, d2)
+            self._copy_stencil_interval(q_in=q, q_out=d2, nord=self._nord)
 
-        self._copy_corners_x_nord(d2, d2)
+        self._copy_corners_x_nord(q_in=d2, q_out=d2, nord=self._nord, current_nord=0)
 
-        self._fx_calc_stencil(d2, self._del6_v, fx2)
+        self._fx_calc_stencil(q=d2, del6_v=self._del6_v, fx=fx2, nord=self._nord)
 
-        self._copy_corners_y_nord(d2, d2)
+        self._copy_corners_y_nord(q_in=d2, q_out=d2, nord=self._nord, current_nord=0)
 
-        self._fy_calc_stencil(d2, self._del6_u, fy2)
+        self._fy_calc_stencil(q=d2, del6_u=self._del6_u, fy=fy2, nord=self._nord)
 
         for n in range(self._nmax):
             self._d2_stencil[n](
-                fx2,
-                fy2,
-                self._rarea,
-                d2,
+                fx=fx2,
+                fy=fy2,
+                rarea=self._rarea,
+                nord=self._nord,
+                d2=d2,
+                current_nord=n,
             )
 
-            self._copy_corners_x_nord(d2, d2)
+            self._copy_corners_x_nord(
+                q_in=d2, q_out=d2, nord=self._nord, current_nord=n
+            )
 
             self._column_conditional_fx_calculation[n](
-                d2,
-                self._del6_v,
-                fx2,
+                q=d2, del6_v=self._del6_v, fx=fx2, nord=self._nord, current_nord=n
             )
 
-            self._copy_corners_y_nord(d2, d2)
+            self._copy_corners_y_nord(
+                q_in=d2, q_out=d2, nord=self._nord, current_nord=n
+            )
 
             self._column_conditional_fy_calculation[n](
-                d2,
-                self._del6_u,
-                fy2,
+                q=d2, del6_u=self._del6_u, fy=fy2, nord=self._nord, current_nord=n
             )

--- a/pyFV3/stencils/delnflux.py
+++ b/pyFV3/stencils/delnflux.py
@@ -593,7 +593,7 @@ class DelnFluxNoSG:
         )
 
         self._d2_stencil = get_stencils_with_varied_bounds(
-            _get_highorder_stencil,
+            _get_highorder_stencil(),
             origins_d2,
             domains_d2,
             stencil_factory=stencil_factory,

--- a/pyFV3/stencils/delnflux.py
+++ b/pyFV3/stencils/delnflux.py
@@ -113,20 +113,7 @@ def fy_calculation_neg(q: FloatField, del6_u: FloatField):
     return -del6_u * (q[0, -1, 0] - q)
 
 
-def d2_highorder_stencil_FV3GFS(
-    fx: FloatField,
-    fy: FloatField,
-    rarea: FloatFieldIJ,
-    nord: FloatFieldK,
-    d2: FloatField,
-    current_nord: int,
-):
-    with computation(PARALLEL), interval(...):
-        if nord > current_nord:
-            d2 = (fx - fx[1, 0, 0] + fy - fy[0, 1, 0]) * rarea
-
-
-def d2_highorder_stencil_GEOS(
+def d2_highorder_stencil(
     fx: FloatField,
     fy: FloatField,
     rarea: FloatFieldIJ,
@@ -137,13 +124,6 @@ def d2_highorder_stencil_GEOS(
     with computation(PARALLEL), interval(...):
         if nord > current_nord:
             d2 = ((fx - fx[1, 0, 0]) + (fy - fy[0, 1, 0])) * rarea
-
-
-def _get_highorder_stencil():
-    if IS_GEOS:
-        return d2_highorder_stencil_GEOS
-    else:
-        return d2_highorder_stencil_FV3GFS
 
 
 def d2_damp_interval(
@@ -593,7 +573,7 @@ class DelnFluxNoSG:
         )
 
         self._d2_stencil = get_stencils_with_varied_bounds(
-            _get_highorder_stencil(),
+            d2_highorder_stencil,
             origins_d2,
             domains_d2,
             stencil_factory=stencil_factory,

--- a/pyFV3/version.py
+++ b/pyFV3/version.py
@@ -1,5 +1,6 @@
 from ndsl.constants import CONST_VERSION, ConstantVersions
 
+
 # By selecting the GEOS constant using (PACE_CONSTANT env var)
 # we select the GEOS flavor of numerics
 IS_GEOS = ConstantVersions.GEOS == CONST_VERSION

--- a/pyFV3/version.py
+++ b/pyFV3/version.py
@@ -1,0 +1,5 @@
+from ndsl.constants import CONST_VERSION, ConstantVersions
+
+# By selecting the GEOS constant using (PACE_CONSTANT env var)
+# we select the GEOS flavor of numerics
+IS_GEOS = ConstantVersions.GEOS == CONST_VERSION

--- a/tests/savepoint/translate/overrides/standard.yaml
+++ b/tests/savepoint/translate/overrides/standard.yaml
@@ -207,8 +207,7 @@ Del2Cubed:
     max_error: 8e-12
 
 FvTp2d:
-  - backend: dace:cpu
-    max_error: 2e-13
+  max_error: 2e-13 # changes in code for mass conservation at single precision, which is not included in original translate tests.
 
 FxAdv:
   - backend: dace:cpu

--- a/tests/savepoint/translate/overrides/standard.yaml
+++ b/tests/savepoint/translate/overrides/standard.yaml
@@ -200,10 +200,7 @@ DivergenceDamping:
     max_error: 1e-9
 
 DelnFlux:
-  - backend: dace:cpu
-    max_error: 2e-13
-  - backend: dace:gpu
-    max_error: 7e-13
+  max_error: 2e-13 # changes in code for mass conservation at single precision, which is not included in original translate tests.
 
 Del2Cubed:
   - backend: dace:cpu

--- a/tests/savepoint/translate/overrides/standard.yaml
+++ b/tests/savepoint/translate/overrides/standard.yaml
@@ -200,14 +200,14 @@ DivergenceDamping:
     max_error: 1e-9
 
 DelnFlux:
-  max_error: 2e-13 # changes in code for mass conservation at single precision, which is not included in original translate tests.
+  - max_error: 2e-13 # changes in code for mass conservation at single precision, which is not included in original translate tests.
 
 Del2Cubed:
   - backend: dace:cpu
     max_error: 8e-12
 
 FvTp2d:
-  max_error: 2e-13 # changes in code for mass conservation at single precision, which is not included in original translate tests.
+  - max_error: 2e-13 # changes in code for mass conservation at single precision, which is not included in original translate tests.
 
 FxAdv:
   - backend: dace:cpu


### PR DESCRIPTION
The original port of `DelnFlux` used the 3 first values of the `nord_dictionary` to compute. The original code reads the `nord` value for all K-levels and decides to execute the code or not.

GEOS use case showed that the assumption in `pyFV3` is incorrect. On top of that, the time "optimized" by the strategy is minimal and by virtue of the DSL should _not_ lie in the hands of the modelers.

In this PR:
- We add `version.py` to introduce a `IS_GEOS` switch that can be used to differentiate between numerical choices between NOAA and NASA
- Full `nord` coverage for DelnFlux
- Add check on column calculation taken as hypothesis for downstream calculations
- FV3GFS/GEOS differences solving:
  - `d2_high_order_stencil` as a difference of orders operations
  - `nord` & `damp` column calculation goes all the way to the `n_sponge` layer in GEOS
  
  
  _NOTE_: to do FV3GFS/GEOS swap we use the `constant` file in `ndsl`, a known refactorable entity.