### PR TITLE
Rossby Test Case Initialization

### DIFF
--- a/pyFV3/_config.py
+++ b/pyFV3/_config.py
@@ -274,7 +274,7 @@ class DynamicalCoreConfig:
     nf_omega: int = NamelistDefaults.nf_omega
     fv_sg_adj: int = NamelistDefaults.fv_sg_adj
     n_sponge: int = NamelistDefaults.n_sponge
-    sw_dynamics: bool = DEFAULT_BOOL
+    sw_dynamics: bool = NamelistDefaults.sw_dynamics
     namelist_override: Optional[str] = None
 
     def __post_init__(self):

--- a/pyFV3/_config.py
+++ b/pyFV3/_config.py
@@ -274,6 +274,7 @@ class DynamicalCoreConfig:
     nf_omega: int = NamelistDefaults.nf_omega
     fv_sg_adj: int = NamelistDefaults.fv_sg_adj
     n_sponge: int = NamelistDefaults.n_sponge
+    sw_dynamics: bool = DEFAULT_BOOL
     namelist_override: Optional[str] = None
 
     def __post_init__(self):

--- a/pyFV3/_config.py
+++ b/pyFV3/_config.py
@@ -274,7 +274,7 @@ class DynamicalCoreConfig:
     nf_omega: int = NamelistDefaults.nf_omega
     fv_sg_adj: int = NamelistDefaults.fv_sg_adj
     n_sponge: int = NamelistDefaults.n_sponge
-    sw_dynamics: bool = NamelistDefaults.sw_dynamics
+    sw_dynamics: bool = False  # TODO: Change to NamelistDefaults.sw_dynamics
     namelist_override: Optional[str] = None
 
     def __post_init__(self):

--- a/pyFV3/initialization/analytic_init.py
+++ b/pyFV3/initialization/analytic_init.py
@@ -8,6 +8,7 @@ from pyFV3.dycore_state import DycoreState
 
 class Cases(Enum, metaclass=MetaEnumStr):
     baroclinic = "baroclinic"
+    rossby = "rossby"
     tropicalcyclone = "tropicalcyclone"
 
 
@@ -58,6 +59,16 @@ def init_analytic_state(
                 grid_data=grid_data,
                 quantity_factory=quantity_factory,
                 hydrostatic=hydrostatic,
+                comm=comm,
+            )
+        elif analytic_init_case == Cases.rossby.value:  # type: ignore
+            import pyFV3.initialization.test_cases.initialize_rossby as rossby
+
+            assert isinstance(comm, CubedSphereCommunicator)
+
+            return rossby.init_rossby_state(
+                grid_data=grid_data,
+                quantity_factory=quantity_factory,
                 comm=comm,
             )
         else:

--- a/pyFV3/initialization/analytic_init.py
+++ b/pyFV3/initialization/analytic_init.py
@@ -4,6 +4,9 @@ from ndsl import CubedSphereCommunicator, MetaEnumStr, QuantityFactory
 from ndsl.grid import GridData
 from ndsl.typing import Communicator
 from pyFV3.dycore_state import DycoreState
+import pyFV3.initialization.test_cases.initialize_baroclinic as bc
+import pyFV3.initialization.test_cases.initialize_tc as tc
+import pyFV3.initialization.test_cases.initialize_rossby as rossby
 
 
 class Cases(Enum, metaclass=MetaEnumStr):
