### PR TITLE
[WIP] [F32 Update] Fix for DelnFlux & DlenFluxNoSG

### DIFF
--- a/pyFV3/stencils/delnflux.py
+++ b/pyFV3/stencils/delnflux.py
@@ -1,6 +1,7 @@
 from typing import Optional
 
 import gt4py.cartesian.gtscript as gtscript
+import numpy as np
 from gt4py.cartesian.gtscript import PARALLEL, computation, horizontal, interval, region
 
 from ndsl import Quantity, QuantityFactory, StencilFactory, orchestrate
@@ -8,7 +9,6 @@ from ndsl.constants import X_DIM, X_INTERFACE_DIM, Y_DIM, Y_INTERFACE_DIM, Z_DIM
 from ndsl.dsl.stencil import get_stencils_with_varied_bounds
 from ndsl.dsl.typing import Float, FloatField, FloatFieldIJ, FloatFieldK
 from ndsl.grid import DampingCoefficients
-import numpy as np
 
 
 def calc_damp(damp_c: Quantity, da_min: Float, nord: Quantity) -> Quantity:

--- a/pyFV3/stencils/delnflux.py
+++ b/pyFV3/stencils/delnflux.py
@@ -17,7 +17,12 @@ def calc_damp(damp_c: Quantity, da_min: Float, nord: Quantity) -> Quantity:
             "current implementation requires damp_c and nord to have "
             "identical data shape and dims"
         )
-    data = np.power((damp_c.data * da_min), (nord.data + 1), dtype=Float)
+    # `da_min` is a 64 bit float and we have to cast the array to deal
+    # with downcasting behavior of array * scalar in numpy
+    # We then reproduce the proper casting so `calc_damp` is a 32-bit float
+    data = np.power(
+        (damp_c.data.astype(np.float64) * da_min), (nord.data + 1), dtype=np.float64
+    ).astype(Float)
     return Quantity(
         data=data,
         dims=damp_c.dims,
@@ -371,6 +376,7 @@ class DelnFlux:
         rarea: Quantity,
         nord_col: Quantity,
         damp_c: Quantity,
+        damp_coeff: Quantity | None = None,
     ):
         """
         nord sets the order of damping to apply:
@@ -419,9 +425,14 @@ class DelnFlux:
             func=diffusive_damp, compute_dims=[X_INTERFACE_DIM, Y_INTERFACE_DIM, Z_DIM]
         )
 
-        self._damp = calc_damp(
-            damp_c=damp_c, da_min=damping_coefficients.da_min, nord=nord_col
-        )
+        damp_c.to_netcdf("damp_c.nc4")
+        nord_col.to_netcdf("nord_col.nc4")
+        if damp_coeff is None:
+            self._damp = calc_damp(
+                damp_c=damp_c, da_min=damping_coefficients.da_min, nord=nord_col
+            )
+        else:
+            self._damp = damp_coeff
 
         self.delnflux_nosg = DelnFluxNoSG(
             stencil_factory, damping_coefficients, rarea, nord_col, nk=nk

--- a/pyFV3/stencils/delnflux.py
+++ b/pyFV3/stencils/delnflux.py
@@ -376,7 +376,6 @@ class DelnFlux:
         rarea: Quantity,
         nord_col: Quantity,
         damp_c: Quantity,
-        damp_coeff: Quantity | None = None,
     ):
         """
         nord sets the order of damping to apply:
@@ -425,14 +424,9 @@ class DelnFlux:
             func=diffusive_damp, compute_dims=[X_INTERFACE_DIM, Y_INTERFACE_DIM, Z_DIM]
         )
 
