### PR TITLE
Tracer rework (Part 1): allow N tracers advection

### DIFF
--- a/examples/standalone/runfile/dynamics.py
+++ b/examples/standalone/runfile/dynamics.py
@@ -263,6 +263,7 @@ def setup_dycore(
         config=dycore_config,
         phis=state.phis,
         state=state,
+        exclude_tracers=[],
         timestep=timedelta(seconds=dycore_config.dt_atmos),
     )
     return dycore, state, stencil_factory

--- a/pyFV3/initialization/test_cases/initialize_baroclinic.py
+++ b/pyFV3/initialization/test_cases/initialize_baroclinic.py
@@ -339,9 +339,11 @@ def init_baroclinic_state(
     )
     state = DycoreState.init_from_numpy_arrays(
         numpy_state.__dict__,
-        sizer=quantity_factory.sizer,
+        quantity_factory=quantity_factory,
         backend=sample_quantity.metadata.gt4py_backend,
+        tracer_list=["vapor", "liquid", "rain", "snow", "ice", "graupel", "cloud"],
     )
+    state.tracers["vapor"].view[:] = numpy_state.qvapor[slice_3d]
 
     comm.halo_update(state.phis, n_points=NHALO)
 

--- a/pyFV3/initialization/test_cases/initialize_tc.py
+++ b/pyFV3/initialization/test_cases/initialize_tc.py
@@ -561,7 +561,6 @@ def init_tc_state(
     numpy_state.pkz[:] = pkz
     numpy_state.ps[:] = pe[:, :, -1]
     numpy_state.pt[:] = pt
-    numpy_state.qvapor[:] = qvapor
     numpy_state.u[:] = ud
     numpy_state.ua[:] = ua
     numpy_state.v[:] = vd
@@ -569,8 +568,10 @@ def init_tc_state(
     numpy_state.w[:] = w
     state = DycoreState.init_from_numpy_arrays(
         numpy_state.__dict__,
-        sizer=quantity_factory.sizer,
+        quantity_factory=quantity_factory,
         backend=sample_quantity.metadata.gt4py_backend,
+        tracer_list=["vapor", "liquid", "rain", "snow", "ice", "graupel", "cloud"],
     )
+    state.tracers["vapor"].view[:] = qvapor
 
     return state

--- a/pyFV3/stencils/dyn_core.py
+++ b/pyFV3/stencils/dyn_core.py
@@ -460,6 +460,7 @@ class AcousticDynamics:
                 quantity_factory=quantity_factory,
                 grid_data=grid_data,
                 grid_type=config.grid_type,
+                use_logp=config.use_logp,
             )
         )
         self._akap = Float(constants.KAPPA)

--- a/pyFV3/stencils/fillz.py
+++ b/pyFV3/stencils/fillz.py
@@ -154,12 +154,11 @@ class FillNegativeTracerValues:
             tracers (inout): tracers to fix negative masses in
         """
         for name, tracer in tracers.items():
-            if name in self._exclude_tracers:
-                continue
-            self._fix_tracer_stencil(
-                tracer,
-                dp2,
-                self._zfix,
-                self._sum0,
-                self._sum1,
-            )
+            if name not in self._exclude_tracers:
+                self._fix_tracer_stencil(
+                    tracer,
+                    dp2,
+                    self._zfix,
+                    self._sum0,
+                    self._sum1,
+                )

--- a/pyFV3/stencils/mapn_tracer.py
+++ b/pyFV3/stencils/mapn_tracer.py
@@ -1,12 +1,12 @@
-from typing import Dict
+from typing import List
 
-import ndsl.dsl.gt4py_utils as utils
-from ndsl import Quantity, QuantityFactory, StencilFactory, orchestrate
+from ndsl import QuantityFactory, StencilFactory, orchestrate
 from ndsl.constants import X_DIM, Y_DIM, Z_DIM
 from ndsl.dsl.typing import Float, FloatField
 from pyFV3.stencils.fillz import FillNegativeTracerValues
 from pyFV3.stencils.map_single import MapSingle
 from pyFV3.tracers import Tracers
+import dace
 
 
 class MapNTracer:
@@ -21,12 +21,14 @@ class MapNTracer:
         kord: int,
         fill: bool,
         tracers: Tracers,
+        exclude_tracers: List[str],
     ):
         orchestrate(
             obj=self,
             config=stencil_factory.config.dace_config,
             dace_compiletime_args=["tracers"],
         )
+        self._exclude_tracers = exclude_tracers
         self._qs = quantity_factory.zeros(
             [X_DIM, Y_DIM, Z_DIM],
             units="unknown",
@@ -52,6 +54,7 @@ class MapNTracer:
             self._fillz = FillNegativeTracerValues(
                 stencil_factory,
                 quantity_factory,
+                exclude_tracers=self._exclude_tracers,
             )
         else:
             self._fill_negative_tracers = False
@@ -74,8 +77,10 @@ class MapNTracer:
             dp2 (in): Difference in pressure between Eulerian levels
             tracers (inout): tracers to be remapped
         """
-        for name, tracer in tracers.items():
-            self._map_single[name](tracer, pe1, pe2, self._qs)
+        for name in tracers.names():
+            if name in self._exclude_tracers:
+                continue
+            self._map_single[name](tracers[name], pe1, pe2, self._qs)
 
         if self._fill_negative_tracers is True:
             self._fillz(dp2, tracers)

--- a/pyFV3/stencils/mapn_tracer.py
+++ b/pyFV3/stencils/mapn_tracer.py
@@ -1,12 +1,13 @@
 from typing import List
 
