### PR TITLE
[Feature] Move `ci` to cover 3.11.7, mirroring `ndsl`

### DIFF
--- a/.github/workflows/translate.yml
+++ b/.github/workflows/translate.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python: [3.8.12]
+        python: [3.8.12, 3.11.7]
     steps:
         - name: Checkout repository
           uses: actions/checkout@v3.5.2


### PR DESCRIPTION
**Description**
The `ndsl` middleware recently started testing under 3.11.7. We updated the `pyFV3` partial regression testing to match the version bump 

**How Has This Been Tested?**
`ci` will run 3.8.12 and 3.11.7 going forward.