@@ -36,11 +39,13 @@ def init_analytic_state(
         an instance of DycoreState class
     """
     if analytic_init_case in Cases:  # type: ignore
+        if not isinstance(comm, CubedSphereCommunicator):
+            raise TypeError(
+                f"Expected CubedSphereCommunicator instance for 'comm', "
+                f"got {type(comm).__name__} instead."
+            )
+
         if analytic_init_case == Cases.baroclinic.value:  # type: ignore
-            import pyFV3.initialization.test_cases.initialize_baroclinic as bc
-
-            assert isinstance(comm, CubedSphereCommunicator)
-
             return bc.init_baroclinic_state(
                 grid_data=grid_data,
                 quantity_factory=quantity_factory,
@@ -49,12 +54,7 @@ def init_analytic_state(
                 moist_phys=moist_phys,
                 comm=comm,
             )
-
         elif analytic_init_case == Cases.tropicalcyclone.value:  # type: ignore
-            import pyFV3.initialization.test_cases.initialize_tc as tc
-
-            assert isinstance(comm, CubedSphereCommunicator)
-
             return tc.init_tc_state(
                 grid_data=grid_data,
                 quantity_factory=quantity_factory,
@@ -62,10 +62,6 @@ def init_analytic_state(
                 comm=comm,
             )
         elif analytic_init_case == Cases.rossby.value:  # type: ignore
-            import pyFV3.initialization.test_cases.initialize_rossby as rossby
-
-            assert isinstance(comm, CubedSphereCommunicator)
-
             return rossby.init_rossby_state(
                 grid_data=grid_data,
                 quantity_factory=quantity_factory,

--- a/pyFV3/initialization/analytic_init.py
+++ b/pyFV3/initialization/analytic_init.py
@@ -1,12 +1,12 @@
 from enum import Enum
 
+import pyFV3.initialization.test_cases.initialize_baroclinic as bc
+import pyFV3.initialization.test_cases.initialize_rossby as rossby
+import pyFV3.initialization.test_cases.initialize_tc as tc
 from ndsl import CubedSphereCommunicator, MetaEnumStr, QuantityFactory
 from ndsl.grid import GridData
 from ndsl.typing import Communicator
 from pyFV3.dycore_state import DycoreState
-import pyFV3.initialization.test_cases.initialize_baroclinic as bc
-import pyFV3.initialization.test_cases.initialize_tc as tc
-import pyFV3.initialization.test_cases.initialize_rossby as rossby
 
 
 class Cases(Enum, metaclass=MetaEnumStr):
@@ -38,7 +38,15 @@ def init_analytic_state(
     Returns:
         an instance of DycoreState class
     """
-    if analytic_init_case in Cases:  # type: ignore
+    # Cases that expect Cubed Sphere Communicator
+    spherical_cases = [
+        Cases.baroclinic.value,
+        Cases.tropicalcyclone.value,
+        Cases.rossby.value,
+    ]
+
+    if analytic_init_case in spherical_cases:  # type: ignore
+        # TODO: Consider CubedSphereCommunicator check within individual init_*() calls
         if not isinstance(comm, CubedSphereCommunicator):
             raise TypeError(
                 f"Expected CubedSphereCommunicator instance for 'comm', "

--- a/pyFV3/initialization/test_cases/initialize_rossby.py
+++ b/pyFV3/initialization/test_cases/initialize_rossby.py
@@ -115,15 +115,20 @@ def _init_for_rossby(numpy_state: DycoreState, grid_data: GridData, shape):
         numpy_state: DycoreState, modified to update the phis, delp, u, v
         grid_Data: GridData
     """
-    nx, ny, _ = init_utils.local_compute_size(shape)
-    _, _, slice_3d_buffer, slice_2d_buffer = init_utils.compute_slices(nx + 1, ny + 1)
-    slice_3d_buffer_orig = slice_3d_buffer
-    slice_3d_buffer = (slice_3d_buffer[0], slice_3d_buffer[1], 0)
     numpy_state.phis[:] = 0.0
 
+    # Calculate helper slices for delp, u+v winds
+    # similar to init_utils.compute_slices(nx, ny)
+    nx, ny, _ = init_utils.local_compute_size(shape)
+    islice = slice(NHALO, NHALO + nx)
+    islice_xtra = slice(NHALO, NHALO + nx + 1)
+    jslice = slice(NHALO, NHALO + ny)
+    jslice_xtra = slice(NHALO, NHALO + ny + 1)
+
     # Initialize delp
-    numpy_state.delp[slice_3d_buffer] = _calc_rossby_delp(grid_data)[slice_2d_buffer]
-    numpy_state.delp[slice_3d_buffer] = numpy_state.delp[slice_3d_buffer] - numpy_state.phis[slice_2d_buffer]
+    delp_2d_buffer = (islice_xtra, jslice_xtra)
+    delp_buffer_0 = (islice_xtra, jslice_xtra, 0)
+    numpy_state.delp[delp_buffer_0] = _calc_rossby_delp(grid_data)[delp_2d_buffer]
 
     grid = np.transpose(
         np.stack(  # TODO: Refactor to non-protected _horizontal_data
@@ -135,30 +140,16 @@ def _init_for_rossby(numpy_state: DycoreState, grid_data: GridData, shape):
     # Initialize u winds
     p1 = grid[:-1, :, :]
     p2 = grid[1:, :, :]
-    u_buffer = (
-        slice(slice_2d_buffer[0].start, slice_2d_buffer[0].stop - 1, None),
-        slice_2d_buffer[1]
-    )
-    u_buffer_0 = (
-        slice(slice_2d_buffer[0].start, slice_2d_buffer[0].stop - 1, None),
-        slice_2d_buffer[1],
-        0
-    )
-    numpy_state.u[u_buffer_0] = _calc_rossby_winds(p1, p2)[u_buffer]
+    u_2d_buffer = (islice, jslice_xtra)
+    u_buffer_0 = (islice, jslice_xtra, 0)
+    numpy_state.u[u_buffer_0] = _calc_rossby_winds(p1, p2)[u_2d_buffer]
 
     # Initialize v winds
     p1 = grid[:, :-1, :]
     p2 = grid[:, 1:, :]
-    v_buffer = (
-        slice_2d_buffer[0],
-        slice(slice_2d_buffer[1].start, slice_2d_buffer[1].stop - 1, None)
-    )
-    v_buffer_0 = (
-        slice_2d_buffer[0],
-        slice(slice_2d_buffer[1].start, slice_2d_buffer[1].stop - 1, None),
-        0
-    )
-    numpy_state.v[v_buffer_0] = _calc_rossby_winds(p1, p2)[v_buffer]
+    v_2d_buffer = (islice_xtra, jslice)
+    v_buffer_0 = (islice_xtra, jslice, 0)
+    numpy_state.v[v_buffer_0] = _calc_rossby_winds(p1, p2)[v_2d_buffer]
 
     # NOTE: test_cases.F90 has dtoa and atoc calls, but not implemented here.
 

--- a/pyFV3/initialization/test_cases/initialize_rossby.py
+++ b/pyFV3/initialization/test_cases/initialize_rossby.py
@@ -108,18 +108,22 @@ def _calc_rossby_delp(grid_data: GridData):
     )
 
 
-def _init_for_rossby(numpy_state: DycoreState, grid_data: GridData):
+def _init_for_rossby(numpy_state: DycoreState, grid_data: GridData, shape):
     """Initialization specific to Rossby-Haurwitz wave test
 
     Args
         numpy_state: DycoreState, modified to update the phis, delp, u, v
         grid_Data: GridData
     """
+    nx, ny, _ = init_utils.local_compute_size(shape)
+    _, _, slice_3d_buffer, slice_2d_buffer = init_utils.compute_slices(nx + 1, ny + 1)
+    slice_3d_buffer_orig = slice_3d_buffer
+    slice_3d_buffer = (slice_3d_buffer[0], slice_3d_buffer[1], 0)
     numpy_state.phis[:] = 0.0
 
     # Initialize delp
-    numpy_state.delp[:, :, 0] = _calc_rossby_delp(grid_data)
-    numpy_state.delp[:, :, 0] = numpy_state.delp[:, :, 0] - numpy_state.phis[:]
+    numpy_state.delp[slice_3d_buffer] = _calc_rossby_delp(grid_data)[slice_2d_buffer]
+    numpy_state.delp[slice_3d_buffer] = numpy_state.delp[slice_3d_buffer] - numpy_state.phis[slice_2d_buffer]
 
     grid = np.transpose(
         np.stack(  # TODO: Refactor to non-protected _horizontal_data
@@ -131,12 +135,30 @@ def _init_for_rossby(numpy_state: DycoreState, grid_data: GridData):
     # Initialize u winds
     p1 = grid[:-1, :, :]
     p2 = grid[1:, :, :]
-    numpy_state.u[:-1, :, 0] = _calc_rossby_winds(p1, p2)
+    u_buffer = (
+        slice(slice_2d_buffer[0].start, slice_2d_buffer[0].stop - 1, None),
+        slice_2d_buffer[1]
+    )
+    u_buffer_0 = (
+        slice(slice_2d_buffer[0].start, slice_2d_buffer[0].stop - 1, None),
+        slice_2d_buffer[1],
+        0
+    )
+    numpy_state.u[u_buffer_0] = _calc_rossby_winds(p1, p2)[u_buffer]
 
     # Initialize v winds
     p1 = grid[:, :-1, :]
     p2 = grid[:, 1:, :]
-    numpy_state.v[:, :-1, 0] = _calc_rossby_winds(p1, p2)
+    v_buffer = (
+        slice_2d_buffer[0],
+        slice(slice_2d_buffer[1].start, slice_2d_buffer[1].stop - 1, None)
+    )
+    v_buffer_0 = (
+        slice_2d_buffer[0],
+        slice(slice_2d_buffer[1].start, slice_2d_buffer[1].stop - 1, None),
+        0
+    )
+    numpy_state.v[v_buffer_0] = _calc_rossby_winds(p1, p2)[v_buffer]
 
     # NOTE: test_cases.F90 has dtoa and atoc calls, but not implemented here.
 
@@ -178,7 +200,7 @@ def init_rossby_state(
     numpy_state = init_utils.empty_numpy_dycore_state(shape)
 
     _preinit_for_all_sw(numpy_state, shape)
-    _init_for_rossby(numpy_state, grid_data)
+    _init_for_rossby(numpy_state, grid_data, shape)
     _postinit_for_all_sw(numpy_state)
 
     state = DycoreState.init_from_numpy_arrays(

--- a/pyFV3/initialization/test_cases/initialize_rossby.py
+++ b/pyFV3/initialization/test_cases/initialize_rossby.py
@@ -1,0 +1,191 @@
+""" Test case initialization for Rossby-Haurwitz wave 4
+
+Corresponds to Fortran shallow-water test #6 found in tools/test_cases.F90 of
+https://github.com/NOAA-GFDL/GFDL_atmos_cubed_sphere.git 
+"""
+
+import math
+import numpy as np
+
+import ndsl.constants as constants
+from ndsl import CubedSphereCommunicator, QuantityFactory
+from ndsl.grid import GridData
+from pyFV3.dycore_state import DycoreState
+from pyFV3.initialization import init_utils
+
+
+NHALO = constants.N_HALO_DEFAULT
+OMG = 7.848e-6
+RK = 7.848e-6
+R = 4.0 # Wave Number (likely)
+GH0 = 8.0e3 * constants.GRAV
+
+
+def preinit_for_all_sw(state: DycoreState,
+                       shape,
+                       grid_data: GridData
+):
+    """ Pre-initialization for all shallow water tests
+
+    Args:
+        state: DycoreState modified to update pe, pt, delp
+        shape: tuple
+        grid_data: GridData
+    """    
+    state.pe[:] = 0.0
+    state.pt[:] = 1.0
+
+    # Initialize Halo Corners
+    nx, ny, _ = init_utils.local_compute_size(shape)
+    state.delp[:NHALO, :NHALO] = 0.0
+    state.delp[:NHALO, NHALO + ny :] = 0.0
+    state.delp[NHALO + nx :, :NHALO] = 0.0
+    state.delp[NHALO + nx :, NHALO + ny :] = 0.0
+
+
+def init_rossby_winds(p1, p2):
+    """ Initializes u or v winds specific to Rossby-Haurwitz wave test
+
+    Args
+        p1 : np.ndarray
+        p2 : np.ndarray
+
+    Returns
+        np.ndarray representing u or v D-winds
+    """
+    muv = init_utils._find_midpoint_unit_vectors(p1, p2)
+    p3 = muv["midpoint"]
+    e2 = muv["unit_dir"] 
+    ex = muv["exv"] 
+    ey = muv["eyv"]
+    utmp = (
+        constants.RADIUS * OMG * np.cos(p3[:, :, 1]) + constants.RADIUS * RK
+        * (np.cos(p3[:, :, 1])**(R-1))
+        * (R * np.sin(p3[:, :, 1])**2 - np.cos(p3[:, :, 1])**2)*np.cos(R*p3[:, :, 0])
+    )
+    vtmp = (
+        -1 * constants.RADIUS * RK * R * np.sin(p3[:, :, 1])
+        * np.sin(R * p3[:, :, 0]) * np.cos(p3[:, :, 1])**(R-1)
+    )
+    return utmp * np.sum(e2 * ex, 2) + vtmp * np.sum(e2 * ey, 2)
+
+
+def init_rossby_delp(state: DycoreState,
+                     grid_data: GridData
+):
+    """ Initializes delp specific to Rossby-Haurwitz wave test
+
+    Args
+        state DycoreState
+        grid_Data GridData
+
+    Returns
+        np.ndarray representing delp values
+    """
+    agd0 = grid_data.lon_agrid.data[:]
+    agd1 = grid_data.lat_agrid.data[:]    
+    A = (0.5 * OMG * (2 * constants.OMEGA + OMG) * (np.cos(agd1)**2)
+         + 0.25 * RK * RK * (np.cos(agd1)**(R + R))
+         * ((R + 1) * (np.cos(agd1)**2) + (2 * R * R - R - 2) - 2 * (R * R) * np.cos(agd1)**(-2)))
+    B = ((2 * (constants.OMEGA + OMG) * RK / ((R+1) * (R+2)))
+         * (np.cos(agd1)**R) * ((R*R+2 * R + 2) - ((R + 1) * np.cos(agd1))**2 ))
+    C = 0.25 * RK * RK * (np.cos(agd1)**(2 * R)) * ((R + 1) * (np.cos(agd1)**2) - (R+2))    
+    return (GH0 + constants.RADIUS * constants.RADIUS
+            * ( A + B * np.cos(R * agd0) + C * np.cos(2 * R * agd0)))
+
+
+def init_for_rossby(state: DycoreState,
+                    grid_data: GridData
+):
+    """ Initialization specific to Rossby-Haurwitz wave test
+
+    Args
+        state DycoreState, modified to update the 
+        grid_Data GridData
+    """
+    
+    state.phis[:] = 0.0
+
+    # Initialize delp
+    state.delp[:,:,0] = init_rossby_delp(state, grid_data)
+    state.delp[:,:,0] = state.delp[:,:,0] - state.phis[:]
+
+    grid = np.transpose(
+        np.stack(
+            [grid_data._horizontal_data.lon.data, grid_data._horizontal_data.lat.data]
+        ),
+        [1, 2, 0],
+    )
+
+    # Initialize u winds
+    p1 = grid[:-1, :, :]
+    p2 = grid[1:, :, :]
+    state.u[:-1, :, 0] = init_rossby_winds(p1, p2)
+
+    # Initialize v winds
+    p1 = grid[:, :-1, :]
+    p2 = grid[:, 1:, :]
+    state.v[:, :-1, 0] = init_rossby_winds(p1, p2)
+    
+    # TODO: Pay attention to the slice indices. u and v are similarly calculated.
+
+    """ From test_cases.F90 (case 6): 
+         call mp_update_dwinds(u, v, npx, npy, npz, domain, bd)
+         call dtoa( u, v,ua,va,dx,dy,dxa,dya,dxc,dyc,npx,npy,ng,bd)
+         !call mpp_update_domains( ua, va, domain, gridtype=AGRID_PARAM)
+         call atoc(ua,va,uc,vc,dx,dy,dxa,dya,npx,npy,ng, gridstruct%bounded_domain, domain, bd)
+         initWindsCase=initWindsCase6
+    """
+
+
+def postinit_for_all_sw(state, grid_data):
+    """ Post-initialization from test_cases.F90 that applies to all shallow water tests
+
+    Args:
+        state: DycoreState - modified
+    """
+
+    # NOTE: The cl/cl2 tracers from the original Fortran test_cases.F90 are not brought over.
+    # NOTE: A-grid and C-grid winds are not initialized here.
+
+    state.delp[:,:,1:] = state.delp[:,:,0][:,:,np.newaxis]
+    state.u[:,:,1:] = state.u[:,:,0][:,:,np.newaxis]
+    state.v[:,:,1:] = state.v[:,:,0][:,:,np.newaxis]
+    state.ps[:] = state.delp[:,:,0]
+    
+    
+def init_rossby_state(
+    grid_data: GridData,
+    quantity_factory: QuantityFactory,
+    comm: CubedSphereCommunicator,
+) -> DycoreState:
+    """
+    Create a DycoreState TODO: explain more
+
+    Args:
+        grid_data:              current selected grid data values
+        quantity_factory:       QuantityFactory
+        comm:                   CubedSphereCommunicator
+
+    Returns:
+        DycoreState
+    """
+    sample_quantity = grid_data.lat
+    shape = (*sample_quantity.data.shape[0:2], grid_data.ak.data.shape[0])
+    numpy_state = init_utils.empty_numpy_dycore_state(shape)
+
+    preinit_for_all_sw(numpy_state, shape, grid_data)
+    init_for_rossby(numpy_state, grid_data)
+    postinit_for_all_sw(numpy_state, grid_data)
+
+    state = DycoreState.init_from_numpy_arrays(
+        numpy_state.__dict__,
+        sizer=quantity_factory.sizer,
+        backend=sample_quantity.metadata.gt4py_backend,
+    )
+
+    comm.halo_update(state.phis, n_points=NHALO)
+    comm.vector_halo_update(state.u, state.v, n_points=NHALO)
+    # TODO: anymore comm updates? delp?
+
+    return state

--- a/pyFV3/initialization/test_cases/initialize_rossby.py
+++ b/pyFV3/initialization/test_cases/initialize_rossby.py
@@ -186,6 +186,10 @@ def init_rossby_state(
     Returns:
         DycoreState
     """
+
+    # TODO: Check sw_dunamics is True (https://github.com/NOAA-GFDL/PyFV3/pull/50)
+    #       May require a change to pass a config here in order to check.
+
     sample_quantity = grid_data.lat
     shape = (*sample_quantity.data.shape[0:2], grid_data.ak.data.shape[0])
     numpy_state = init_utils.empty_numpy_dycore_state(shape)

--- a/pyFV3/initialization/test_cases/initialize_rossby.py
+++ b/pyFV3/initialization/test_cases/initialize_rossby.py
@@ -1,13 +1,12 @@
 """ Test case initialization for Rossby-Haurwitz wave 4
 
 Corresponds to Fortran shallow-water test #6 found in tools/test_cases.F90 of
-https://github.com/NOAA-GFDL/GFDL_atmos_cubed_sphere.git 
+https://github.com/NOAA-GFDL/GFDL_atmos_cubed_sphere.git
 """
 
 import numpy as np
 
-from ndsl import constants
-from ndsl import CubedSphereCommunicator, QuantityFactory
+from ndsl import CubedSphereCommunicator, QuantityFactory, constants
 from ndsl.grid import GridData
 from pyFV3.dycore_state import DycoreState
 from pyFV3.initialization import init_utils
@@ -16,14 +15,12 @@ from pyFV3.initialization import init_utils
 NHALO = constants.N_HALO_DEFAULT
 OMG = 7.848e-6
 RK = 7.848e-6
-R = 4.0 # Wave Number (likely)
+R = 4.0  # Wave Number (likely)
 GH0 = 8.0e3 * constants.GRAV
 
 
-def _preinit_for_all_sw(numpy_state: DycoreState,
-                        shape
-):
-    """ Pre-initialization for all shallow water tests
+def _preinit_for_all_sw(numpy_state: DycoreState, shape):
+    """Pre-initialization for all shallow water tests
 
     Args:
         numpy_state: DycoreState modified to update pe, pt, delp
@@ -41,7 +38,7 @@ def _preinit_for_all_sw(numpy_state: DycoreState,
 
 
 def _calc_rossby_winds(p1, p2):
-    """ Calculates initial u or v winds specific to Rossby-Haurwitz wave test
+    """Calculates initial u or v winds specific to Rossby-Haurwitz wave test
 
     Args
         p1: np.ndarray
@@ -50,25 +47,32 @@ def _calc_rossby_winds(p1, p2):
     Returns
         np.ndarray: representing u or v (D-winds)
     """
-    muv = init_utils._find_midpoint_unit_vectors(p1, p2) # TODO: Refactor to non-protected
+    muv = init_utils._find_midpoint_unit_vectors(
+        p1, p2
+    )  # TODO: Refactor to non-protected
     p3 = muv["midpoint"]
     e2 = muv["unit_dir"]
     ex = muv["exv"]
     ey = muv["eyv"]
-    utmp = (
-        constants.RADIUS * OMG * np.cos(p3[:, :, 1]) + constants.RADIUS * RK
-        * (np.cos(p3[:, :, 1])**(R-1))
-        * (R * np.sin(p3[:, :, 1])**2 - np.cos(p3[:, :, 1])**2)*np.cos(R*p3[:, :, 0])
+    utmp = constants.RADIUS * OMG * np.cos(p3[:, :, 1]) + constants.RADIUS * RK * (
+        np.cos(p3[:, :, 1]) ** (R - 1)
+    ) * (R * np.sin(p3[:, :, 1]) ** 2 - np.cos(p3[:, :, 1]) ** 2) * np.cos(
+        R * p3[:, :, 0]
     )
     vtmp = (
-        -1 * constants.RADIUS * RK * R * np.sin(p3[:, :, 1])
-        * np.sin(R * p3[:, :, 0]) * np.cos(p3[:, :, 1])**(R-1)
+        -1
+        * constants.RADIUS
+        * RK
+        * R
+        * np.sin(p3[:, :, 1])
+        * np.sin(R * p3[:, :, 0])
+        * np.cos(p3[:, :, 1]) ** (R - 1)
     )
     return utmp * np.sum(e2 * ex, 2) + vtmp * np.sum(e2 * ey, 2)
 
 
 def _calc_rossby_delp(grid_data: GridData):
-    """ Calculates initial delp, specific to Rossby-Haurwitz wave test
+    """Calculates initial delp, specific to Rossby-Haurwitz wave test
 
     Args
         grid_Data GridData
@@ -78,20 +82,32 @@ def _calc_rossby_delp(grid_data: GridData):
     """
     agd0 = grid_data.lon_agrid.data[:]
     agd1 = grid_data.lat_agrid.data[:]
-    a = (0.5 * OMG * (2 * constants.OMEGA + OMG) * (np.cos(agd1)**2)
-         + 0.25 * RK * RK * (np.cos(agd1)**(R + R))
-         * ((R + 1) * (np.cos(agd1)**2) + (2 * R * R - R - 2) - 2 * (R * R) * np.cos(agd1)**(-2)))
-    b = ((2 * (constants.OMEGA + OMG) * RK / ((R+1) * (R+2)))
-         * (np.cos(agd1)**R) * ((R*R+2 * R + 2) - ((R + 1) * np.cos(agd1))**2 ))
-    c = 0.25 * RK * RK * (np.cos(agd1)**(2 * R)) * ((R + 1) * (np.cos(agd1)**2) - (R+2))
-    return (GH0 + constants.RADIUS * constants.RADIUS
-            * ( a + b * np.cos(R * agd0) + c * np.cos(2 * R * agd0)))
+    a = 0.5 * OMG * (2 * constants.OMEGA + OMG) * (
+        np.cos(agd1) ** 2
+    ) + 0.25 * RK * RK * (np.cos(agd1) ** (R + R)) * (
+        (R + 1) * (np.cos(agd1) ** 2)
+        + (2 * R * R - R - 2)
+        - 2 * (R * R) * np.cos(agd1) ** (-2)
+    )
+    b = (
+        (2 * (constants.OMEGA + OMG) * RK / ((R + 1) * (R + 2)))
+        * (np.cos(agd1) ** R)
+        * ((R * R + 2 * R + 2) - ((R + 1) * np.cos(agd1)) ** 2)
+    )
+    c = (
+        0.25
+        * RK
+        * RK
+        * (np.cos(agd1) ** (2 * R))
+        * ((R + 1) * (np.cos(agd1) ** 2) - (R + 2))
+    )
+    return GH0 + constants.RADIUS * constants.RADIUS * (
+        a + b * np.cos(R * agd0) + c * np.cos(2 * R * agd0)
+    )
 
 
-def _init_for_rossby(numpy_state: DycoreState,
-                     grid_data: GridData
-):
-    """ Initialization specific to Rossby-Haurwitz wave test
+def _init_for_rossby(numpy_state: DycoreState, grid_data: GridData):
+    """Initialization specific to Rossby-Haurwitz wave test
 
     Args
         numpy_state: DycoreState, modified to update the phis, delp, u, v
@@ -100,11 +116,11 @@ def _init_for_rossby(numpy_state: DycoreState,
     numpy_state.phis[:] = 0.0
 
     # Initialize delp
-    numpy_state.delp[:,:,0] = _calc_rossby_delp(grid_data)
-    numpy_state.delp[:,:,0] = numpy_state.delp[:,:,0] - numpy_state.phis[:]
+    numpy_state.delp[:, :, 0] = _calc_rossby_delp(grid_data)
+    numpy_state.delp[:, :, 0] = numpy_state.delp[:, :, 0] - numpy_state.phis[:]
 
     grid = np.transpose(
-        np.stack( # TODO: Refactor to non-protected _horizontal_data
+        np.stack(  # TODO: Refactor to non-protected _horizontal_data
             [grid_data._horizontal_data.lon.data, grid_data._horizontal_data.lat.data]
         ),
         [1, 2, 0],
@@ -120,23 +136,23 @@ def _init_for_rossby(numpy_state: DycoreState,
     p2 = grid[:, 1:, :]
     numpy_state.v[:, :-1, 0] = _calc_rossby_winds(p1, p2)
 
-    # NOTE: Fortran test_cases.F90 has dtoa and atoc calls, but they're not implemented here.
+    # NOTE: test_cases.F90 has dtoa and atoc calls, but not implemented here.
 
 
 def _postinit_for_all_sw(numpy_state: DycoreState):
-    """ Post-initialization from test_cases.F90 that applies to all shallow water tests
+    """Post-initialization from test_cases.F90 that applies to all shallow water tests
 
     Args
         numpy_state: DycoreState - modified
     """
 
-    # NOTE: The cl/cl2 tracers from the original Fortran test_cases.F90 are not brought over.
+    # NOTE: The cl/cl2 tracers from the original test_cases.F90 aren't brought over.
     # NOTE: A-grid and C-grid winds are not initialized here.
 
-    numpy_state.delp[:,:,1:] = numpy_state.delp[:,:,0][:,:,np.newaxis]
-    numpy_state.u[:,:,1:] = numpy_state.u[:,:,0][:,:,np.newaxis]
-    numpy_state.v[:,:,1:] = numpy_state.v[:,:,0][:,:,np.newaxis]
-    numpy_state.ps[:] = numpy_state.delp[:,:,0]
+    numpy_state.delp[:, :, 1:] = numpy_state.delp[:, :, 0][:, :, np.newaxis]
+    numpy_state.u[:, :, 1:] = numpy_state.u[:, :, 0][:, :, np.newaxis]
+    numpy_state.v[:, :, 1:] = numpy_state.v[:, :, 0][:, :, np.newaxis]
+    numpy_state.ps[:] = numpy_state.delp[:, :, 0]
 
 
 def init_rossby_state(

--- a/pyFV3/initialization/test_cases/initialize_rossby.py
+++ b/pyFV3/initialization/test_cases/initialize_rossby.py
@@ -4,10 +4,9 @@ Corresponds to Fortran shallow-water test #6 found in tools/test_cases.F90 of
 https://github.com/NOAA-GFDL/GFDL_atmos_cubed_sphere.git 
 """
 
-import math
 import numpy as np
 
-import ndsl.constants as constants
+from ndsl import constants
 from ndsl import CubedSphereCommunicator, QuantityFactory
 from ndsl.grid import GridData
 from pyFV3.dycore_state import DycoreState
@@ -21,42 +20,40 @@ R = 4.0 # Wave Number (likely)
 GH0 = 8.0e3 * constants.GRAV
 
 
-def preinit_for_all_sw(state: DycoreState,
-                       shape,
-                       grid_data: GridData
+def _preinit_for_all_sw(numpy_state: DycoreState,
+                        shape
 ):
     """ Pre-initialization for all shallow water tests
 
     Args:
-        state: DycoreState modified to update pe, pt, delp
+        numpy_state: DycoreState modified to update pe, pt, delp
         shape: tuple
-        grid_data: GridData
-    """    
-    state.pe[:] = 0.0
-    state.pt[:] = 1.0
+    """
+    numpy_state.pe[:] = 0.0
+    numpy_state.pt[:] = 1.0
 
     # Initialize Halo Corners
     nx, ny, _ = init_utils.local_compute_size(shape)
-    state.delp[:NHALO, :NHALO] = 0.0
-    state.delp[:NHALO, NHALO + ny :] = 0.0
-    state.delp[NHALO + nx :, :NHALO] = 0.0
-    state.delp[NHALO + nx :, NHALO + ny :] = 0.0
+    numpy_state.delp[:NHALO, :NHALO] = 0.0
+    numpy_state.delp[:NHALO, NHALO + ny :] = 0.0
+    numpy_state.delp[NHALO + nx :, :NHALO] = 0.0
+    numpy_state.delp[NHALO + nx :, NHALO + ny :] = 0.0
 
 
-def init_rossby_winds(p1, p2):
-    """ Initializes u or v winds specific to Rossby-Haurwitz wave test
+def _calc_rossby_winds(p1, p2):
+    """ Calculates initial u or v winds specific to Rossby-Haurwitz wave test
 
     Args
-        p1 : np.ndarray
-        p2 : np.ndarray
+        p1: np.ndarray
+        p2: np.ndarray
 
     Returns
-        np.ndarray representing u or v D-winds
+        np.ndarray: representing u or v (D-winds)
     """
-    muv = init_utils._find_midpoint_unit_vectors(p1, p2)
+    muv = init_utils._find_midpoint_unit_vectors(p1, p2) # TODO: Refactor to non-protected
     p3 = muv["midpoint"]
-    e2 = muv["unit_dir"] 
-    ex = muv["exv"] 
+    e2 = muv["unit_dir"]
+    ex = muv["exv"]
     ey = muv["eyv"]
     utmp = (
         constants.RADIUS * OMG * np.cos(p3[:, :, 1]) + constants.RADIUS * RK
@@ -70,48 +67,44 @@ def init_rossby_winds(p1, p2):
     return utmp * np.sum(e2 * ex, 2) + vtmp * np.sum(e2 * ey, 2)
 
 
-def init_rossby_delp(state: DycoreState,
-                     grid_data: GridData
-):
-    """ Initializes delp specific to Rossby-Haurwitz wave test
+def _calc_rossby_delp(grid_data: GridData):
+    """ Calculates initial delp, specific to Rossby-Haurwitz wave test
 
     Args
-        state DycoreState
         grid_Data GridData
 
     Returns
         np.ndarray representing delp values
     """
     agd0 = grid_data.lon_agrid.data[:]
-    agd1 = grid_data.lat_agrid.data[:]    
-    A = (0.5 * OMG * (2 * constants.OMEGA + OMG) * (np.cos(agd1)**2)
+    agd1 = grid_data.lat_agrid.data[:]
+    a = (0.5 * OMG * (2 * constants.OMEGA + OMG) * (np.cos(agd1)**2)
          + 0.25 * RK * RK * (np.cos(agd1)**(R + R))
          * ((R + 1) * (np.cos(agd1)**2) + (2 * R * R - R - 2) - 2 * (R * R) * np.cos(agd1)**(-2)))
-    B = ((2 * (constants.OMEGA + OMG) * RK / ((R+1) * (R+2)))
+    b = ((2 * (constants.OMEGA + OMG) * RK / ((R+1) * (R+2)))
          * (np.cos(agd1)**R) * ((R*R+2 * R + 2) - ((R + 1) * np.cos(agd1))**2 ))
-    C = 0.25 * RK * RK * (np.cos(agd1)**(2 * R)) * ((R + 1) * (np.cos(agd1)**2) - (R+2))    
+    c = 0.25 * RK * RK * (np.cos(agd1)**(2 * R)) * ((R + 1) * (np.cos(agd1)**2) - (R+2))
     return (GH0 + constants.RADIUS * constants.RADIUS
-            * ( A + B * np.cos(R * agd0) + C * np.cos(2 * R * agd0)))
+            * ( a + b * np.cos(R * agd0) + c * np.cos(2 * R * agd0)))
 
 
-def init_for_rossby(state: DycoreState,
-                    grid_data: GridData
+def _init_for_rossby(numpy_state: DycoreState,
+                     grid_data: GridData
 ):
     """ Initialization specific to Rossby-Haurwitz wave test
 
     Args
-        state DycoreState, modified to update the 
-        grid_Data GridData
+        numpy_state: DycoreState, modified to update the phis, delp, u, v
+        grid_Data: GridData
     """
-    
-    state.phis[:] = 0.0
+    numpy_state.phis[:] = 0.0
 
     # Initialize delp
-    state.delp[:,:,0] = init_rossby_delp(state, grid_data)
-    state.delp[:,:,0] = state.delp[:,:,0] - state.phis[:]
+    numpy_state.delp[:,:,0] = _calc_rossby_delp(grid_data)
+    numpy_state.delp[:,:,0] = numpy_state.delp[:,:,0] - numpy_state.phis[:]
 
     grid = np.transpose(
-        np.stack(
+        np.stack( # TODO: Refactor to non-protected _horizontal_data
             [grid_data._horizontal_data.lon.data, grid_data._horizontal_data.lat.data]
         ),
         [1, 2, 0],
@@ -120,40 +113,32 @@ def init_for_rossby(state: DycoreState,
     # Initialize u winds
     p1 = grid[:-1, :, :]
     p2 = grid[1:, :, :]
-    state.u[:-1, :, 0] = init_rossby_winds(p1, p2)
+    numpy_state.u[:-1, :, 0] = _calc_rossby_winds(p1, p2)
 
     # Initialize v winds
     p1 = grid[:, :-1, :]
     p2 = grid[:, 1:, :]
-    state.v[:, :-1, 0] = init_rossby_winds(p1, p2)
-    
-    # TODO: Pay attention to the slice indices. u and v are similarly calculated.
+    numpy_state.v[:, :-1, 0] = _calc_rossby_winds(p1, p2)
 
-    """ From test_cases.F90 (case 6): 
-         call mp_update_dwinds(u, v, npx, npy, npz, domain, bd)
-         call dtoa( u, v,ua,va,dx,dy,dxa,dya,dxc,dyc,npx,npy,ng,bd)
-         !call mpp_update_domains( ua, va, domain, gridtype=AGRID_PARAM)
-         call atoc(ua,va,uc,vc,dx,dy,dxa,dya,npx,npy,ng, gridstruct%bounded_domain, domain, bd)
-         initWindsCase=initWindsCase6
-    """
+    # NOTE: Fortran test_cases.F90 has dtoa and atoc calls, but they're not implemented here.
 
 
-def postinit_for_all_sw(state, grid_data):
+def _postinit_for_all_sw(numpy_state: DycoreState):
     """ Post-initialization from test_cases.F90 that applies to all shallow water tests
 
-    Args:
-        state: DycoreState - modified
+    Args
+        numpy_state: DycoreState - modified
     """
 
     # NOTE: The cl/cl2 tracers from the original Fortran test_cases.F90 are not brought over.
     # NOTE: A-grid and C-grid winds are not initialized here.
 
-    state.delp[:,:,1:] = state.delp[:,:,0][:,:,np.newaxis]
-    state.u[:,:,1:] = state.u[:,:,0][:,:,np.newaxis]
-    state.v[:,:,1:] = state.v[:,:,0][:,:,np.newaxis]
-    state.ps[:] = state.delp[:,:,0]
-    
-    
+    numpy_state.delp[:,:,1:] = numpy_state.delp[:,:,0][:,:,np.newaxis]
+    numpy_state.u[:,:,1:] = numpy_state.u[:,:,0][:,:,np.newaxis]
+    numpy_state.v[:,:,1:] = numpy_state.v[:,:,0][:,:,np.newaxis]
+    numpy_state.ps[:] = numpy_state.delp[:,:,0]
+
+
 def init_rossby_state(
     grid_data: GridData,
     quantity_factory: QuantityFactory,
@@ -174,9 +159,9 @@ def init_rossby_state(
     shape = (*sample_quantity.data.shape[0:2], grid_data.ak.data.shape[0])
     numpy_state = init_utils.empty_numpy_dycore_state(shape)
 
-    preinit_for_all_sw(numpy_state, shape, grid_data)
-    init_for_rossby(numpy_state, grid_data)
-    postinit_for_all_sw(numpy_state, grid_data)
+    _preinit_for_all_sw(numpy_state, shape)
+    _init_for_rossby(numpy_state, grid_data)
+    _postinit_for_all_sw(numpy_state)
 
     state = DycoreState.init_from_numpy_arrays(
         numpy_state.__dict__,
@@ -186,6 +171,5 @@ def init_rossby_state(
 
     comm.halo_update(state.phis, n_points=NHALO)
     comm.vector_halo_update(state.u, state.v, n_points=NHALO)
-    # TODO: anymore comm updates? delp?
 
     return state

--- a/pyFV3/initialization/test_cases/initialize_rossby.py
+++ b/pyFV3/initialization/test_cases/initialize_rossby.py
@@ -7,16 +7,17 @@ https://github.com/NOAA-GFDL/GFDL_atmos_cubed_sphere.git
 import numpy as np
 
 from ndsl import CubedSphereCommunicator, QuantityFactory, constants
+from ndsl.dsl.typing import Float
 from ndsl.grid import GridData
 from pyFV3.dycore_state import DycoreState
 from pyFV3.initialization import init_utils
 
 
 NHALO = constants.N_HALO_DEFAULT
-OMG = 7.848e-6
-RK = 7.848e-6
-R = 4.0  # Wave Number (likely)
-GH0 = 8.0e3 * constants.GRAV
+OMG = Float(7.848e-6)
+RK = Float(7.848e-6)
+R = Float(4.0)  # Wave Number (likely)
+GH0 = Float(8.0e3) * constants.GRAV
 
 
 def _preinit_for_all_sw(numpy_state: DycoreState, shape):
@@ -49,7 +50,7 @@ def _calc_rossby_winds(p1, p2):
     """
     muv = init_utils._find_midpoint_unit_vectors(
         p1, p2
-    )  # TODO: Refactor to non-protected
+    )  # TODO: Refactor to non-protected call
     p3 = muv["midpoint"]
     e2 = muv["unit_dir"]
     ex = muv["exv"]
@@ -82,9 +83,10 @@ def _calc_rossby_delp(grid_data: GridData):
     """
     agd0 = grid_data.lon_agrid.data[:]
     agd1 = grid_data.lat_agrid.data[:]
-    a = 0.5 * OMG * (2 * constants.OMEGA + OMG) * (
-        np.cos(agd1) ** 2
-    ) + 0.25 * RK * RK * (np.cos(agd1) ** (R + R)) * (
+
+    a = Float(0.5) * OMG * (2 * constants.OMEGA + OMG) * (np.cos(agd1) ** 2) + Float(
+        0.25
+    ) * RK * RK * (np.cos(agd1) ** (R + R)) * (
         (R + 1) * (np.cos(agd1) ** 2)
         + (2 * R * R - R - 2)
         - 2 * (R * R) * np.cos(agd1) ** (-2)
@@ -95,7 +97,7 @@ def _calc_rossby_delp(grid_data: GridData):
         * ((R * R + 2 * R + 2) - ((R + 1) * np.cos(agd1)) ** 2)
     )
     c = (
-        0.25
+        Float(0.25)
         * RK
         * RK
         * (np.cos(agd1) ** (2 * R))


### PR DESCRIPTION
**Description**
This is the first step in porting a Fortran shallow water test to pace. This PR will add DycoreState initialization for the Rossby-Haurwitz wave 4 test case found in `tools/test_cases.F90` (shallow-water test 6) of the [GFDL_atmos_cubed_sphere repo](https://github.com/NOAA-GFDL/GFDL_atmos_cubed_sphere.git).

Additionally, there is an new `sw_dynamics` configuration flag added to the DynamicalCoreConfig that does nothing yet, but it will eventually be used to modify logic based on whether or not the test is for shallow water.

Fixes # (issue) 
None.

**How Has This Been Tested?**
DycoreState initialization for the Rossby case was unit-tested in the pace repository. This related code will be added in a separate PR for that repo.

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation - _I don't believe there is corresponding documentation for this change._
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules - _Dependent changes will be merged eventually, but haven't been merged yet._
- [ ] New check tests, if applicable, are included - _Unit test will be added in a separate repository PR_
- [ ] Targeted model if this changed was triggered by a model need/shortcoming - _Unsure. I don't think this is applicable._
