### PR TITLE
Synchronize xppm and yppm

### DIFF
--- a/convert_xppm_yppm.sh
+++ b/convert_xppm_yppm.sh
@@ -6,52 +6,54 @@
 
 set -e -x
 
-cp pace/fv3core/stencils/xppm.py pace/fv3core/stencils/yppm.py
-cp pace/fv3core/stencils/xtp_u.py pace/fv3core/stencils/ytp_v.py
+cp pyFV3/stencils/xppm.py pyFV3/stencils/yppm.py
+cp pyFV3/stencils/xtp_u.py pyFV3/stencils/ytp_v.py
 
-for fname in pace/fv3core/stencils/yppm.py pace/fv3core/stencils/ytp_v.py
+for fname in pyFV3/stencils/yppm.py pyFV3/stencils/ytp_v.py
 do
-    gsed -i 's/ub/vb/g' $fname
-    gsed -i 's/dx/dy/g' $fname
-    gsed -i 's/xt/yt/g' $fname
-    gsed -i 's/eyternals/externals/g' $fname
-    gsed -i 's/xflux/yflux/g' $fname
-    gsed -i 's/_x/_y/g' $fname
-    gsed -i 's/_u/_v/g' $fname
-    gsed -i 's/u_/v_/g' $fname
-    gsed -i 's/u,/v,/g' $fname
-    gsed -i 's/u:/v:/g' $fname
-    gsed -i 's/u\[/v\[/g' $fname
-    gsed -i 's/u)/v)/g' $fname
-    gsed -i 's/iord/jord/g' $fname
-    gsed -i 's/\[-1, 0/\[0, -1/g' $fname
-    gsed -i 's/\[-2, 0/\[0, -2/g' $fname
-    gsed -i 's/\[1, 0/\[0, 1/g' $fname
-    gsed -i 's/\[2, 0/\[0, 2/g' $fname
-    gsed -i 's/ u / v /g' $fname
-    gsed -i 's/x-/y-/g' $fname
-    gsed -i 's/i_start/j_start/g' $fname
-    gsed -i 's/i_end/j_end/g' $fname
-    gsed -i 's/\[j_start - 1, :/\[:, j_start - 1/g' $fname
-    gsed -i 's/\[j_start, :/\[:, j_start/g' $fname
-    gsed -i 's/\[j_start + 1, :/\[:, j_start + 1/g' $fname
-    gsed -i 's/\[j_end - 2, :/\[:, j_end - 2/g' $fname
-    gsed -i 's/\[j_end - 1, :/\[:, j_end - 1/g' $fname
-    gsed -i 's/\[j_end, :/\[:, j_end/g' $fname
-    gsed -i 's/\[j_end + 1, :/\[:, j_end + 1/g' $fname
-    gsed -i 's/\[j_end + 2, :/\[:, j_end + 2/g' $fname
+    sed -i 's/ub/vb/g' $fname
+    sed -i 's/dx/dy/g' $fname
+    sed -i 's/xt/yt/g' $fname
+    sed -i 's/eyternals/externals/g' $fname
+    sed -i 's/xflux/yflux/g' $fname
+    sed -i 's/_x/_y/g' $fname
+    sed -i 's/_u/_v/g' $fname
+    sed -i 's/u_/v_/g' $fname
+    sed -i 's/u,/v,/g' $fname
+    sed -i 's/u:/v:/g' $fname
+    sed -i 's/u\[/v\[/g' $fname
+    sed -i 's/u)/v)/g' $fname
+    sed -i 's/iord/jord/g' $fname
+    sed -i 's/\[-1, 0/\[0, -1/g' $fname
+    sed -i 's/\[-2, 0/\[0, -2/g' $fname
+    sed -i 's/\[1, 0/\[0, 1/g' $fname
+    sed -i 's/\[2, 0/\[0, 2/g' $fname
+    sed -i 's/ u / v /g' $fname
+    sed -i 's/x-/y-/g' $fname
+    sed -i 's/i_start/j_start/g' $fname
+    sed -i 's/i_end/j_end/g' $fname
+    sed -i 's/\[j_start - 1, :/\[:, j_start - 1/g' $fname
+    sed -i 's/\[j_start, :/\[:, j_start/g' $fname
+    sed -i 's/\[j_start + 1, :/\[:, j_start + 1/g' $fname
+    sed -i 's/\[j_end - 2, :/\[:, j_end - 2/g' $fname
+    sed -i 's/\[j_end - 1, :/\[:, j_end - 1/g' $fname
+    sed -i 's/\[j_end, :/\[:, j_end/g' $fname
+    sed -i 's/\[j_end + 1, :/\[:, j_end + 1/g' $fname
+    sed -i 's/\[j_end + 2, :/\[:, j_end + 2/g' $fname
 done
 
-gsed -i 's/i_start/j_start/g' pace/fv3core/stencils/yppm.py
-gsed -i 's/i_end/j_end/g' pace/fv3core/stencils/yppm.py
-gsed -i 's/XPiecewise/YPiecewise/g' pace/fv3core/stencils/yppm.py
-gsed -i 's/u\*/v\*/g' pace/fv3core/stencils/yppm.py
+sed -i 's/i_start/j_start/g' pyFV3/stencils/yppm.py
+sed -i 's/i_end/j_end/g' pyFV3/stencils/yppm.py
+sed -i 's/XPiecewise/YPiecewise/g' pyFV3/stencils/yppm.py
+sed -i 's/X Piecewise/Y Piecewise/g' pyFV3/stencils/yppm.py
+sed -i 's/xppm/yppm/g' pyFV3/stencils/yppm.py
+sed -i 's/u\*/v\*/g' pyFV3/stencils/yppm.py
 
