### PR TITLE
Cleanup pass in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-"""The setup script."""
-
 from setuptools import find_namespace_packages, setup
 
 
@@ -15,35 +13,46 @@ requirements = [
     "xarray",
 ]
 
-test_requirements = ["pytest", "pytest-subtests", "serialbox", "coverage"]
-ndsl_requirements = ["ndsl @ git+https://github.com/NOAA-GFDL/NDSL.git@develop"]
-develop_requirements = test_requirements + ndsl_requirements + ["pre-commit"]
+test_requirements = [
+    "coverage",
+    "pytest",
+    "pytest-subtests",
+    "serialbox",
+]
+
+ndsl_requirements = ["ndsl @ git+https://github.com/NOAA-GFDL/NDSL.git@2024.09.00"]
+
+develop_requirements = [
+    *ndsl_requirements,
+    *test_requirements,
+    "pre-commit",
+]
 
 extras_requires = {
-    "test": test_requirements,
-    "ndsl": ndsl_requirements,
     "develop": develop_requirements,
+    "ndsl": ndsl_requirements,
+    "test": test_requirements,
 }
 
 setup(
-    author="The Allen Institute for Artificial Intelligence",
+    author="NOAA - Geophysical Fluid Dynamics Laboratory",
     author_email="oliver.elbert@noaa.gov",
-    python_requires=">=3.11",
+    python_requires=">=3.11,<3.12",
     classifiers=[
         "Development Status :: 2 - Pre-Alpha",
         "Intended Audience :: Developers",
-        "License :: OSI Approved :: BSD License",
+        "License :: OSI Approved :: GPLv3 License",
         "Natural Language :: English",
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3.11",
     ],
-    description="pyFV3 is a NDSL-based FV3 dynamical core for atmospheric models",
+    description="PyFV3 is a NDSL-based FV3 dynamical core for atmospheric models.",
     install_requires=requirements,
     extras_require=extras_requires,
-    license="BSD license",
+    license="GPLv3 license",
     long_description=readme,
     include_package_data=True,
-    name="pyFV3",
+    name="PyFV3",
     packages=find_namespace_packages(include=["pyFV3", "pyFV3.*"]),
     setup_requires=[],
     test_suite="tests",

--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ setup(
     license="GPLv3 license",
     long_description=readme,
     include_package_data=True,
-    name="PyFV3",
+    name="pyFV3",
     packages=find_namespace_packages(include=["pyFV3", "pyFV3.*"]),
     setup_requires=[],
     test_suite="tests",

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,6 @@ setup(
     extras_require=extras_requires,
     license="GPLv3 license",
     long_description=readme,
-    include_package_data=True,
     name="pyFV3",
     packages=find_namespace_packages(include=["pyFV3", "pyFV3.*"]),
     setup_requires=[],


### PR DESCRIPTION
**Description**

This PR does a pass on the `setup.py` file and changes the following

- Fully move ownership information from AI2 to NOAA-GDFL
- Restrict python version to 3.11 ([NDSL requirement](https://github.com/NOAA-GFDL/NDSL?tab=readme-ov-file#requirements--supported-compilers))
- Consistent license information
- Pin NDSL at latest release, 2024.09.00, see https://github.com/NOAA-GFDL/PyFV3/pull/23#discussion_r1668732097

This is a follow-up from  a couple of PRs and mentions including

- https://github.com/NOAA-GFDL/PyFV3/pull/21#discussion_r1671043186 and https://github.com/NOAA-GFDL/PyFV3/pull/21#pullrequestreview-2175496120 which advocated for a holistic pass on the file
- https://github.com/NOAA-GFDL/PyFV3/pull/27 which only updated python version

**How Has This Been Tested?**

Tested `python_requires` locally (with different python version and multiple virtual environments)

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [ ] New check tests, if applicable, are included
- [ ] Targeted model if this changed was triggered by a model need/shortcoming
