### PR TITLE
[WIP] Rayleigh Damping mixed precision fix

### DIFF
--- a/pyFV3/stencils/fv_dynamics.py
+++ b/pyFV3/stencils/fv_dynamics.py
@@ -483,12 +483,6 @@ class DynamicalCore:
                 "Dynamical Core (fv_dynamics): compute total energy is not implemented"
             )
 
-        if (not self.config.rf_fast) and self.config.tau != 0:
-            raise NotImplementedError(
-                "Dynamical Core (fv_dynamics): Rayleigh_Super,"
-                " called when rf_fast=False and tau !=0, is not implemented"
-            )
-
         if self.config.adiabatic and self.config.kord_tm > 0:
             raise NotImplementedError(
                 "Dynamical Core (fv_dynamics): Adiabatic with positive kord_tm"

--- a/pyFV3/stencils/ray_fast.py
+++ b/pyFV3/stencils/ray_fast.py
@@ -5,12 +5,12 @@ from gt4py.cartesian.gtscript import (
     FORWARD,
     PARALLEL,
     computation,
+    f64,
     horizontal,
     interval,
     log,
     region,
     sin,
-    f64,
 )
 
 import ndsl.constants as constants

--- a/pyFV3/stencils/ray_fast.py
+++ b/pyFV3/stencils/ray_fast.py
@@ -15,11 +15,8 @@ from gt4py.cartesian.gtscript import (
 
 import ndsl.constants as constants
 from ndsl import StencilFactory, orchestrate
-from ndsl.constants import X_INTERFACE_DIM, Y_INTERFACE_DIM, Z_DIM
+from ndsl.constants import SECONDS_PER_DAY, X_INTERFACE_DIM, Y_INTERFACE_DIM, Z_DIM
 from ndsl.dsl.typing import Float, FloatField, FloatFieldK
-
-
-SDAY = Float(86400.0)
 
 
 # NOTE: The fortran version of this computes rf in the first timestep only. Then
@@ -77,7 +74,7 @@ def ray_fast_wind_compute(
         if pfull < rf_cutoff:
             # rf is rayleigh damping increment, fraction of vertical velocity
             # left after doing rayleigh damping (w -> w * rf)
-            rf = compute_rff_vals(pfull, dt, rf_cutoff, tau * SDAY, ptop)
+            rf = compute_rff_vals(pfull, dt, rf_cutoff, tau * SECONDS_PER_DAY, ptop)
     with computation(FORWARD):
         with interval(0, 1):
             if pfull < rf_cutoff_nudge:

--- a/pyFV3/stencils/ray_fast.py
+++ b/pyFV3/stencils/ray_fast.py
@@ -15,7 +15,15 @@ from gt4py.cartesian.gtscript import (
 
 import ndsl.constants as constants
 from ndsl import StencilFactory, orchestrate
-from ndsl.constants import SECONDS_PER_DAY, X_INTERFACE_DIM, Y_INTERFACE_DIM, Z_DIM
+from ndsl.boilerplate import get_factories_single_tile
+from ndsl.constants import (
+    SECONDS_PER_DAY,
+    X_INTERFACE_DIM,
+    Y_INTERFACE_DIM,
+    Z_DIM,
+    X_DIM,
+    Y_DIM,
+)
 from ndsl.dsl.typing import Float, FloatField, FloatFieldK
 
 
@@ -43,14 +51,31 @@ def dm_layer(rf, dp, wind):
     return (1.0 - rf) * dp * wind
 
 
+def ray_fast_damping_increment(
+    pfull: FloatFieldK,  # type:ignore
+    dt: Float,  # type:ignore
+    ptop: Float,  # type:ignore
+    rf: FloatField,  # type:ignore
+):
+    """rf is rayleigh damping increment, fraction of vertical velocity
+    left after doing rayleigh damping (w -> w * rf)
+    """
+    from __externals__ import rf_cutoff, tau
+
+    with computation(PARALLEL), interval(...):
+        if pfull < rf_cutoff:
+            # rf is rayleigh damping increment, fraction of vertical velocity
+            # left after doing rayleigh damping (w -> w * rf)
+            rf = compute_rff_vals(pfull, dt, rf_cutoff, tau * SECONDS_PER_DAY, ptop)
+
+
 def ray_fast_wind_compute(
     u: FloatField,
     v: FloatField,
     w: FloatField,
     delta_p_ref: FloatFieldK,  # reference delta pressure
     pfull: FloatFieldK,  # input layer pressure reference?
-    dt: Float,
-    ptop: Float,
+    rf: FloatFieldK,
     rf_cutoff_nudge: Float,
 ):
     """
@@ -68,13 +93,6 @@ def ray_fast_wind_compute(
     from __externals__ import hydrostatic, local_ie, local_je, rf_cutoff, tau
 
     # dm_stencil
-    with computation(PARALLEL), interval(...):
-        # TODO -- in the fortran model rf is only computed once, repeating
-        # the computation every time ray_fast is run is inefficient
-        if pfull < rf_cutoff:
-            # rf is rayleigh damping increment, fraction of vertical velocity
-            # left after doing rayleigh damping (w -> w * rf)
-            rf = compute_rff_vals(pfull, dt, rf_cutoff, tau * SECONDS_PER_DAY, ptop)
     with computation(FORWARD):
         with interval(0, 1):
             if pfull < rf_cutoff_nudge:
@@ -191,6 +209,29 @@ class RayleighDamping:
             },
         )
 
+        # We compute the damping increment once using a trick to write a
+        # FloatFieldK as a (1, 1, K) 3D writable Field
+        K_stencil_factory, K_quantity_factory = get_factories_single_tile(
+            1,
+            1,
+            domain[2],
+            0,
+            stencil_factory.backend,
+        )
+        self._ray_fast_damping_increment = K_stencil_factory.from_origin_domain(
+            ray_fast_damping_increment,
+            origin=(0, 0, origin[2]),
+            domain=(1, 1, domain[2]),
+            externals={
+                "rf_cutoff": self._rf_cutoff,
+                "tau": tau,
+            },
+        )
+        self._damping_increment = K_quantity_factory.ones(
+            [X_DIM, Y_DIM, Z_DIM], units="n/a"
+        )
+        self._initialize_damping_increment = False
+
     def __call__(
         self,
         u: FloatField,
@@ -203,13 +244,17 @@ class RayleighDamping:
     ):
         rf_cutoff_nudge = self._rf_cutoff + min(Float(100.0), Float(10.0) * ptop)
 
+        if not self._initialize_damping_increment:
+            self._ray_fast_damping_increment(
+                pfull=pfull, dt=dt, ptop=ptop, rf=self._damping_increment
+            )
+            self._initialize_damping_increment = True
         self._ray_fast_wind_compute(
-            u,
-            v,
-            w,
-            dp,
-            pfull,
-            dt,
-            ptop,
-            rf_cutoff_nudge,
+            u=u,
+            v=v,
+            w=w,
+            delta_p_ref=dp,
+            pfull=pfull,
+            rf=self._damping_increment.view[0, 0, :],
+            rf_cutoff_nudge=rf_cutoff_nudge,
         )

--- a/pyFV3/stencils/ray_fast.py
+++ b/pyFV3/stencils/ray_fast.py
@@ -242,6 +242,16 @@ class RayleighDamping:
         dt: Float,
         ptop: Float,
     ):
+        """
+        Args:
+            u (inout)
+            v (inout)
+            w (inout)
+            dp (in)
+            pfull (in)
+            dt (in)
+            ptop (in)
+        """
         rf_cutoff_nudge = self._rf_cutoff + min(Float(100.0), Float(10.0) * ptop)
 
         if not self._initialize_damping_increment:


### PR DESCRIPTION
- Move RFF calculation to f64 to match Fortran
- Fix the implementation check for RayleighDamping and move it closer to the code

:warning:  This _cannot be merged_ as of 2024/11/29 :warning:

- The mixed precision system relies on features that are not yet merged in mainline `gt4py` but only available on the experimental NASA branch
- To be tested, this requires a f32 dataset 