### PR TITLE
Cleanup: remove stale version variable and fix typos in comments

### DIFF
--- a/pyFV3/__init__.py
+++ b/pyFV3/__init__.py
@@ -9,5 +9,3 @@ DycoreState: Dataclass containing state of the dynamical core
 DryConvectiveAdjustment: Sub-grid dry convective adjustment
 DynamicalCore: The FV3 dynamical core
 """
-
-__version__ = "0.2.0"

--- a/pyFV3/initialization/analytic_init.py
+++ b/pyFV3/initialization/analytic_init.py
@@ -21,7 +21,7 @@ def init_analytic_state(
     comm: Communicator,
 ) -> DycoreState:
     """
-    This method initializes the choosen analytic test case type
+    This method initializes the chosen analytic test case type
     Args:
         analytic_init_str:      test case specifier
         grid_data:              current selected grid data values

--- a/pyFV3/initialization/init_utils.py
+++ b/pyFV3/initialization/init_utils.py
@@ -30,7 +30,7 @@ T_0 = 288.0
 DELTA_T = 480000.0
 LAPSE_RATE = 0.005  # From Table VI of DCMIP2016
 # NOTE RADIUS = 6.3712e6 in FV3 vs Jabowski paper 6.371229e6
-R = constants.RADIUS / 10.0  # Perturbation radiusfor test case 13
+R = constants.RADIUS / 10.0  # Perturbation radius for test case 13
 NHALO = constants.N_HALO_DEFAULT
 
 

--- a/pyFV3/stencils/__init__.py
+++ b/pyFV3/stencils/__init__.py
@@ -56,7 +56,7 @@ NonhydrostaticVerticalSolver: Calculates nonhydrostatic w and p after advection
 NonhydrostaticVerticalSolverCGrid: Calculates nonhydrostatic w and p after
                                    C-grid advection
 SatAdjust3d: Fast microphysical phase changes
-Sim1Solver: Semi-implict method solver
+Sim1Solver: Semi-implicit method solver
 TracerAdvection: Advects tracers
 UpdateGeopotentialHeightOnCGrid: Updates cell heights on C-grid
 UpdateHeightOnDGrid: Updates cell heights on D-grid

--- a/pyFV3/stencils/a2b_ord4.py
+++ b/pyFV3/stencils/a2b_ord4.py
@@ -18,7 +18,7 @@ from ndsl.grid import GridData
 from ndsl.stencils.basic_operations import copy_defn
 
 
-# comact 4-pt cubic interpolation
+# compact 4-pt cubic interpolation
 c1 = 2.0 / 3.0
 c2 = -1.0 / 6.0
 d1 = 0.375