-        damp_c.to_netcdf("damp_c.nc4")
-        nord_col.to_netcdf("nord_col.nc4")
-        if damp_coeff is None:
-            self._damp = calc_damp(
-                damp_c=damp_c, da_min=damping_coefficients.da_min, nord=nord_col
-            )
-        else:
-            self._damp = damp_coeff
+        self._damp = calc_damp(
+            damp_c=damp_c, da_min=damping_coefficients.da_min, nord=nord_col
+        )
 
         self.delnflux_nosg = DelnFluxNoSG(
             stencil_factory, damping_coefficients, rarea, nord_col, nk=nk

--- a/pyFV3/stencils/delnflux.py
+++ b/pyFV3/stencils/delnflux.py
@@ -429,7 +429,11 @@ class DelnFlux:
         )
 
         self.delnflux_nosg = DelnFluxNoSG(
-            stencil_factory, damping_coefficients, rarea, nord_col, nk=nk
+            stencil_factory,
+            damping_coefficients,
+            rarea,
+            nord_col,
+            nk=nk,
         )
 
     def __call__(
@@ -443,11 +447,11 @@ class DelnFlux:
         """
         Del-n damping for fluxes, where n = 2 * nord + 2
         Args:
-            q: Field for which to calculate damped fluxes (in)
-            fx: x-flux on A-grid (inout)
-            fy: y-flux on A-grid (inout)
-            d2: A damped copy of the q field (in)
-            mass: Mass to weight the diffusive flux by (in)
+            q (in): Field for which to calculate damped fluxes
+            fx (inout): x-flux on A-grid
+            fy (inout): y-flux on A-grid
+            d2 (in): A damped copy of the q field
+            mass (in): Mass to weight the diffusive flux by
         """
         if self._no_compute is True:
             return fx, fy
@@ -617,14 +621,12 @@ class DelnFluxNoSG:
             externals={**corner_axis_offsets},
             origin=corner_origin,
             domain=corner_domain,
-            skip_passes=("UnreachableStmtPruning",),
         )
         self._copy_corners_y_nord = stencil_factory.from_origin_domain(
             copy_corners_y_nord,
             externals={**corner_axis_offsets},
             origin=corner_origin,
             domain=corner_domain,
-            skip_passes=("UnreachableStmtPruning",),
         )
 
     def __call__(self, q, fx2, fy2, damp_c, d2, mass=None):
@@ -645,17 +647,46 @@ class DelnFluxNoSG:
         """
 
         if mass is None:
-            self._d2_damp(q=q, d2=d2, damp=damp_c, nord=self._nord)
+            self._d2_damp(
+                q=q,
+                d2=d2,
+                damp=damp_c,
+                nord=self._nord,
+            )
         else:
-            self._copy_stencil_interval(q_in=q, q_out=d2, nord=self._nord)
+            self._copy_stencil_interval(
+                q_in=q,
+                q_out=d2,
+                nord=self._nord,
+            )
 
-        self._copy_corners_x_nord(q_in=d2, q_out=d2, nord=self._nord, current_nord=0)
+        self._copy_corners_x_nord(
+            q_in=d2,
+            q_out=d2,
+            nord=self._nord,
+            current_nord=0,
+        )
 
-        self._fx_calc_stencil(q=d2, del6_v=self._del6_v, fx=fx2, nord=self._nord)
+        self._fx_calc_stencil(
+            q=d2,
+            del6_v=self._del6_v,
+            fx=fx2,
+            nord=self._nord,
+        )
 
-        self._copy_corners_y_nord(q_in=d2, q_out=d2, nord=self._nord, current_nord=0)
+        self._copy_corners_y_nord(
+            q_in=d2,
+            q_out=d2,
+            nord=self._nord,
+            current_nord=0,
+        )
 
-        self._fy_calc_stencil(q=d2, del6_u=self._del6_u, fy=fy2, nord=self._nord)
+        self._fy_calc_stencil(
+            q=d2,
+            del6_u=self._del6_u,
+            fy=fy2,
+            nord=self._nord,
+        )
 
         for n in range(self._nmax):
             self._d2_stencil[n](
@@ -668,17 +699,31 @@ class DelnFluxNoSG:
             )
 
             self._copy_corners_x_nord(
-                q_in=d2, q_out=d2, nord=self._nord, current_nord=n
+                q_in=d2,
+                q_out=d2,
+                nord=self._nord,
+                current_nord=n,
             )
 
             self._column_conditional_fx_calculation[n](
-                q=d2, del6_v=self._del6_v, fx=fx2, nord=self._nord, current_nord=n
+                q=d2,
+                del6_v=self._del6_v,
+                fx=fx2,
+                nord=self._nord,
+                current_nord=n,
             )
 
             self._copy_corners_y_nord(
-                q_in=d2, q_out=d2, nord=self._nord, current_nord=n
+                q_in=d2,
+                q_out=d2,
+                nord=self._nord,
+                current_nord=n,
             )
 
             self._column_conditional_fy_calculation[n](
-                q=d2, del6_u=self._del6_u, fy=fy2, nord=self._nord, current_nord=n
+                q=d2,
+                del6_u=self._del6_u,
+                fy=fy2,
+                nord=self._nord,
+                current_nord=n,
             )


### PR DESCRIPTION
The Fortran calculate the negative flux by inverting the `q` and offset-ed `q` in the gradient calculation, while the original port of `pyFV3` was using a negative u/v and the same gradient. This works at f64 but introduces errors at f32 for very small values advected.

Clean up of a few differences with Fortran that don't necessarily fail now but could with other data.

E.g.:
- Replicate Fortran subtraction to reduce f32 errors
- Use `np.power` to insure proper type casting of power op
- Verbose the half damp calculation

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] New check tests, if applicable, are included
- [ ] Targeted model if this changed was triggered by a model need/shortcoming