+import dace
+
 from ndsl import QuantityFactory, StencilFactory, orchestrate
 from ndsl.constants import X_DIM, Y_DIM, Z_DIM
 from ndsl.dsl.typing import Float, FloatField
 from pyFV3.stencils.fillz import FillNegativeTracerValues
 from pyFV3.stencils.map_single import MapSingle
 from pyFV3.tracers import Tracers
-import dace
 
 
 class MapNTracer:

--- a/pyFV3/stencils/mapn_tracer.py
+++ b/pyFV3/stencils/mapn_tracer.py
@@ -6,6 +6,7 @@ from ndsl.constants import X_DIM, Y_DIM, Z_DIM
 from ndsl.dsl.typing import Float, FloatField
 from pyFV3.stencils.fillz import FillNegativeTracerValues
 from pyFV3.stencils.map_single import MapSingle
+from pyFV3.tracers import Tracers
 
 
 class MapNTracer:
@@ -18,43 +19,39 @@ class MapNTracer:
         stencil_factory: StencilFactory,
         quantity_factory: QuantityFactory,
         kord: int,
-        nq: int,
         fill: bool,
-        tracers: Dict[str, Quantity],
+        tracers: Tracers,
     ):
         orchestrate(
             obj=self,
             config=stencil_factory.config.dace_config,
             dace_compiletime_args=["tracers"],
         )
-        self._nq = int(nq)
         self._qs = quantity_factory.zeros(
             [X_DIM, Y_DIM, Z_DIM],
             units="unknown",
             dtype=Float,
         )
 
-        kord_tracer = [kord] * self._nq
-        kord_tracer[5] = 9  # qcld
-
-        self._list_of_remap_objects = [
-            MapSingle(
+        self._map_single = {}
+        for name in tracers.names():
+            if name == "cloud":
+                this_kord = 9
+            else:
+                this_kord = kord
+            self._map_single[name] = MapSingle(
                 stencil_factory,
                 quantity_factory,
-                kord_tracer[i],
+                this_kord,
                 0,
                 dims=[X_DIM, Y_DIM, Z_DIM],
             )
-            for i in range(len(kord_tracer))
-        ]
 
         if fill:
             self._fill_negative_tracers = True
             self._fillz = FillNegativeTracerValues(
                 stencil_factory,
                 quantity_factory,
-                self._nq,
-                tracers,
             )
         else:
             self._fill_negative_tracers = False
@@ -64,7 +61,7 @@ class MapNTracer:
         pe1: FloatField,
         pe2: FloatField,
         dp2: FloatField,
-        tracers: Dict[str, Quantity],
+        tracers: Tracers,
     ):
         """
         Remaps the tracer species onto the Eulerian grid
@@ -77,8 +74,8 @@ class MapNTracer:
             dp2 (in): Difference in pressure between Eulerian levels
             tracers (inout): tracers to be remapped
         """
-        for i, q in enumerate(utils.tracer_variables[0 : self._nq]):
-            self._list_of_remap_objects[i](tracers[q], pe1, pe2, self._qs)
+        for name, tracer in tracers.items():
+            self._map_single[name](tracer, pe1, pe2, self._qs)
 
         if self._fill_negative_tracers is True:
             self._fillz(dp2, tracers)

--- a/pyFV3/stencils/mapn_tracer.py
+++ b/pyFV3/stencils/mapn_tracer.py
@@ -1,7 +1,5 @@
 from typing import List
 
-import dace
-
 from ndsl import QuantityFactory, StencilFactory, orchestrate
 from ndsl.constants import X_DIM, Y_DIM, Z_DIM
 from ndsl.dsl.typing import Float, FloatField

