### PR TITLE
Fix that enables proper reading of RF_fast in hybrid GEOS+PyFV3 execution 

### DIFF
--- a/pyFV3/_config.py
+++ b/pyFV3/_config.py
@@ -269,7 +269,7 @@ class DynamicalCoreConfig:
     convert_ke: bool = NamelistDefaults.convert_ke
     breed_vortex_inline: bool = NamelistDefaults.breed_vortex_inline
     use_old_omega: bool = NamelistDefaults.use_old_omega
-    rf_fast: bool = NamelistDefaults.rf_fast
+    RF_fast: bool = NamelistDefaults.rf_fast
     adiabatic: bool = NamelistDefaults.adiabatic
     nf_omega: int = NamelistDefaults.nf_omega
     fv_sg_adj: int = NamelistDefaults.fv_sg_adj
@@ -378,7 +378,7 @@ class DynamicalCoreConfig:
             convert_ke=namelist.convert_ke,
             breed_vortex_inline=namelist.breed_vortex_inline,
             use_old_omega=namelist.use_old_omega,
-            rf_fast=namelist.rf_fast,
+            RF_fast=namelist.rf_fast,
             adiabatic=namelist.adiabatic,
             nf_omega=namelist.nf_omega,
             fv_sg_adj=namelist.fv_sg_adj,
@@ -482,7 +482,7 @@ class DynamicalCoreConfig:
             n_split=self.n_split,
             m_split=self.m_split,
             delt_max=self.delt_max,
-            rf_fast=self.rf_fast,
+            rf_fast=self.RF_fast,
             rf_cutoff=self.rf_cutoff,
             breed_vortex_inline=self.breed_vortex_inline,
             use_old_omega=self.use_old_omega,

--- a/pyFV3/stencils/fv_dynamics.py
+++ b/pyFV3/stencils/fv_dynamics.py
@@ -483,10 +483,10 @@ class DynamicalCore:
                 "Dynamical Core (fv_dynamics): compute total energy is not implemented"
             )
 
-        if (not self.config.rf_fast) and self.config.tau != 0:
+        if (not self.config.RF_fast) and self.config.tau != 0:
             raise NotImplementedError(
                 "Dynamical Core (fv_dynamics): Rayleigh_Super,"
-                " called when rf_fast=False and tau !=0, is not implemented"
+                " called when RF_fast=False and tau !=0, is not implemented"
             )
 
         if self.config.adiabatic and self.config.kord_tm > 0:


### PR DESCRIPTION
**Description**
Change capitalization of `RF_fast` namelist variable

Fixes # (issue)
In a hybrid GEOS + PyFV3 run, GEOS' Fortran/Python interface was unable to properly pass the namelist flag `RF_fast` from Fortran into Python.  It turns out that the capitalization of `RF_fast` prevented the `hasattr` function in [`_generic_config_bridge`](https://github.com/GEOS-ESM/FVdycoreCubed_GridComp/blob/09582d1fea60df00546a433eec8943f69ed20d7d/python/interface/fv_flags.py#L178) from returning `True`. When `hasattr` searches for `RF_fast`, there's not a matching flag in `py_config` since `py_config` has the flag as `rf_fast`.  The simple fix is to rename `rf_fast` to `RF_fast` in [`class DynamicalCoreConfig`](https://github.com/NOAA-GFDL/PyFV3/blob/3466d21850945071ee1fce7e7bf3f9960015ddb8/pyFV3/_config.py#L156) and propagate appropriate changes in PyFV3 of `rf_fast` to `RF_fast`.

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] New check tests, if applicable, are included
- [ ] Targeted model if this changed was triggered by a model need/shortcoming