-gsed -i 's/j_start - 1 : j_start + 1, j_start/i_start, j_start - 1 : j_start + 1/g' pace/fv3core/stencils/ytp_v.py
-gsed -i 's/j_start - 1 : j_start + 1, j_end + 1/i_end + 1, j_start - 1 : j_start + 1/g' pace/fv3core/stencils/ytp_v.py
-gsed -i 's/j_end : j_end + 2, j_start/i_start, j_end : j_end + 2/g' pace/fv3core/stencils/ytp_v.py
-gsed -i 's/j_end : j_end + 2, j_end + 1/i_end + 1, j_end : j_end + 2/g' pace/fv3core/stencils/ytp_v.py
-gsed -i 's/j_end, j_start, jord, j_end, j_start/j_end, j_start, jord, i_end, i_start/g' pace/fv3core/stencils/ytp_v.py
-gsed -i 's/xppm/yppm/g' pace/fv3core/stencils/ytp_v.py
+sed -i 's/j_start - 1 : j_start + 1, j_start/i_start, j_start - 1 : j_start + 1/g' pyFV3/stencils/ytp_v.py
+sed -i 's/j_start - 1 : j_start + 1, j_end + 1/i_end + 1, j_start - 1 : j_start + 1/g' pyFV3/stencils/ytp_v.py
+sed -i 's/j_end : j_end + 2, j_start/i_start, j_end : j_end + 2/g' pyFV3/stencils/ytp_v.py
+sed -i 's/j_end : j_end + 2, j_end + 1/i_end + 1, j_end : j_end + 2/g' pyFV3/stencils/ytp_v.py
+sed -i 's/j_end, j_start, jord, j_end, j_start/i_end, i_start, j_end, j_start, jord/g' pyFV3/stencils/ytp_v.py
+sed -i 's/xppm/yppm/g' pyFV3/stencils/ytp_v.py
 
-gsed -i 's/region\[j_start - 1 : j_start + 2, :\], region\[j_end - 1 : j_end + 2, :\]/region\[:, j_start - 1 : j_start + 2\], region\[:, j_end - 1 : j_end + 2\]/g' pace/fv3core/stencils/yppm.py
+sed -i 's/region\[j_start - 1 : j_start + 2, :\], region\[j_end - 1 : j_end + 2, :\]/region\[:, j_start - 1 : j_start + 2\], region\[:, j_end - 1 : j_end + 2\]/g' pyFV3/stencils/yppm.py

--- a/pyFV3/stencils/xppm.py
+++ b/pyFV3/stencils/xppm.py
@@ -9,7 +9,7 @@ from gt4py.cartesian.gtscript import (
     region,
 )
 
-from ndsl import StencilFactory
+from ndsl import StencilFactory, orchestrate
 from ndsl.dsl.typing import FloatField, FloatFieldIJ, Index3D
 from ndsl.stencils.basic_operations import sign
 from pyFV3.stencils import ppm
@@ -307,6 +307,7 @@ class XPiecewiseParabolic:
         origin: Index3D,
         domain: Index3D,
     ):
+        orchestrate(obj=self, config=stencil_factory.config.dace_config)
         # Arguments come from:
         # namelist.grid_type
         # grid.dxa

--- a/pyFV3/stencils/yppm.py
+++ b/pyFV3/stencils/yppm.py
@@ -313,7 +313,7 @@ class YPiecewiseParabolic:
         # grid.dya
         if grid_type == 3 or grid_type > 4:
             raise NotImplementedError(
-                "Y Piecewise Parabolic (xppm): "
+                "Y Piecewise Parabolic (yppm): "
                 f" grid type {grid_type} not implemented. <3 or 4 available."
             )
 

--- a/pyFV3/stencils/yppm.py
+++ b/pyFV3/stencils/yppm.py
@@ -351,7 +351,7 @@ class YPiecewiseParabolic:
         q_mean_advected_through_y_interface: FloatField,
     ):
         """
-        Determine the mean value of q_in to be advected along y-interfaces.
+        Determine the mean value per area of q_in to be advected along y-interfaces.
 
         This is done by integrating a piecewise-parabolic svbgrid reconstruction
         of q_in along the y-direction over the segment of gridcell which

--- a/pyFV3/stencils/ytp_v.py
+++ b/pyFV3/stencils/ytp_v.py
@@ -32,6 +32,7 @@ def get_bl_br(v, dy, dya):
         compile_assert(jord == 8)
 
         bl, br = yppm.blbr_jord8(v, v_on_cell_corners, dm)
+
         if __INLINED(grid_type < 3):
             bl, br = yppm.bl_br_edges(bl, br, v, dya, v_on_cell_corners, dm)
 


### PR DESCRIPTION
**Description**

Synchronize `xppm.py` and `yppm.py`. In particular, propagate an orchestration call from `yppm.py` to `xppm.py`.

There is script to generate `yppm` from `xppm`. That script was having outdated paths. Fixed that and and added other fixes such that it generates the expected output again. Also changed `gsed` to `sed` assuming people (or CI who I guess is eventually supposed to run the script) are running on non-BSD  linux versions, which comes by default with the gnu flavor of `sed`.

**How Has This Been Tested?**

- Ran xppm and yppm tests locally
- Ran `covert_xppm_yppm.sh` locally which generated no changes to `yppm.py`.

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas: N/A
- [ ] I have made corresponding changes to the documentation: N/A
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules: N/A
- [ ] New check tests, if applicable, are included: N/A
- [ ] Targeted model if this changed was triggered by a model need/shortcoming: N/A
