### PR TITLE
[CI] Cache test_data for translate tests

### DIFF
--- a/.github/workflows/translate.yaml
+++ b/.github/workflows/translate.yaml
@@ -22,8 +22,11 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/noaa-gfdl/miniforge:mpich
-    steps:
+    env:
+      DATA_PATH: ./test_data/8.1.3/c12_6ranks_standard/dycore
+      DATA_URL: "https://portal.nccs.nasa.gov/datashare/astg/smt/pace-regression-data/8.1.3_c12_6ranks_standard.tar.gz"
 
+    steps:
       - name: External trigger Checkout pyFV3
         if: ${{inputs.component_trigger}}
         uses: actions/checkout@v4
@@ -51,19 +54,27 @@ jobs:
           cd ${GITHUB_WORKSPACE}/pyFV3
           pip install .[ndsl,test]
 
-      - name: Prepare test_data
+      - name: Restore test_data (if cached)
+        id: cache-restore
+        uses: actions/cache/restore@v4
+        with:
+          key: ${{ env.DATA_PATH }}
+          path: pyFV3/test_data
+
+      - name: Download test_data (if not cached)
+        if: steps.cache-restore.outputs.cache-hit != 'true'
         run: |
           cd ${GITHUB_WORKSPACE}/pyFV3
           mkdir -p test_data  && cd test_data
-          wget https://portal.nccs.nasa.gov/datashare/astg/smt/pace-regression-data/8.1.3_c12_6ranks_standard.tar.gz
-          tar -xzvf  8.1.3_c12_6ranks_standard.tar.gz --no-same-owner
+          wget ${{ env.DATA_URL }}
+          tar -xzvf 8.1.3_c12_6ranks_standard.tar.gz --no-same-owner
           cd ..
 
       - name: NumPy FvTp2d
         run: |
           cd ${GITHUB_WORKSPACE}/pyFV3
           coverage run --rcfile=setup.cfg -m pytest \
-              -v -s --data_path=./test_data/8.1.3/c12_6ranks_standard/dycore \
+              -v -s --data_path=${{ env.DATA_PATH }} \
               --backend=numpy \
               --which_modules=FvTp2d \
               --threshold_overrides_file=./tests/savepoint/translate/overrides/standard.yaml \
@@ -73,7 +84,7 @@ jobs:
         run: |
          cd ${GITHUB_WORKSPACE}/pyFV3
          coverage run --rcfile=setup.cfg -m pytest \
-              -v -s --data_path=./test_data/8.1.3/c12_6ranks_standard/dycore \
+              -v -s --data_path=${{ env.DATA_PATH }} \
               --backend=numpy \
               --which_modules=D_SW \
               --threshold_overrides_file=./tests/savepoint/translate/overrides/standard.yaml \
@@ -83,7 +94,7 @@ jobs:
         run: |
           cd ${GITHUB_WORKSPACE}/pyFV3
           coverage run --rcfile=setup.cfg -m pytest \
-              -v -s --data_path=./test_data/8.1.3/c12_6ranks_standard/dycore \
+              -v -s --data_path=${{ env.DATA_PATH }} \
               --backend=numpy \
               --which_modules=Remapping \
               --threshold_overrides_file=./tests/savepoint/translate/overrides/standard.yaml \
@@ -98,10 +109,17 @@ jobs:
           export OMP_NUM_THREADS=1
           export PACE_LOGLEVEL=Debug
           mpiexec -mca orte_abort_on_non_zero_status 1 -np 6 --oversubscribe coverage run --rcfile=setup.cfg -m mpi4py -m pytest \
-            -v -s --data_path=./test_data/8.1.3/c12_6ranks_standard/dycore \
+            -v -s --data_path=${{ env.DATA_PATH }} \
             --backend=dace:cpu \
             -m parallel \
             --which_rank=0 \
             --which_modules=DynCore \
             --threshold_overrides_file=./tests/savepoint/translate/overrides/standard.yaml \
             ./tests/savepoint
+
+      - name: Cache test_data
+        if: steps.cache-restore.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: pyFV3/test_data
+          key: ${{ steps.cache-restore.outputs.cache-primary-key }}


### PR DESCRIPTION
**Description**

Currently, translate tests go and fetch test_data/ from scratch every run. We had issues with data fetching in the past so I put in a cache under the assumption that GH cache servers are very reliable. They are also closer (in a network sense) to the executing machines, leading to slightly faster transfer times (not that this would matter in the 30min runtime that we are looking at).

**How Has This Been Tested?**

- Changed CI workflow is still passing.

**Checklist:**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation: N/A
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules: N/A
- [x] New check tests, if applicable, are included
- [ ] Targeted model if this changed was triggered by a model need/shortcoming: N/A
