### PR TITLE
[F32] Divergence Damping

### DIFF
--- a/tests/savepoint/translate/translate_divergencedamping.py
+++ b/tests/savepoint/translate/translate_divergencedamping.py
@@ -60,13 +60,3 @@ class TranslateDivergenceDamping(TranslateDycoreFortranData2Py):
         )
         self.divdamp(**inputs)
         return inputs
-
-    def subset_output(self, varname: str, output):
-        """
-        Given an output array, return the slice of the array which we'd
-        like to validate against reference data
-        """
-        if self.divdamp is None:
-            raise RuntimeError("must call compute_from_storage before subset_output")
-        else:
-            return self.divdamp.subset_output(varname, output)  # type: ignore


### PR DESCRIPTION
We need to make sure scalars are properly type so 64-bit computation does not bleed into a 32-bit based computation

Also, removed an extraneous subset slicing in translate test which was a previous strategy to deal with expected NaNs in the test data

This should not change 64-bit calculations and therefore is ready for `develop`

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
- [ ] Targeted model if this changed was triggered by a model need/shortcoming
