### PR TITLE
Bump NDSL from 2024.09.00 to 2025.03.00

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ test_requirements = [
     "serialbox",
 ]
 
-ndsl_requirements = ["ndsl @ git+https://github.com/NOAA-GFDL/NDSL.git@2024.09.00"]
+ndsl_requirements = ["ndsl @ git+https://github.com/NOAA-GFDL/NDSL.git@2025.03.00"]
 
 develop_requirements = [
     *ndsl_requirements,


### PR DESCRIPTION
**Description**

This PR updates NDSL from `2024.09.00` to `2025.03.00`. This includes two releases (`2025.01` and `2025.03`) of NDSL. Check the following links for NDSL release notes

- [NDSL 2025.01](https://github.com/NOAA-GFDL/NDSL/releases/tag/2025.01.00)
- [NDSL 2025.03](https://github.com/NOAA-GFDL/NDSL/releases/tag/2025.03.00)

**How Has This Been Tested?**

All good as long as CI is happy. Parts of this release (e.g. the refactored GT4Py-DaCe bridge) have been tested locally running more translate tests with dace:cpu than what CI does.

**Checklist:**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas: N/A
- [ ] I have made corresponding changes to the documentation: N/A
- [ ] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [ ] New check tests, if applicable, are included: N/A
- [ ] Targeted model if this changed was triggered by a model need/shortcoming: N/A
