### PR TITLE
Checks for unimplemented iord/jord

### DIFF
--- a/pyFV3/stencils/xppm.py
+++ b/pyFV3/stencils/xppm.py
@@ -315,6 +315,18 @@ class XPiecewiseParabolic:
                 "X Piecewise Parabolic (xppm): "
                 f" grid type {grid_type} not implemented. <3 or 4 available."
             )
+
+        if abs(iord) >= 8 and iord != 8:
+            raise NotImplementedError(
+                "X Piecewise Parabolic (xppm): "
+                f"iord {iord} != 8 not implemented when >= 8."
+            )
+
+        if iord < 0:
+            raise NotImplementedError(
+                f"X Piecewise Parabolic (xppm): iord {iord} < 0 not implemented."
+            )
+
         self._dxa = dxa
         ax_offsets = stencil_factory.grid_indexing.axis_offsets(origin, domain)
         self._compute_flux_stencil = stencil_factory.from_origin_domain(

--- a/pyFV3/stencils/yppm.py
+++ b/pyFV3/stencils/yppm.py
@@ -316,6 +316,18 @@ class YPiecewiseParabolic:
                 "Y Piecewise Parabolic (xppm): "
                 f" grid type {grid_type} not implemented. <3 or 4 available."
             )
+
+        if abs(jord) >= 8 and jord != 8:
+            raise NotImplementedError(
+                "Y Piecewise Parabolic (yppm): "
+                f"jord {jord} != 8 not implemented when >= 8."
+            )
+
+        if jord < 0:
+            raise NotImplementedError(
+                f"Y Piecewise Parabolic (yppm): jord {jord} < 0 not implemented."
+            )
+
         self._dya = dya
         ax_offsets = stencil_factory.grid_indexing.axis_offsets(origin, domain)
         self._compute_flux_stencil = stencil_factory.from_origin_domain(


### PR DESCRIPTION
**Description**
Double the `compile_assert` in XPPM/YPPM with a check/raise on the class `__init__` to verbose the non implemented features.

**How Has This Been Tested?**
With GEOS model which demands unimplemented features. *Do not* change default behavior.

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] New check tests, if applicable, are included
- [x] Targeted model if this changed was triggered by a model need/shortcoming
