### PR TITLE
Feature/config from yaml

### DIFF
--- a/examples/configs/c12_baroclinic.yaml
+++ b/examples/configs/c12_baroclinic.yaml
@@ -1,0 +1,100 @@
+stencil_config:
+  compilation_config:
+    backend: numpy
+    rebuild: false
+    validate_args: false
+    format_source: false
+    device_sync: false
+grid_config:
+  type: generated
+  config:
+    grid_type: 0
+    eta_file: '/pace/input_data/eta79.nc'
+initialization:
+  type: analytic
+  config:
+    case: baroclinic
+performance_config:
+  collect_performance: false
+  experiment_name: c12_baroclinic
+grid_type: 0
+nx_tile: 12
+nz: 79
+dt_atmos: 225
+minutes: 15
+layout:
+  - 1
+  - 1
+diagnostics_config:
+  path: output.zarr
+  output_format: zarr
+  names:
+    - u
+    - v
+    - ua
+    - va
+    - pt
+    - delp
+    - qvapor
+    - qliquid
+    - qice
+    - qrain
+    - qsnow
+    - qgraupel
+    - qcld
+  z_select:
+    - level: 30
+      names:
+        - pt
+output_initial_state: true
+dycore_config:
+  a_imp: 1.0
+  beta: 0.
+  consv_te: 0.
+  d2_bg: 0.
+  d2_bg_k1: 0.2
+  d2_bg_k2: 0.1
+  d4_bg: 0.15
+  d_con: 1.0
+  d_ext: 0.0
+  dddmp: 0.5
+  delt_max: 0.002
+  do_sat_adj: true
+  do_vort_damp: true
+  fill: true
+  hord_dp: 6
+  hord_mt: 6
+  hord_tm: 6
+  hord_tr: 8
+  hord_vt: 6
+  hydrostatic: false
+  k_split: 1
+  ke_bg: 0.
+  kord_mt: 9
+  kord_tm: -9
+  kord_tr: 9
+  kord_wz: 9
+  n_split: 1
+  nord: 3
+  nwat: 6
+  p_fac: 0.05
+  rf_cutoff: 3000.
+  rf_fast: true
+  tau: 10.
+  vtdm4: 0.06
+  z_tracer: true
+  do_qa: true
+  tau_i2s: 1000.
+  tau_g2v: 1200.
+  ql_gen: 0.001
+  ql_mlt: 0.002
+  qs_mlt: 0.000001
+  qi_lim: 1.0
+  dw_ocean: 0.1
+  dw_land: 0.15
+  icloud_f: 0
+  tau_l2v: 300.
+  tau_v2l: 90.
+  fv_sg_adj: 0
+  n_sponge: 48
+  u_max: 355.0

--- a/pyFV3/_config.py
+++ b/pyFV3/_config.py
@@ -391,7 +391,7 @@ class DynamicalCoreConfig:
         with open(yaml_config, "r") as f:
             raw_config = yaml.safe_load(f)
         flat_config: dict = {}
-        timestep = timedelta(seconds=raw_config.dt_atmos)
+        timestep = timedelta(seconds=raw_config["dt_atmos"])
         runtime = {
             "days": 0.0,
             "hours": 0.0,

--- a/pyFV3/_config.py
+++ b/pyFV3/_config.py
@@ -1,7 +1,10 @@
 import dataclasses
+from datetime import timedelta
+from math import floor
 from typing import Optional, Tuple
 
 import f90nml
+import yaml
 
 from ndsl.namelist import Namelist, NamelistDefaults
 
@@ -152,6 +155,7 @@ class AcousticDynamicsConfig:
 @dataclasses.dataclass
 class DynamicalCoreConfig:
     dt_atmos: int = DEFAULT_INT
+    n_steps: int = 1
     a_imp: float = DEFAULT_FLOAT
     beta: float = DEFAULT_FLOAT
     consv_te: float = DEFAULT_FLOAT
@@ -380,6 +384,55 @@ class DynamicalCoreConfig:
             fv_sg_adj=namelist.fv_sg_adj,
             n_sponge=namelist.n_sponge,
         )
