### PR TITLE
Fixes import that was not previously caught

### DIFF
--- a/pyFV3/initialization/test_cases/initialize_tc.py
+++ b/pyFV3/initialization/test_cases/initialize_tc.py
@@ -2,7 +2,8 @@ import numpy as np
 
 import ndsl.constants as constants
 from ndsl import CubedSphereCommunicator, QuantityFactory
-from ndsl.grid import GridData, great_circle_distance_lon_lat
+from ndsl.grid import GridData
+from ndsl.grid.gnomonic import great_circle_distance_lon_lat
 from pyFV3.dycore_state import DycoreState
 from pyFV3.initialization import init_utils
 


### PR DESCRIPTION
**Description**
Import of `great_circle_distance_lon_lat` in `pyFV3/initialization/test_cases/initialize_tc.py`


**Checklist:**
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] New check tests, if applicable, are included
- [ ] Targeted model if this changed was triggered by a model need/shortcoming