--- a/pyFV3/stencils/mapn_tracer.py
+++ b/pyFV3/stencils/mapn_tracer.py
@@ -79,9 +79,8 @@ class MapNTracer:
             tracers (inout): tracers to be remapped
         """
         for name in tracers.names():
-            if name in self._exclude_tracers:
-                continue
-            self._map_single[name](tracers[name], pe1, pe2, self._qs)
+            if name not in self._exclude_tracers:
+                self._map_single[name](tracers[name], pe1, pe2, self._qs)
 
         if self._fill_negative_tracers is True:
             self._fillz(dp2, tracers)

--- a/pyFV3/stencils/remapping.py
+++ b/pyFV3/stencils/remapping.py
@@ -31,6 +31,7 @@ from pyFV3.stencils.map_single import MapSingle
 from pyFV3.stencils.mapn_tracer import MapNTracer
 from pyFV3.stencils.moist_cv import moist_pt_func, moist_pt_last_step
 from pyFV3.stencils.saturation_adjustment import SatAdjust3d
+from pyFV3.tracers import Tracers
 
 
 # TODO: Should this be set here or in global_constants?
@@ -292,9 +293,8 @@ class LagrangianToEulerian:
         quantity_factory: QuantityFactory,
         config: RemappingConfig,
         area_64,
-        nq,
         pfull,
-        tracers: Dict[str, Quantity],
+        tracers: Tracers,
         checkpointer: Optional[Checkpointer] = None,
     ):
         orchestrate(
@@ -314,7 +314,6 @@ class LagrangianToEulerian:
             raise NotImplementedError("Hydrostatic is not implemented")
 
         self._t_min = 184.0
-        self._nq = nq
         # do_omega = hydrostatic and last_step # TODO pull into inputs
         self._domain_jextra = (
             grid_indexing.domain[0],
@@ -410,7 +409,6 @@ class LagrangianToEulerian:
             stencil_factory,
             quantity_factory,
             abs(config.kord_tr),
-            nq,
             fill=config.fill,
             tracers=tracers,
         )
@@ -518,7 +516,7 @@ class LagrangianToEulerian:
 
     def __call__(
         self,
-        tracers: Dict[str, Quantity],
+        tracers: Tracers,
         pt: FloatField,
         delp: FloatField,
         delz: FloatField,
@@ -528,7 +526,6 @@ class LagrangianToEulerian:
         w: FloatField,
         cappa: FloatField,
         q_con: FloatField,
-        q_cld: FloatField,
         pkz: FloatField,
         pk: FloatField,
         pe: FloatField,
@@ -562,7 +559,6 @@ class LagrangianToEulerian:
             va (inout): A-grid y-velocity
             cappa (inout): Power to raise pressure to
             q_con (out): Total condensate mixing ratio
-            q_cld (out): Cloud fraction
             pkz (in): Layer mean pressure raised to the power of Kappa
             pk (out): Interface pressure raised to power of kappa, final acoustic value
             pe (in): Pressure at layer edges
@@ -593,12 +589,12 @@ class LagrangianToEulerian:
         # pe2 is final Eulerian edge pressures
 
         self._moist_cv_pt_pressure(
-            tracers["qvapor"],
-            tracers["qliquid"],
-            tracers["qrain"],
-            tracers["qsnow"],
-            tracers["qice"],
-            tracers["qgraupel"],
+            tracers["vapor"],
+            tracers["liquid"],
+            tracers["rain"],
+            tracers["snow"],
+            tracers["ice"],
+            tracers["graupel"],
             q_con,
             pt,
             cappa,
@@ -633,12 +629,12 @@ class LagrangianToEulerian:
         # it clear the outputs are not needed until then?
         # or, are its outputs actually used? can we delete this stencil call?
         self._moist_cv_pkz(
-            tracers["qvapor"],
-            tracers["qliquid"],
-            tracers["qrain"],
-            tracers["qsnow"],
-            tracers["qice"],
-            tracers["qgraupel"],
+            tracers["vapor"],
+            tracers["liquid"],
+            tracers["rain"],
+            tracers["snow"],
+            tracers["ice"],
+            tracers["graupel"],
             q_con,
             self._gz,
             self._cvm,
@@ -683,13 +679,13 @@ class LagrangianToEulerian:
             fast_mp_consv = consv_te > CONSV_MIN
             self._saturation_adjustment(
                 dp1,
-                tracers["qvapor"],
-                tracers["qliquid"],
-                tracers["qice"],
-                tracers["qrain"],
-                tracers["qsnow"],
-                tracers["qgraupel"],
-                q_cld,
+                tracers["vapor"],
+                tracers["liquid"],
+                tracers["ice"],
+                tracers["rain"],
+                tracers["snow"],
+                tracers["graupel"],
+                tracers["cloud"],
                 hs,
                 peln,
                 delp,
@@ -711,12 +707,12 @@ class LagrangianToEulerian:
             # to the physics, but if we're staying in dynamics we need
             # to keep it as the virtual potential temperature
             self._moist_cv_last_step_stencil(
-                tracers["qvapor"],
-                tracers["qliquid"],
-                tracers["qrain"],
-                tracers["qsnow"],
-                tracers["qice"],
-                tracers["qgraupel"],
+                tracers["vapor"],
+                tracers["liquid"],
+                tracers["rain"],
+                tracers["snow"],
+                tracers["ice"],
+                tracers["graupel"],
                 self._gz,
                 pt,
                 pkz,

--- a/pyFV3/stencils/remapping.py
+++ b/pyFV3/stencils/remapping.py
@@ -1,4 +1,4 @@
-from typing import Dict, Optional
+from typing import List, Optional
 
 from gt4py.cartesian.gtscript import (
     __INLINED,
@@ -13,7 +13,7 @@ from gt4py.cartesian.gtscript import (
     region,
 )
 
-from ndsl import Quantity, QuantityFactory, StencilFactory, orchestrate
+from ndsl import QuantityFactory, StencilFactory, orchestrate
 from ndsl.constants import (
     X_DIM,
     X_INTERFACE_DIM,
@@ -295,6 +295,7 @@ class LagrangianToEulerian:
         area_64,
         pfull,
         tracers: Tracers,
+        exclude_tracers: List[str],
         checkpointer: Optional[Checkpointer] = None,
     ):
         orchestrate(
@@ -411,6 +412,7 @@ class LagrangianToEulerian:
             abs(config.kord_tr),
             fill=config.fill,
             tracers=tracers,
+            exclude_tracers=exclude_tracers,
         )
 
         self._map_single_w = MapSingle(

--- a/pyFV3/stencils/tracer_2d_1l.py
+++ b/pyFV3/stencils/tracer_2d_1l.py
@@ -399,26 +399,27 @@ class TracerAdvection:
             )
             for name, q in tracers.items():
                 if name in self._exclude_tracers:
-                    continue
-                self.finite_volume_transport(
-                    q,
-                    x_courant,
-                    y_courant,
-                    self._x_area_flux,
-                    self._y_area_flux,
-                    self._x_flux,
-                    self._y_flux,
-                    x_mass_flux=x_mass_flux,
-                    y_mass_flux=y_mass_flux,
-                )
-                self._apply_tracer_flux(
-                    q,
-                    dp1,
-                    self._x_flux,
-                    self._y_flux,
-                    self.grid_data.rarea,
-                    dp2,
-                )
+                    pass
+                else:
+                    self.finite_volume_transport(
+                        q,
+                        x_courant,
+                        y_courant,
+                        self._x_area_flux,
+                        self._y_area_flux,
+                        self._x_flux,
+                        self._y_flux,
+                        x_mass_flux=x_mass_flux,
+                        y_mass_flux=y_mass_flux,
+                    )
+                    self._apply_tracer_flux(
+                        q,
+                        dp1,
+                        self._x_flux,
+                        self._y_flux,
+                        self.grid_data.rarea,
+                        dp2,
+                    )
             if not last_call:
                 self._tracers_halo_updater.update()
                 # we can't use variable assignment to avoid a data copy

--- a/pyFV3/testing/translate_dyncore.py
+++ b/pyFV3/testing/translate_dyncore.py
@@ -140,7 +140,10 @@ class TranslateDynCore(ParallelTranslate2PyState):
             grid_data.bk = inputs["bk"]
             grid_data.ptop = inputs["ptop"]
         self._base.make_storage_data_input_vars(inputs)
-        state = DycoreState.init_zeros(quantity_factory=self.grid.quantity_factory)
+        state = DycoreState.init_zeros(
+            quantity_factory=self.grid.quantity_factory,
+            tracer_list=[],  # No tracers used in acoustics
+        )
         wsd: Quantity = self.grid.quantity_factory.zeros(
             dims=[X_DIM, Y_DIM],
             units="unknown",

--- a/pyFV3/tracers.py
+++ b/pyFV3/tracers.py
@@ -1,0 +1,127 @@
+from __future__ import annotations
+from ndsl import Quantity, QuantityFactory
+from ndsl.constants import X_DIM, Y_DIM, Z_DIM
+from typing import Dict, List
+import numpy as np
+
+# FOR REFERENCE - previous descriptive of the tracers, lining up with Pace work
+# tracer_variables = [
+#     "qvapor",
+#     "qliquid",
+#     "qrain",
+#     "qice",
+#     "qsnow",
+#     "qgraupel",
+#     "qo3mr",
+#     "qsgs_tke",
+#     "qcld",
+# ]
+
+
+class Tracers:
+    def __init__(self, factory: QuantityFactory) -> None:
+        self._quantities: Dict[str, Quantity] = {}
+        self._quantity_factory = factory
+        self._dims = [X_DIM, Y_DIM, Z_DIM]
+
+    def copy_tracer_data(
+        self,
+        name: str,
+        data: np.ndarray,
+        units="unknown",
+    ):
+        qty = self._quantity_factory.empty(dims=self._dims, units=units)
+        if data.shape > qty.data.shape:
+            raise ValueError(
+                f"[pyFV3] Tracer {name} size ({data.shape}"
+                f" is bigger than grid {qty.data.shape})"
+            )
+        qty.data[: data.shape[0], : data.shape[1], : data.shape[2]] = data
+        self._quantities[name] = qty
+
+    @property
+    def count(self) -> int:
+        return len(self._quantities)
+
+    def values(self):
+        return self._quantities.values()
+
+    def names(self):
+        return self._quantities.keys()
+
+    def items(self):
+        return self._quantities.items()
+
+    def as_fortran_4D(self) -> np.ndarray:
+        shape = self._quantity_factory.sizer.get_shape(self._dims)
+        var4d = np.empty(
+            (
+                shape[0] - 1,
+                shape[1] - 1,
+                shape[2] - 1,
+                self.count,
+            )
+        )
+        for idx, q in enumerate(self.values()):
+            var4d[:, :, :, idx] = q.data[:-1, :-1, :-1]
+        return var4d
+
+    def as_dict(self) -> Dict[str, Quantity]:
+        return self._quantities
+
+    def __getitem__(self, key):
+        return self._quantities[key]
+
+    def __setitem__(self, key, value):
+        self._quantities[key] = value
+
+    def __str__(self) -> str:
+        return self.__repr__()
+
+    def __repr__(self) -> str:
+        msg = f"[pyFV3] {self.count} Tracers:\n"
+        for q in self.names():
+            msg += f"  {q}\n"
+        return msg
+
+    @classmethod
+    def make(
+        cls,
+        quantity_factory: QuantityFactory,
+        tracer_mapping: List[str],
+    ):
+        tracers = cls(quantity_factory)
+        for name in tracer_mapping:
+            qty = quantity_factory.empty(dims=tracers._dims, units="kg/m^2")
+            tracers._quantities[name] = qty
+        return tracers
+
+    @classmethod
+    def make_from_fortran(
+        cls,
+        quantity_factory: QuantityFactory,
+        tracer_mapping: List[str],
+        tracer_data: np.ndarray,
+    ) -> Tracers:
+        if len(tracer_data.shape) != 4:
+            raise ValueError("Expected 4D field as input")
+        count = len(tracer_mapping)
+        if count > tracer_data.shape[3]:
+            raise ValueError(
+                f"Mapping size {len(tracer_mapping)} is bigger than"
+                f" data dimensionality {tracer_data.shape[3]}"
+            )
+        tracers = cls(quantity_factory)
+        for idx in range(0, count):
+            tracers.copy_tracer_data(
+                name=tracer_mapping[idx] or f"Tracer_{idx}",
+                data=tracer_data[:, :, :, idx],
+                units="kg/m^2",
+            )
+        return tracers
+
+    @staticmethod
+    def make_mapping(tracer_data: np.ndarray):
+        if len(tracer_data.shape) != 4:
+            raise ValueError("Expected 4D field as input")
+        return tracer_data.shape[3] * [None]

--- a/pyFV3/tracers.py
+++ b/pyFV3/tracers.py
@@ -124,9 +124,3 @@ class Tracers:
                 unit=cls.unit,
             )
         return tracers
-
-    @staticmethod
-    def make_mapping(tracer_data: np.ndarray):
-        if len(tracer_data.shape) != 4:
-            raise ValueError("Expected 4D field as input")
-        return tracer_data.shape[3] * [None]

--- a/pyFV3/tracers.py
+++ b/pyFV3/tracers.py
@@ -101,6 +101,12 @@ class Tracers:
             tracers._quantities[name] = qty
         return tracers
 
+    @staticmethod
+    def blind_mapping_from_data(tracer_data: np.ndarray):
+        if len(tracer_data.shape) != 4:
+            raise ValueError("Expected 4D field as input")
+        return [f"Tracer_{idx}" for idx in range(tracer_data.shape[3])]
+
     @classmethod
     def make_from_4D_array(
         cls,

--- a/pyFV3/tracers.py
+++ b/pyFV3/tracers.py
@@ -1,3 +1,4 @@
+from typing import TypeAlias
 from ndsl import QuantityFactory
 from ndsl.constants import X_DIM, Y_DIM, Z_DIM
 from ndsl.quantity.field_bundle import FieldBundle, FieldBundleType
@@ -25,7 +26,7 @@ _default_mapping_PACE = {
 }
 
 
-TracersType = FieldBundleType.T("Tracers")
+TracersType: TypeAlias = FieldBundleType.T("Tracers")  # type: ignore
 
 
 def setup_tracers(

--- a/pyFV3/tracers.py
+++ b/pyFV3/tracers.py
@@ -1,132 +1,60 @@
-from __future__ import annotations
-
-from typing import Dict, List
-
-import numpy as np
-
-from ndsl import Quantity, QuantityFactory
+from ndsl import QuantityFactory
 from ndsl.constants import X_DIM, Y_DIM, Z_DIM
+from ndsl.quantity.field_bundle import FieldBundle, FieldBundleType
+from pyFV3.version import IS_GEOS
+
+# Defauult maopping for common models
+_default_mapping_GEOS = {
+    "vapor": 0,
+    "liquid": 1,
+    "rain": 2,
+    "snow": 3,
+    "ice": 4,
+    "graupel": 5,
+    "cloud": 6,
+}
+_default_mapping_PACE = {
+    "vapor": 0,
+    "liquid": 1,
+    "rain": 2,
+    "ice": 3,
+    "snow": 4,
+    "graupel": 5,
+    "om3r": 6,
+    "cloud": 7,
+}
 
 
-# FOR REFERENCE - previous descriptive of the tracers, lining up with Pace work
-# tracer_variables = [
-#     "qvapor",
-#     "qliquid",
-#     "qrain",
-#     "qice",
-#     "qsnow",
-#     "qgraupel",
-#     "qo3mr",
-#     "qsgs_tke",
-#     "qcld",
-# ]
+TracersType = FieldBundleType.T("Tracers")
 
 
-class Tracers:
-    unit = "g/kg"
-    dims = [X_DIM, Y_DIM, Z_DIM]
+def setup_tracers(
+    number_of_tracers: int,
+    quantity_factory: QuantityFactory,
+    mappings: dict[str, int] | None = None,
+) -> FieldBundle:
+    """Setup a FieldBundle for tracers. Should be called only once."""
 
-    def __init__(self, factory: QuantityFactory) -> None:
-        self._quantities: Dict[str, Quantity] = {}
-        self._quantity_factory = factory
+    FieldBundleType.register("Tracers", (number_of_tracers,))
 
-    def copy_tracer_data(
-        self,
-        name: str,
-        data: np.ndarray,
-        unit="unknown",
-    ):
-        qty = self._quantity_factory.empty(dims=self.dims, units=unit)
-        if data.shape > qty.data.shape:
-            raise ValueError(
-                f"[pyFV3] Tracer {name} size ({data.shape}"
-                f" is bigger than grid {qty.data.shape})"
-            )
-        qty.data[: data.shape[0], : data.shape[1], : data.shape[2]] = data
-        self._quantities[name] = qty
+    _unit = "g/kg"
+    _dims = [X_DIM, Y_DIM, Z_DIM, "tracers"]
 
-    @property
-    def count(self) -> int:
-        return len(self._quantities)
+    tracers_qty_factory = FieldBundle.extend_3D_quantity_factory(
+        quantity_factory, {"tracers": number_of_tracers}
+    )
+    data = tracers_qty_factory.zeros(_dims, units=_unit)
 
-    def values(self):
-        return self._quantities.values()
+    # Some default mappings for ease of use with commonly
+    # run models
+    if mappings is None:
+        if IS_GEOS:
+            mappings = _default_mapping_GEOS
+        else:
+            mappings = _default_mapping_PACE
 
-    def names(self):
-        return self._quantities.keys()
-
-    def items(self):
-        return self._quantities.items()
-
-    def as_4D_array(self) -> np.ndarray:
-        shape = self._quantity_factory.sizer.get_shape(self.dims)
-        var4d = np.empty(
-            (
-                shape[0] - 1,
-                shape[1] - 1,
-                shape[2] - 1,
-                self.count,
-            )
-        )
-        # Skip the extra data point that is meant to align interface
-        # and non interface fields
-        for idx, q in enumerate(self.values()):
-            var4d[:, :, :, idx] = q.data[:-1, :-1, :-1]
-        return var4d
-
-    def __getitem__(self, key):
-        return self._quantities[key]
-
-    def __setitem__(self, key, value):
-        self._quantities[key] = value
-
-    def __str__(self) -> str:
-        return self.__repr__()
-
-    def __repr__(self) -> str:
-        msg = f"[pyFV3] {self.count} Tracers:\n"
-        for q in self.names():
-            msg += f"  {q}\n"
-        return msg
-
-    @classmethod
-    def make(
-        cls,
-        quantity_factory: QuantityFactory,
-        tracer_mapping: List[str],
-    ):
-        tracers = cls(quantity_factory)
-        for name in tracer_mapping:
-            qty = quantity_factory.empty(dims=cls.dims, units=cls.unit)
-            tracers._quantities[name] = qty
-        return tracers
-
-    @staticmethod
-    def blind_mapping_from_data(tracer_data: np.ndarray):
-        if len(tracer_data.shape) != 4:
-            raise ValueError("Expected 4D field as input")
-        return [f"Tracer_{idx}" for idx in range(tracer_data.shape[3])]
-
-    @classmethod
-    def make_from_4D_array(
-        cls,
-        quantity_factory: QuantityFactory,
-        tracer_mapping: List[str],
-        tracer_data: np.ndarray,
-    ) -> Tracers:
-        if len(tracer_data.shape) != 4:
-            raise ValueError("Expected 4D field as input")
-        count = len(tracer_mapping)
-        if count > tracer_data.shape[3]:
-            raise ValueError(
-                f"Mapping size {len(tracer_mapping)} is bigger than"
-                f" data dimensionality {tracer_data.shape[3]}"
-            )
-        tracers = cls(quantity_factory)
-        for idx in range(0, count):
-            tracers.copy_tracer_data(
-                name=tracer_mapping[idx] or f"Tracer_{idx}",
-                data=tracer_data[:, :, :, idx],
-                unit=cls.unit,
-            )
-        return tracers
+    return FieldBundle(
+        "Tracers",
+        quantity=data,
+        mapping=mappings,
+    )

--- a/pyFV3/tracers.py
+++ b/pyFV3/tracers.py
@@ -8,9 +8,9 @@ from pyFV3.version import IS_GEOS
 _default_mapping_GEOS = {
     "vapor": 0,
     "liquid": 1,
-    "rain": 2,
-    "snow": 3,
-    "ice": 4,
+    "ice": 2,
+    "rain": 3,
+    "snow": 4,
     "graupel": 5,
     "cloud": 6,
 }

--- a/tests/mpi/test_doubly_periodic.py
+++ b/tests/mpi/test_doubly_periodic.py
@@ -128,6 +128,7 @@ def setup_dycore() -> Tuple[DynamicalCore, List[Any]]:
         config=config,
         phis=state.phis,
         state=state,
+        exclude_tracers=[],
         timestep=timedelta(seconds=255),
     )
     # TODO compute from namelist

--- a/tests/savepoint/translate/translate_fillz.py
+++ b/tests/savepoint/translate/translate_fillz.py
@@ -1,12 +1,13 @@
+from typing import List
+
 import numpy as np
 
-from ndsl import Namelist, StencilFactory, QuantityFactory
+from ndsl import Namelist, QuantityFactory, StencilFactory
 from ndsl.stencils.testing import pad_field_in_j
 from ndsl.utils import safe_assign_array
 from pyFV3.stencils.fillz import FillNegativeTracerValues
 from pyFV3.testing import TranslateDycoreFortranData2Py
 from pyFV3.tracers import Tracers
-from typing import List
 
 
 class TranslateFillz(TranslateDycoreFortranData2Py):
@@ -62,8 +63,8 @@ class TranslateFillz(TranslateDycoreFortranData2Py):
             "ice",
             "snow",
             "graupel",
-            "qo3mr",
-            "qsgs_tke",
+            "o3mr",
+            "sgs_tke",
         ]
         tracers = Tracers.make(
             quantity_factory=self._quantity_factory,
@@ -90,6 +91,7 @@ class TranslateFillz(TranslateDycoreFortranData2Py):
         fillz = FillNegativeTracerValues(
             self.stencil_factory,
             self.grid.quantity_factory,
+            exclude_tracers=[],
         )
         fillz(**inputs)
         ds = self.grid.default_domain_dict()

--- a/tests/savepoint/translate/translate_fillz.py
+++ b/tests/savepoint/translate/translate_fillz.py
@@ -1,11 +1,12 @@
 import numpy as np
 
-import ndsl.dsl.gt4py_utils as utils
-from ndsl import Namelist, StencilFactory
+from ndsl import Namelist, StencilFactory, QuantityFactory
 from ndsl.stencils.testing import pad_field_in_j
 from ndsl.utils import safe_assign_array
-from pyFV3.stencils import fillz
+from pyFV3.stencils.fillz import FillNegativeTracerValues
 from pyFV3.testing import TranslateDycoreFortranData2Py
+from pyFV3.tracers import Tracers
+from typing import List
 
 
 class TranslateFillz(TranslateDycoreFortranData2Py):
@@ -33,18 +34,20 @@ class TranslateFillz(TranslateDycoreFortranData2Py):
         self.max_error = 1e-13
         self.ignore_near_zero_errors = {"q2tracers": True}
         self.stencil_factory = stencil_factory
+        self._quantity_factory = QuantityFactory.from_backend(
+            sizer=stencil_factory.grid_indexing._sizer,
+            backend=stencil_factory.backend,
+        )
 
-    def make_storage_data_input_vars(self, inputs, storage_vars=None):
-        if storage_vars is None:
-            storage_vars = self.storage_vars()
+    def make_storage_data_input_vars(self, inputs, tracer_mapping: List[str]):
+        storage_vars = self.storage_vars()
         info = storage_vars["dp2"]
         inputs["dp2"] = self.make_storage_data(
             np.squeeze(inputs["dp2"]), istart=info["istart"], axis=info["axis"]
         )
-        inputs["tracers"] = {}
         info = storage_vars["q2tracers"]
         for i in range(int(inputs["nq"])):
-            inputs["tracers"][utils.tracer_variables[i]] = self.make_storage_data(
+            inputs["tracers"][tracer_mapping[i]] = self.make_storage_data(
                 np.squeeze(inputs["q2tracers"][:, :, i]),
                 istart=info["istart"],
                 axis=info["axis"],
@@ -52,7 +55,23 @@ class TranslateFillz(TranslateDycoreFortranData2Py):
         del inputs["q2tracers"]
 
     def compute(self, inputs):
-        self.make_storage_data_input_vars(inputs)
+        tracer_mapping = [
+            "vapor",
+            "liquid",
+            "rain",
+            "ice",
+            "snow",
+            "graupel",
+            "qo3mr",
+            "qsgs_tke",
+        ]
+        tracers = Tracers.make(
+            quantity_factory=self._quantity_factory,
+            tracer_mapping=tracer_mapping,
+        )
+        inputs["tracers"] = tracers
+
+        self.make_storage_data_input_vars(inputs, tracer_mapping=tracer_mapping)
         for name, value in tuple(inputs.items()):
             if hasattr(value, "shape") and len(value.shape) > 1 and value.shape[1] == 1:
                 inputs[name] = self.make_storage_data(
@@ -67,18 +86,17 @@ class TranslateFillz(TranslateDycoreFortranData2Py):
                         value, self.grid.njd, backend=self.stencil_factory.backend
                     )
                 )
-        run_fillz = fillz.FillNegativeTracerValues(
+        inputs.pop("nq")
+        fillz = FillNegativeTracerValues(
             self.stencil_factory,
             self.grid.quantity_factory,
-            inputs.pop("nq"),
-            inputs["tracers"],
         )
-        run_fillz(**inputs)
+        fillz(**inputs)
         ds = self.grid.default_domain_dict()
         ds.update(self.out_vars["q2tracers"])
-        tracers = np.zeros((self.grid.nic, self.grid.npz, len(inputs["tracers"])))
+        tracers = np.zeros((self.grid.nic, self.grid.npz, inputs["tracers"].count))
         for varname, data in inputs["tracers"].items():
-            index = utils.tracer_variables.index(varname)
+            index = tracer_mapping.index(varname)
             data[self.grid.slice_dict(ds)]
             safe_assign_array(
                 tracers[:, :, index], np.squeeze(data[self.grid.slice_dict(ds)])

--- a/tests/savepoint/translate/translate_remapping.py
+++ b/tests/savepoint/translate/translate_remapping.py
@@ -1,5 +1,5 @@
 import ndsl.dsl.gt4py_utils as utils
-from ndsl import Namelist, StencilFactory, QuantityFactory
+from ndsl import Namelist, QuantityFactory, StencilFactory
 from ndsl.constants import Z_DIM
 from pyFV3 import DynamicalCoreConfig
 from pyFV3.stencils import LagrangianToEulerian
@@ -109,7 +109,7 @@ class TranslateRemapping(TranslateDycoreFortranData2Py):
         )
         wsd_2d[:, :] = inputs["wsd"][:, :, 0]
         inputs["wsd"] = wsd_2d
-        tracers = Tracers.make_from_fortran(
+        tracers = Tracers.make_from_4D_array(
             quantity_factory=self._quantity_factory,
             tracer_mapping=[
                 "vapor",
@@ -136,7 +136,8 @@ class TranslateRemapping(TranslateDycoreFortranData2Py):
             area_64=self.grid.area_64,
             pfull=pfull,
             tracers=inputs["tracers"],
+            exclude_tracers=["cloud"],
         )
         l_to_e_obj(**inputs)
-        inputs["tracers"] = tracers.as_fortran_4D()
+        inputs["tracers"] = tracers.as_4D_array()
         return inputs

--- a/tests/savepoint/translate/translate_remapping.py
+++ b/tests/savepoint/translate/translate_remapping.py
@@ -1,9 +1,10 @@
 import ndsl.dsl.gt4py_utils as utils
-from ndsl import Namelist, StencilFactory
+from ndsl import Namelist, StencilFactory, QuantityFactory
 from ndsl.constants import Z_DIM
 from pyFV3 import DynamicalCoreConfig
 from pyFV3.stencils import LagrangianToEulerian
 from pyFV3.testing import TranslateDycoreFortranData2Py
+from pyFV3.tracers import Tracers
 
 
 class TranslateRemapping(TranslateDycoreFortranData2Py):
@@ -97,6 +98,10 @@ class TranslateRemapping(TranslateDycoreFortranData2Py):
         self.ignore_near_zero_errors = {"q_con": True, "tracers": True}
         self.stencil_factory = stencil_factory
         self.namelist = DynamicalCoreConfig.from_namelist(namelist)
+        self._quantity_factory = QuantityFactory.from_backend(
+            sizer=stencil_factory.grid_indexing._sizer,
+            backend=stencil_factory.backend,
+        )
 
     def compute_from_storage(self, inputs):
         wsd_2d = utils.make_storage_from_shape(
@@ -104,19 +109,34 @@ class TranslateRemapping(TranslateDycoreFortranData2Py):
         )
         wsd_2d[:, :] = inputs["wsd"][:, :, 0]
         inputs["wsd"] = wsd_2d
-        inputs["q_cld"] = inputs["tracers"]["qcld"]
+        tracers = Tracers.make_from_fortran(
+            quantity_factory=self._quantity_factory,
+            tracer_mapping=[
+                "vapor",
+                "liquid",
+                "rain",
+                "ice",
+                "snow",
+                "graupel",
+                "qo3mr",
+                "qsgs_tke",
+                "cloud",
+            ],
+            tracer_data=inputs["tracers"],
+        )
         inputs["last_step"] = bool(inputs["last_step"])
         pfull = self.grid.quantity_factory.zeros([Z_DIM], units="Pa")
         pfull.data[:] = pfull.np.asarray(inputs.pop("pfull"))
+        inputs.pop("nq")
+        inputs["tracers"] = tracers
         l_to_e_obj = LagrangianToEulerian(
             self.stencil_factory,
             quantity_factory=self.grid.quantity_factory,
             config=DynamicalCoreConfig.from_namelist(self.namelist).remapping,
             area_64=self.grid.area_64,
-            nq=inputs.pop("nq"),
             pfull=pfull,
             tracers=inputs["tracers"],
         )
         l_to_e_obj(**inputs)
-        inputs.pop("q_cld")
+        inputs["tracers"] = tracers.as_fortran_4D()
         return inputs

--- a/tests/savepoint/translate/translate_tracer2d1l.py
+++ b/tests/savepoint/translate/translate_tracer2d1l.py
@@ -1,11 +1,12 @@
 import pytest
 
 import ndsl.dsl.gt4py_utils as utils
-from ndsl import Namelist, StencilFactory
+from ndsl import Namelist, StencilFactory, QuantityFactory
 from ndsl.constants import X_DIM, Y_DIM, Z_DIM
 from ndsl.stencils.testing import ParallelTranslate
 from pyFV3.stencils import FiniteVolumeTransport, TracerAdvection
 from pyFV3.utils.functional_validation import get_subset_func
+from pyFV3.tracers import Tracers
 
 
 class TranslateTracer2D1L(ParallelTranslate):
@@ -34,6 +35,10 @@ class TranslateTracer2D1L(ParallelTranslate):
         self._base.in_vars["parameters"] = ["nq"]
         self._base.out_vars = self._base.in_vars["data_vars"]
         self.stencil_factory = stencil_factory
+        self._quantity_factory = QuantityFactory.from_backend(
+            sizer=stencil_factory.grid_indexing._sizer,
+            backend=stencil_factory.backend,
+        )
         self.namelist = namelist
         self._subset = get_subset_func(
             self.grid.grid_indexing,
@@ -46,11 +51,23 @@ class TranslateTracer2D1L(ParallelTranslate):
         return input_data
 
     def compute_parallel(self, inputs, communicator):
-        self._base.make_storage_data_input_vars(inputs)
-        all_tracers = inputs["tracers"]
-        inputs["tracers"] = self.get_advected_tracer_dict(
-            inputs["tracers"], int(inputs.pop("nq"))
+        tracers = Tracers.make_from_fortran(
+            quantity_factory=self._quantity_factory,
+            tracer_mapping=[
+                "vapor",
+                "liquid",
+                "rain",
+                "ice",
+                "snow",
+                "graupel",
+                "qo3mr",
+                "qsgs_tke",
+            ],
+            tracer_data=inputs["tracers"],
         )
+        self._base.make_storage_data_input_vars(inputs, dict_4d=False)
+        inputs.pop("nq")  # Fortran NQ is intrinsic to Tracers (e.g Tracers.count)
+        all_tracers = inputs.pop("tracers")
         transport = FiniteVolumeTransport(
             stencil_factory=self.stencil_factory,
             quantity_factory=self.grid.quantity_factory,
@@ -66,20 +83,24 @@ class TranslateTracer2D1L(ParallelTranslate):
             transport,
             self.grid.grid_data,
             communicator,
-            inputs["tracers"],
+            tracers,
         )
         inputs["x_mass_flux"] = inputs.pop("mfxd")
         inputs["y_mass_flux"] = inputs.pop("mfyd")
         inputs["x_courant"] = inputs.pop("cxd")
         inputs["y_courant"] = inputs.pop("cyd")
-        self.tracer_advection(**inputs)
+        self.tracer_advection(tracers=tracers, **inputs)
         inputs["mfxd"] = inputs.pop("x_mass_flux")
         inputs["mfyd"] = inputs.pop("y_mass_flux")
         inputs["cxd"] = inputs.pop("x_courant")
         inputs["cyd"] = inputs.pop("y_courant")
-        inputs[
-            "tracers"
-        ] = all_tracers  # some aren't advected, still need to be validated
+        # Put back un-advected tracers
+        # Tracers have -1 on all cartesian because of NDSL padding
+        # Dev note: qcld is not advected in Pace dataset for some reason
+        tracers_as_4d = tracers.as_fortran_4D()
+        for idx in range(0, tracers_as_4d.shape[3]):
+            all_tracers[:-1, :-1, :-1, idx] = tracers_as_4d[:, :, :, idx]
+        inputs["tracers"] = all_tracers
         # need to convert tracers dict to [x, y, z, n_tracer] array before subsetting
         outputs = self._base.slice_output(inputs)
         outputs["tracers"] = self.subset_output("tracers", outputs["tracers"])


### PR DESCRIPTION
As explained in https://github.com/NOAA-GFDL/pace/discussions/100, the tracer in dynamics is a fixed-length series of 9 tracers. We propose here to solve the first step of a global rework by allowing N tracers to be advected.

:warning: This PR will trigger failure in Pace and requires a sync PR in NDSL (TBPR) :warning: 

The solution merely generalize the previous tracer system into a class which carries a dictionary of `Quantities`. An `exclude_tracers` list is now present in Tracer Advection and Remapping to cover the FV3GFS dataset which (oddly) excludes `clouds` from the schemes.

**Checklist:**
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] New check tests, if applicable, are included
- [ ] Targeted model if this changed was triggered by a model need/shortcoming

## WIP

- [x] Fix orchestration
- [ ] PR in NDSL
- [ ] Fix GEOS_WRAPPER
- [ ] FIx initialize TC
- [ ] Fix initialize Baroclinic
- [ ] Connect back to Pace 