+
+    @classmethod
+    def from_yaml(cls, yaml_config: str) -> "DynamicalCoreConfig":
+        config = cls()
+        with open(yaml_config, "r") as f:
+            raw_config = yaml.safe_load(f)
+        flat_config: dict = {}
+        timestep = timedelta(seconds=raw_config.dt_atmos)
+        runtime = {
+            "days": 0.0,
+            "hours": 0.0,
+            "minutes": 0.0,
+            "seconds": 0.0,
+        }
+        for key in runtime.keys():
+            if key in raw_config.keys():
+                runtime[key] = raw_config[key]
+
+        total_time = timedelta(
+            days=runtime["days"],
+            hours=runtime["hours"],
+            minutes=runtime["minutes"],
+            seconds=runtime["seconds"],
+        )
+        for key, value in raw_config.items():
+            if isinstance(value, dict):
+                for subkey, subvalue in value.items():
+                    if subkey in config.__annotations__.keys():
+                        if subkey in flat_config:
+                            if subvalue != flat_config[subkey]:
+                                raise ValueError(
+                                    "Cannot flatten this config ",
+                                    f"duplicate keys: {subkey}",
+                                )
+                        flat_config[subkey] = subvalue
+            else:
+                if key == "nx_tile":
+                    flat_config["npx"] = value + 1
+                    flat_config["npy"] = value + 1
+                elif key == "nz":
+                    flat_config["npz"] = value
+                else:
+                    if key in config.__annotations__.keys():
+                        flat_config[key] = value
+        for field in dataclasses.fields(config):
+            if field.name in flat_config.keys():
+                setattr(config, field.name, flat_config[field.name])
+        config.n_steps = floor(total_time.total_seconds() / timestep.total_seconds())
+        return config
 
     @property
     def do_dry_convective_adjustment(self) -> bool:

--- a/tests/main/test_config_from_yaml.py
+++ b/tests/main/test_config_from_yaml.py
@@ -10,7 +10,7 @@ from pyFV3 import DynamicalCoreConfig
 
 
 TESTED_CONFIGS: List[str] = [
-    "/examples/configs/c12_baroclinic.yaml",
+    "/pyFV3/examples/configs/c12_baroclinic.yaml",
 ]
 
 
@@ -39,7 +39,7 @@ def test_config_from_yaml(tested_configs: List[str]):
             minutes=runtime["minutes"],
             seconds=runtime["seconds"],
         )
-        timestep = timedelta(seconds=config.dt_atmos)
+        timestep = timedelta(seconds=config["dt_atmos"])
         n_steps = floor(total_time.total_seconds() / timestep.total_seconds())
         dycore_config = DynamicalCoreConfig.from_yaml(config_file)
         assert dycore_config.n_steps == n_steps

--- a/tests/main/test_config_from_yaml.py
+++ b/tests/main/test_config_from_yaml.py
@@ -1,0 +1,45 @@
+import os
+from datetime import timedelta
+from math import floor
+from typing import List
+
+import pytest
+import yaml
+
+from pyFV3 import DynamicalCoreConfig
+
+
+TESTED_CONFIGS: List[str] = [
+    "/examples/configs/c12_baroclinic.yaml",
+]
+
+
+@pytest.mark.parametrize(
+    "tested_configs",
+    [
+        pytest.param(TESTED_CONFIGS, id="example configs"),
+    ],
+)
+def test_config_from_yaml(tested_configs: List[str]):
+    for config_file in tested_configs:
+        with open(os.path.abspath(config_file), "r") as f:
+            config = yaml.safe_load(f)
+        runtime = {
+            "days": 0.0,
+            "hours": 0.0,
+            "minutes": 0.0,
+            "seconds": 0.0,
+        }
+        for key in runtime.keys():
+            if key in config.keys():
+                runtime[key] = config[key]
+        total_time = timedelta(
+            days=runtime["days"],
+            hours=runtime["hours"],
+            minutes=runtime["minutes"],
+            seconds=runtime["seconds"],
+        )
+        timestep = timedelta(seconds=config.dt_atmos)
+        n_steps = floor(total_time.total_seconds() / timestep.total_seconds())
+        dycore_config = DynamicalCoreConfig.from_yaml(config_file)
+        assert dycore_config.n_steps == n_steps


### PR DESCRIPTION
**Description**
Adds the option to create a dynamical core config directly from a yaml file without going through the Pace driver. This is especially helpful for running standalone-dycore development tests like the baroclinic instability.

**How Has This Been Tested?**
This has been verified through running the baroclinic instability test using a yaml config, and a test case was created.

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [ ] Targeted model if this changed was triggered by a model need/shortcoming