--- a/pyFV3/stencils/c_sw.py
+++ b/pyFV3/stencils/c_sw.py
@@ -265,7 +265,7 @@ def compute_nonhydrostatic_fluxes_x(
         fx (out): heat (entropy) flux, first-order upwind flux of delp
             in units per second
         fx1 (out): first-order upwind flux of delp in units per second
-        fx2 (out): flux of veritcal momentum, first-order upwind flux of w
+        fx2 (out): flux of vertical momentum, first-order upwind flux of w
             in units per second
     """
     with computation(PARALLEL), interval(...):

--- a/pyFV3/stencils/d_sw.py
+++ b/pyFV3/stencils/d_sw.py
@@ -45,9 +45,9 @@ def flux_capacitor(
     Args:
         cx (inout): accumulated courant number in the x direction
         cy (inout): accumulated courant number in the y direction
-        xflux (inout): flux capacitor in the x direction, accumlated mass flux
-        yflux (inout): flux capacitor in the y direction, accumlated mass flux
-        crx_adv (in): local courant numver, dt*ut/dx
+        xflux (inout): flux capacitor in the x direction, accumulated mass flux
+        yflux (inout): flux capacitor in the y direction, accumulated mass flux
+        crx_adv (in): local courant number, dt*ut/dx
         cry_adv (in): local courant number dt*vt/dy
         fx (in): 1-D x-direction flux
         fy (in): 1-D y-direction flux

--- a/pyFV3/stencils/del2cubed.py
+++ b/pyFV3/stencils/del2cubed.py
@@ -176,7 +176,7 @@ class HyperdiffusionDamping:
         Args:
             qdel (inout): Variable to be filtered
             nmax: Number of times to apply filtering
-            cd: Damping coeffcient
+            cd: Damping coefficient
         """
 
         for n in range(self._ntimes):

--- a/pyFV3/stencils/dyn_core.py
+++ b/pyFV3/stencils/dyn_core.py
@@ -245,7 +245,7 @@ def dyncore_temporaries(
 class AcousticDynamics:
     """
     Fortran name is dyn_core
-    Peforms the Lagrangian acoustic dynamics described by Lin 2004
+    Performs the Lagrangian acoustic dynamics described by Lin 2004
     """
 
     class _HaloUpdaters(object):
@@ -294,7 +294,7 @@ class AcousticDynamics:
 
             # Build the HaloUpdater. We could build one updater per specification group
             # but because of call overlap between different variable, we kept the
-            # straighforward solution of one HaloUpdater per group of updated variable.
+            # straightforward solution of one HaloUpdater per group of updated variable.
             # It also makes the code in call() more readable
             # [DaCe] Wrapping call to a DaCe readable halo updater
             #        Biggest parsing issue is that DaCe cannot do

--- a/pyFV3/stencils/fv_dynamics.py
+++ b/pyFV3/stencils/fv_dynamics.py
@@ -49,7 +49,7 @@ def omega_from_w(delp: FloatField, delz: FloatField, w: FloatField, omega: Float
         delp (in): vertical layer thickness in Pa
         delz (in): vertical layer thickness in m
         w (in): vertical wind in m/s
-        omga (out): vertical wind in Pa/s
+        omega (out): vertical wind in Pa/s
     """
     with computation(PARALLEL), interval(...):
         omega = delp / delz * w

--- a/pyFV3/stencils/fvtp2d.py
+++ b/pyFV3/stencils/fvtp2d.py
@@ -349,7 +349,7 @@ class FiniteVolumeTransport:
             self._q_advected_x, cry, self._q_advected_x_y_advected_mean
         )
 
-        # TODO [DACE]: due to an aliiasing issue (see above for original code)
+        # TODO [DACE]: due to an aliasing issue (see above for original code)
         # we duplicate the code here
         if x_mass_flux is None:
             if y_mass_flux is None:

--- a/pyFV3/stencils/fxadv.py
+++ b/pyFV3/stencils/fxadv.py
@@ -506,7 +506,7 @@ def fxadv_fluxes_stencil(
 
 class FiniteVolumeFluxPrep:
     """
-    A large section of code near the beginning of Fortran's d_sw subroutinw
+    A large section of code near the beginning of Fortran's d_sw subroutine
     Known in this repo as FxAdv,
     """
 

--- a/pyFV3/stencils/pe_halo.py
+++ b/pyFV3/stencils/pe_halo.py
@@ -6,7 +6,7 @@ from ndsl.dsl.typing import Float, FloatField
 def edge_pe(pe: FloatField, delp: FloatField, ptop: Float):
     """
     This corresponds to the pe_halo routine in FV3core
-    Updading the interface pressure from the pressure differences
+    Updating the interface pressure from the pressure differences
 
     Args:
         pe (out): The pressure on the interfaces of the cell

--- a/pyFV3/stencils/riem_solver3.py
+++ b/pyFV3/stencils/riem_solver3.py
@@ -103,7 +103,7 @@ def finalize(
     last_call: bool,
 ):
     """
-    Updates auxilary pressure values
+    Updates auxiliary pressure values
 
     Args:
         zs (in):

--- a/pyFV3/stencils/sim1_solver.py
+++ b/pyFV3/stencils/sim1_solver.py
@@ -184,7 +184,7 @@ class Sim1Solver:
         Chapter 7 of the FV3 documentation
 
         Args:
-          dt (in): timstep in seconds of solver
+          dt (in): timestep in seconds of solver
           gm (in): ?? 1 / (1 - cappa)
           cp3 (in): cappa
           pe (out): full hydrostatic pressure

--- a/pyFV3/stencils/updatedzc.py
+++ b/pyFV3/stencils/updatedzc.py
@@ -72,7 +72,7 @@ def update_dz_c(
 ):
     """
     Step dz forward on c-grid
-    Eusures gz is monotonically increasing in z at the end
+    Ensures gz is monotonically increasing in z at the end
     Args:
         dp_ref:
         zs:

--- a/pyFV3/testing/translate_fvdynamics.py
+++ b/pyFV3/testing/translate_fvdynamics.py
@@ -301,11 +301,11 @@ class TranslateFVDynamics(ParallelTranslateBaseSlicing):
         input_storages = super().state_from_inputs(inputs)
         # making sure we init DycoreState with the exact set of variables
         accepted_keys = [_field.name for _field in fields(DycoreState)]
-        todelete = []
+        to_delete = []
         for name in input_storages.keys():
             if name not in accepted_keys:
-                todelete.append(name)
-        for name in todelete:
+                to_delete.append(name)
+        for name in to_delete:
             del input_storages[name]
 
         state = DycoreState.init_from_storages(input_storages, sizer=self.grid.sizer)


### PR DESCRIPTION
**Description**

This PR removes an old/stale hard-coded version number from `pyFV3/__init__.py` and fixes a bunch of typos in comments.

**How Has This Been Tested?**

Ran `pre-commit` locally :wink: 

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas: N/A
- [ ] I have made corresponding changes to the documentation: N/A
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules: N/A
- [ ] New check tests, if applicable, are included: N/A
- [ ] Targeted model if this changed was triggered by a model need/shortcoming: N/A
