### PR TITLE
[QOL] Streamline linting workflow

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -6,21 +6,18 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-        - name: Checkout Pace repository
-          uses: actions/checkout@v3.5.2
+        - name: Checkout repository
+          uses: actions/checkout@v4
+
+        - name: Setup Python 3.11
+          uses: actions/setup-python@v5
           with:
-            submodules: 'recursive'
-        - name: Step Python 3.11.7
-          uses: actions/setup-python@v4.6.0
-          with:
-            python-version: '3.11.7'
-        - name: Install OpenMPI for gt4py
+            python-version: '3.11'
+
+        - name: Install pre-commit
           run: |
-            sudo apt-get install libopenmpi-dev
-        - name: Install Python packages
-          run: |
-            python -m pip install --upgrade pip setuptools wheel
-            pip install .[develop]
+            pip install pre-commit
+
         - name: Run lint via pre-commit
           run: |
             pre-commit run --all-files


### PR DESCRIPTION
**Description**

Linting should give fast feedback. The current workflow took almost 3 minutes where most time is spent installing (unnecessary) python packages. To run `pre-commit` we only need the source files and `pre-commit`, which can be installed standalone. This brings the total runtime of this action down to ~30 seconds.

Other changes:
 - update checkout action to v4
 - as far as I can see, there are no submodules in this repo. Dropped that configuration
 - update python setup action to v5
 - change python version from 3.11.7 to 3.11 (any patch number will do)

**How Has This Been Tested?**

Tested new action in a PR inside my fork.

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas: N/A
- [ ] I have made corresponding changes to the documentation: N/A
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules: N/A
- [ ] New check tests, if applicable, are included: N/A
- [ ] Targeted model if this changed was triggered by a model need/shortcoming: N/A
