### PR TITLE
Removed Direct GT4Py Imports

### DIFF
--- a/pyFV3/stencils/a2b_ord4.py
+++ b/pyFV3/stencils/a2b_ord4.py
@@ -1,6 +1,6 @@
-import gt4py.cartesian.gtscript as gtscript
-from gt4py.cartesian.gtscript import (
+from ndsl.dsl.gt4py import (
     PARALLEL,
+    function,
     asin,
     computation,
     cos,
@@ -31,14 +31,14 @@ a1 = 9.0 / 16.0
 a2 = -1.0 / 16.0
 
 
-@gtscript.function
+@function
 def great_circle_dist(p1a, p1b, p2a, p2b):
     tb = sin((p1b - p2b) / 2.0) ** 2.0
     ta = sin((p1a - p2a) / 2.0) ** 2.0
     return asin(sqrt(tb + cos(p1b) * cos(p2b) * ta)) * 2.0
 
 
-@gtscript.function
+@function
 def extrap_corner(
     p0a,
     p0b,
@@ -271,12 +271,12 @@ def _se_corner(
         tmp_qout_edges = qout
 
 
-@gtscript.function
+@function
 def lagrange_y_func(qx):
     return a2 * (qx[0, -2, 0] + qx[0, 1, 0]) + a1 * (qx[0, -1, 0] + qx)
 
 
-@gtscript.function
+@function
 def lagrange_x_func(qy):
     return a2 * (qy[-2, 0, 0] + qy[1, 0, 0]) + a1 * (qy[-1, 0, 0] + qy)
 
@@ -323,7 +323,7 @@ def qout_y_edge(
         tmp_qout_edges = qout
 
 
-@gtscript.function
+@function
 def qx_edge_west(qin: FloatField, dxa: FloatFieldIJ):
     g_in = dxa[1, 0] / dxa
     g_ou = dxa[-2, 0] / dxa[-1, 0]
@@ -333,7 +333,7 @@ def qx_edge_west(qin: FloatField, dxa: FloatFieldIJ):
     )
 
 
-@gtscript.function
+@function
 def qx_edge_west2(qin: FloatField, dxa: FloatFieldIJ):
     g_in = dxa / dxa[-1, 0]
     g_ou = dxa[-3, 0] / dxa[-2, 0]
@@ -347,7 +347,7 @@ def qx_edge_west2(qin: FloatField, dxa: FloatFieldIJ):
     )
 
 
-@gtscript.function
+@function
 def qx_edge_east(qin: FloatField, dxa: FloatFieldIJ):
     g_in = dxa[-2, 0] / dxa[-1, 0]
     g_ou = dxa[1, 0] / dxa
@@ -357,7 +357,7 @@ def qx_edge_east(qin: FloatField, dxa: FloatFieldIJ):
     )
 
 
-@gtscript.function
+@function
 def qx_edge_east2(qin: FloatField, dxa: FloatFieldIJ):
     g_in = dxa[-1, 0] / dxa
     g_ou = dxa[2, 0] / dxa[1, 0]
@@ -371,7 +371,7 @@ def qx_edge_east2(qin: FloatField, dxa: FloatFieldIJ):
     )
 
 
-@gtscript.function
+@function
 def qy_edge_south(qin: FloatField, dya: FloatFieldIJ):
     g_in = dya[0, 1] / dya
     g_ou = dya[0, -2] / dya[0, -1]
@@ -381,7 +381,7 @@ def qy_edge_south(qin: FloatField, dya: FloatFieldIJ):
     )
 
 
-@gtscript.function
+@function
 def qy_edge_south2(qin: FloatField, dya: FloatFieldIJ):
     g_in = dya / dya[0, -1]
     g_ou = dya[0, -3] / dya[0, -2]
@@ -395,7 +395,7 @@ def qy_edge_south2(qin: FloatField, dya: FloatFieldIJ):
     )
 
 
-@gtscript.function
+@function
 def qy_edge_north(qin: FloatField, dya: FloatFieldIJ):
     g_in = dya[0, -2] / dya[0, -1]
     g_ou = dya[0, 1] / dya
@@ -405,7 +405,7 @@ def qy_edge_north(qin: FloatField, dya: FloatFieldIJ):
     )
 
 
-@gtscript.function
+@function
 def qy_edge_north2(qin: FloatField, dya: FloatFieldIJ):
     g_in = dya[0, -1] / dya
     g_ou = dya[0, 2] / dya[0, 1]
@@ -504,7 +504,7 @@ def a2b_interpolation(
         qout = 0.5 * (qxx + qyy)
 
 
-@gtscript.function
+@function
 def doubly_periodic_a2b_ord4(qin):
     """
     Grid conversion is much simpler on a doubly-periodic, orthogonal grid so we

--- a/pyFV3/stencils/a2b_ord4.py
+++ b/pyFV3/stencils/a2b_ord4.py
@@ -1,18 +1,17 @@
+from ndsl import GridIndexing, QuantityFactory, StencilFactory, orchestrate
+from ndsl.constants import X_DIM, X_INTERFACE_DIM, Y_DIM, Y_INTERFACE_DIM, Z_DIM
 from ndsl.dsl.gt4py import (
     PARALLEL,
-    function,
     asin,
     computation,
     cos,
+    function,
     horizontal,
     interval,
     region,
     sin,
     sqrt,
 )
-
-from ndsl import GridIndexing, QuantityFactory, StencilFactory, orchestrate
-from ndsl.constants import X_DIM, X_INTERFACE_DIM, Y_DIM, Y_INTERFACE_DIM, Z_DIM
 from ndsl.dsl.typing import Float, FloatField, FloatFieldI, FloatFieldIJ
 from ndsl.grid import GridData
 from ndsl.stencils.basic_operations import copy_defn

--- a/pyFV3/stencils/a2b_ord4.py
+++ b/pyFV3/stencils/a2b_ord4.py
@@ -1,17 +1,8 @@
 from ndsl import GridIndexing, QuantityFactory, StencilFactory, orchestrate
 from ndsl.constants import X_DIM, X_INTERFACE_DIM, Y_DIM, Y_INTERFACE_DIM, Z_DIM
-from ndsl.dsl.gt4py import (
-    PARALLEL,
-    asin,
-    computation,
-    cos,
-    function,
-    horizontal,
-    interval,
-    region,
-    sin,
-    sqrt,
-)
+from ndsl.dsl.gt4py import PARALLEL, asin, computation, cos
+from ndsl.dsl.gt4py import function as gtfunction
+from ndsl.dsl.gt4py import horizontal, interval, region, sin, sqrt
 from ndsl.dsl.typing import Float, FloatField, FloatFieldI, FloatFieldIJ
 from ndsl.grid import GridData
 from ndsl.stencils.basic_operations import copy_defn
@@ -30,14 +21,14 @@ a1 = 9.0 / 16.0
 a2 = -1.0 / 16.0
 
 
-@function
+@gtfunction
 def great_circle_dist(p1a, p1b, p2a, p2b):
     tb = sin((p1b - p2b) / 2.0) ** 2.0
     ta = sin((p1a - p2a) / 2.0) ** 2.0
     return asin(sqrt(tb + cos(p1b) * cos(p2b) * ta)) * 2.0
 
 
-@function
+@gtfunction
 def extrap_corner(
     p0a,
     p0b,
@@ -270,12 +261,12 @@ def _se_corner(
         tmp_qout_edges = qout
 
 
-@function
+@gtfunction
 def lagrange_y_func(qx):
     return a2 * (qx[0, -2, 0] + qx[0, 1, 0]) + a1 * (qx[0, -1, 0] + qx)
 
 
-@function
+@gtfunction
 def lagrange_x_func(qy):
     return a2 * (qy[-2, 0, 0] + qy[1, 0, 0]) + a1 * (qy[-1, 0, 0] + qy)
 
@@ -322,7 +313,7 @@ def qout_y_edge(
         tmp_qout_edges = qout
 
 
-@function
+@gtfunction
 def qx_edge_west(qin: FloatField, dxa: FloatFieldIJ):
     g_in = dxa[1, 0] / dxa
     g_ou = dxa[-2, 0] / dxa[-1, 0]
@@ -332,7 +323,7 @@ def qx_edge_west(qin: FloatField, dxa: FloatFieldIJ):
     )
 
 
-@function
+@gtfunction
 def qx_edge_west2(qin: FloatField, dxa: FloatFieldIJ):
     g_in = dxa / dxa[-1, 0]
     g_ou = dxa[-3, 0] / dxa[-2, 0]
@@ -346,7 +337,7 @@ def qx_edge_west2(qin: FloatField, dxa: FloatFieldIJ):
     )
 
 
-@function
+@gtfunction
 def qx_edge_east(qin: FloatField, dxa: FloatFieldIJ):
     g_in = dxa[-2, 0] / dxa[-1, 0]
     g_ou = dxa[1, 0] / dxa
@@ -356,7 +347,7 @@ def qx_edge_east(qin: FloatField, dxa: FloatFieldIJ):
     )
 
 
-@function
+@gtfunction
 def qx_edge_east2(qin: FloatField, dxa: FloatFieldIJ):
     g_in = dxa[-1, 0] / dxa
     g_ou = dxa[2, 0] / dxa[1, 0]
@@ -370,7 +361,7 @@ def qx_edge_east2(qin: FloatField, dxa: FloatFieldIJ):
     )
 
 
-@function
+@gtfunction
 def qy_edge_south(qin: FloatField, dya: FloatFieldIJ):
     g_in = dya[0, 1] / dya
     g_ou = dya[0, -2] / dya[0, -1]
@@ -380,7 +371,7 @@ def qy_edge_south(qin: FloatField, dya: FloatFieldIJ):
     )
 
 
-@function
+@gtfunction
 def qy_edge_south2(qin: FloatField, dya: FloatFieldIJ):
     g_in = dya / dya[0, -1]
     g_ou = dya[0, -3] / dya[0, -2]
@@ -394,7 +385,7 @@ def qy_edge_south2(qin: FloatField, dya: FloatFieldIJ):
     )
 
 
-@function
+@gtfunction
 def qy_edge_north(qin: FloatField, dya: FloatFieldIJ):
     g_in = dya[0, -2] / dya[0, -1]
     g_ou = dya[0, 1] / dya
@@ -404,7 +395,7 @@ def qy_edge_north(qin: FloatField, dya: FloatFieldIJ):
     )
 
 
-@function
+@gtfunction
 def qy_edge_north2(qin: FloatField, dya: FloatFieldIJ):
     g_in = dya[0, -1] / dya
     g_ou = dya[0, 2] / dya[0, 1]
@@ -503,7 +494,7 @@ def a2b_interpolation(
         qout = 0.5 * (qxx + qyy)
 
 
-@function
+@gtfunction
 def doubly_periodic_a2b_ord4(qin):
     """
     Grid conversion is much simpler on a doubly-periodic, orthogonal grid so we

--- a/pyFV3/stencils/c_sw.py
+++ b/pyFV3/stencils/c_sw.py
@@ -1,5 +1,4 @@
-from gt4py.cartesian.gtscript import (  # noqa
-    __INLINED,
+from ndsl.dsl.gt4py import (  # noqa
     PARALLEL,
     computation,
     horizontal,
@@ -13,6 +12,8 @@ from ndsl.dsl.typing import Float, FloatField, FloatFieldIJ
 from ndsl.grid import GridData
 from ndsl.stencils import corners
 from pyFV3.stencils.d2a2c_vect import DGrid2AGrid2CGridVectors
+
+from gt4py.cartesian.gtscript import __INLINED  # isort:skip
 
 
 def zero_delpc_ptc(delpc: FloatField, ptc: FloatField):

--- a/pyFV3/stencils/c_sw.py
+++ b/pyFV3/stencils/c_sw.py
@@ -1,17 +1,11 @@
-from ndsl.dsl.gt4py import (  # noqa
-    PARALLEL,
-    computation,
-    horizontal,
-    interval,
-    region,
-)
-
 from ndsl import Quantity, QuantityFactory, StencilFactory, orchestrate
 from ndsl.constants import X_DIM, X_INTERFACE_DIM, Y_DIM, Y_INTERFACE_DIM, Z_DIM
+from ndsl.dsl.gt4py import PARALLEL, computation, horizontal, interval, region  # noqa
 from ndsl.dsl.typing import Float, FloatField, FloatFieldIJ
 from ndsl.grid import GridData
 from ndsl.stencils import corners
 from pyFV3.stencils.d2a2c_vect import DGrid2AGrid2CGridVectors
+
 
 from gt4py.cartesian.gtscript import __INLINED  # isort:skip
 

--- a/pyFV3/stencils/d2a2c_vect.py
+++ b/pyFV3/stencils/d2a2c_vect.py
@@ -1,5 +1,4 @@
-import gt4py.cartesian.gtscript as gtscript
-from gt4py.cartesian.gtscript import PARALLEL, computation, horizontal, interval, region
+from ndsl.dsl.gt4py import PARALLEL, function, computation, horizontal, interval, region
 
 from ndsl import QuantityFactory, StencilFactory, orchestrate
 from ndsl.constants import X_DIM, Y_DIM, Z_DIM
@@ -22,7 +21,7 @@ def set_tmps(utmp: FloatField, vtmp: FloatField, big_number: Float):
 
 
 # almost the same as a2b_ord4's version
-@gtscript.function
+@function
 def lagrange_y_func_p1(qx):
     return a2 * (qx[0, -1, 0] + qx[0, 2, 0]) + a1 * (qx + qx[0, 1, 0])
 
@@ -32,7 +31,7 @@ def lagrange_interpolation_y_p1(qx: FloatField, qout: FloatField):
         qout = lagrange_y_func_p1(qx)
 
 
-@gtscript.function
+@function
 def lagrange_x_func_p1(qy):
     return a2 * (qy[-1, 0, 0] + qy[2, 0, 0]) + a1 * (qy + qy[1, 0, 0])
 
@@ -219,7 +218,7 @@ def vt_main(
         vt = contravariant(vc, u, cosa_v, rsin_v)
 
 
-@gtscript.function
+@function
 def contravariant(v1, v2, cosa, rsin2):
     """
     Retrieve the contravariant component of the wind from its covariant
@@ -290,22 +289,22 @@ def contravariant_stencil(
         out = contravariant(u, v, cosa, rsin)
 
 
-@gtscript.function
+@function
 def vol_conserv_cubic_interp_func_x(u):
     return c1 * u[-2, 0, 0] + c2 * u[-1, 0, 0] + c3 * u
 
 
-@gtscript.function
+@function
 def vol_conserv_cubic_interp_func_x_rev(u):
     return c1 * u[1, 0, 0] + c2 * u + c3 * u[-1, 0, 0]
 
 
-@gtscript.function
+@function
 def vol_conserv_cubic_interp_func_y(v):
     return c1 * v[0, -2, 0] + c2 * v[0, -1, 0] + c3 * v
 
 
-@gtscript.function
+@function
 def vol_conserv_cubic_interp_func_y_rev(v):
     return c1 * v[0, 1, 0] + c2 * v + c3 * v[0, -1, 0]
 
@@ -357,7 +356,7 @@ def vc_y_edge1(
         vc = vt * sin_sg4[0, -1] if vt > 0 else vt * sin_sg2
 
 
-@gtscript.function
+@function
 def edge_interpolate4_x(ua, dxa):
     t1 = dxa[-2, 0] + dxa[-1, 0]
     t2 = dxa[0, 0] + dxa[1, 0]
@@ -366,7 +365,7 @@ def edge_interpolate4_x(ua, dxa):
     return 0.5 * (n1 / t1 + n2 / t2)
 
 
-@gtscript.function
+@function
 def edge_interpolate4_y(va, dya):
     t1 = dya[0, -2] + dya[0, -1]
     t2 = dya[0, 0] + dya[0, 1]

--- a/pyFV3/stencils/d2a2c_vect.py
+++ b/pyFV3/stencils/d2a2c_vect.py
@@ -1,7 +1,6 @@
-from ndsl.dsl.gt4py import PARALLEL, function, computation, horizontal, interval, region
-
 from ndsl import QuantityFactory, StencilFactory, orchestrate
 from ndsl.constants import X_DIM, Y_DIM, Z_DIM
+from ndsl.dsl.gt4py import PARALLEL, computation, function, horizontal, interval, region
 from ndsl.dsl.typing import Float, FloatField, FloatFieldIJ
 from ndsl.grid import GridData
 from ndsl.stencils import corners

--- a/pyFV3/stencils/d2a2c_vect.py
+++ b/pyFV3/stencils/d2a2c_vect.py
@@ -1,6 +1,8 @@
 from ndsl import QuantityFactory, StencilFactory, orchestrate
 from ndsl.constants import X_DIM, Y_DIM, Z_DIM
-from ndsl.dsl.gt4py import PARALLEL, computation, function, horizontal, interval, region
+from ndsl.dsl.gt4py import PARALLEL, computation
+from ndsl.dsl.gt4py import function as gtfunction
+from ndsl.dsl.gt4py import horizontal, interval, region
 from ndsl.dsl.typing import Float, FloatField, FloatFieldIJ
 from ndsl.grid import GridData
 from ndsl.stencils import corners
@@ -20,7 +22,7 @@ def set_tmps(utmp: FloatField, vtmp: FloatField, big_number: Float):
 
 
 # almost the same as a2b_ord4's version
-@function
+@gtfunction
 def lagrange_y_func_p1(qx):
     return a2 * (qx[0, -1, 0] + qx[0, 2, 0]) + a1 * (qx + qx[0, 1, 0])
 
@@ -30,7 +32,7 @@ def lagrange_interpolation_y_p1(qx: FloatField, qout: FloatField):
         qout = lagrange_y_func_p1(qx)
 
 
-@function
+@gtfunction
 def lagrange_x_func_p1(qy):
     return a2 * (qy[-1, 0, 0] + qy[2, 0, 0]) + a1 * (qy + qy[1, 0, 0])
 
@@ -217,7 +219,7 @@ def vt_main(
         vt = contravariant(vc, u, cosa_v, rsin_v)
 
 
-@function
+@gtfunction
 def contravariant(v1, v2, cosa, rsin2):
     """
     Retrieve the contravariant component of the wind from its covariant
@@ -288,22 +290,22 @@ def contravariant_stencil(
         out = contravariant(u, v, cosa, rsin)
 
 
-@function
+@gtfunction
 def vol_conserv_cubic_interp_func_x(u):
     return c1 * u[-2, 0, 0] + c2 * u[-1, 0, 0] + c3 * u
 
 
-@function
+@gtfunction
 def vol_conserv_cubic_interp_func_x_rev(u):
     return c1 * u[1, 0, 0] + c2 * u + c3 * u[-1, 0, 0]
 
 
-@function
+@gtfunction
 def vol_conserv_cubic_interp_func_y(v):
     return c1 * v[0, -2, 0] + c2 * v[0, -1, 0] + c3 * v
 
 
-@function
+@gtfunction
 def vol_conserv_cubic_interp_func_y_rev(v):
     return c1 * v[0, 1, 0] + c2 * v + c3 * v[0, -1, 0]
 
@@ -355,7 +357,7 @@ def vc_y_edge1(
         vc = vt * sin_sg4[0, -1] if vt > 0 else vt * sin_sg2
 
 
-@function
+@gtfunction
 def edge_interpolate4_x(ua, dxa):
     t1 = dxa[-2, 0] + dxa[-1, 0]
     t2 = dxa[0, 0] + dxa[1, 0]
@@ -364,7 +366,7 @@ def edge_interpolate4_x(ua, dxa):
     return 0.5 * (n1 / t1 + n2 / t2)
 
 
-@function
+@gtfunction
 def edge_interpolate4_y(va, dya):
     t1 = dya[0, -2] + dya[0, -1]
     t2 = dya[0, 0] + dya[0, 1]

--- a/pyFV3/stencils/d_sw.py
+++ b/pyFV3/stencils/d_sw.py
@@ -1,16 +1,8 @@
 from typing import Dict, Mapping
 
-from ndsl.dsl.gt4py import (
-    PARALLEL,
-    function,
-    computation,
-    horizontal,
-    interval,
-    region,
-)
-
 from ndsl import Quantity, QuantityFactory, StencilFactory, orchestrate
 from ndsl.constants import X_DIM, X_INTERFACE_DIM, Y_DIM, Y_INTERFACE_DIM, Z_DIM
+from ndsl.dsl.gt4py import PARALLEL, computation, function, horizontal, interval, region
 from ndsl.dsl.typing import Float, FloatField, FloatFieldIJ, FloatFieldK
 from ndsl.grid import DampingCoefficients, GridData
 from pyFV3._config import DGridShallowWaterLagrangianDynamicsConfig
@@ -23,6 +15,7 @@ from pyFV3.stencils.fxadv import FiniteVolumeFluxPrep
 from pyFV3.stencils.xtp_u import advect_u_along_x
 from pyFV3.stencils.ytp_v import advect_v_along_y
 from pyFV3.version import IS_GEOS
+
 
 from gt4py.cartesian.gtscript import __INLINED  # isort:skip
 

--- a/pyFV3/stencils/d_sw.py
+++ b/pyFV3/stencils/d_sw.py
@@ -1,9 +1,8 @@
 from typing import Dict, Mapping
 
-import gt4py.cartesian.gtscript as gtscript
-from gt4py.cartesian.gtscript import (
-    __INLINED,
+from ndsl.dsl.gt4py import (
     PARALLEL,
+    function,
     computation,
     horizontal,
     interval,
@@ -25,6 +24,7 @@ from pyFV3.stencils.xtp_u import advect_u_along_x
 from pyFV3.stencils.ytp_v import advect_v_along_y
 from pyFV3.version import IS_GEOS
 
+from gt4py.cartesian.gtscript import __INLINED  # isort:skip
 
 dcon_threshold = 1e-5
 
@@ -102,7 +102,7 @@ def heat_diss(
             diss_est = heat_source
 
 
-@gtscript.function
+@function
 def flux_increment(gx, gy, rarea):
     """
     Args:
@@ -144,7 +144,7 @@ def apply_fluxes(
         q = q * delp + flux_increment(gx, gy, rarea)
 
 
-@gtscript.function
+@function
 def apply_pt_delp_fluxes(
     pt_x_flux: FloatField,
     pt_y_flux: FloatField,
@@ -261,7 +261,7 @@ def compute_kinetic_energy(
         )
 
 
-@gtscript.function
+@function
 def corner_ke(
     u,
     v,
@@ -286,7 +286,7 @@ def corner_ke(
     )
 
 
-@gtscript.function
+@function
 def all_corners_ke(ke, u, v, ut, vt, dt):
     from __externals__ import i_end, i_start, j_end, j_start
 
@@ -386,7 +386,7 @@ def vort_differencing(
 
 
 # TODO: This is untested and the radius may be incorrect
-@gtscript.function
+@function
 def coriolis_force_correction(zh, radius):
     return 1.0 + (zh + zh[0, 0, 1]) / radius
 
@@ -407,7 +407,7 @@ def rel_vorticity_to_abs(
         absolute_vorticity = relative_vorticity + f0
 
 
-@gtscript.function
+@function
 def u_from_ke(ke, u, dx, fy):
     """
     Described in section 5.2 eq 5.3d and 5.3e of FV3 docs.
@@ -435,7 +435,7 @@ def u_from_ke(ke, u, dx, fy):
     return u * dx + ke - ke[1, 0, 0] + fy
 
 
-@gtscript.function
+@function
 def v_from_ke(ke, v, dy, fx):
     # see docstring for u_from_ke
     return v * dy + ke - ke[0, 1, 0] - fx
@@ -482,7 +482,7 @@ def u_and_v_from_ke(
             v = v_from_ke(ke, v, dy, fx)
 
 
-@gtscript.function
+@function
 def heat_damping_term(ub, vb, gx, gy, rsin2, cosa_s, u2, v2, du2, dv2):
     return (
         rsin2
@@ -739,7 +739,7 @@ def get_column_namelist(
     return col
 
 
-@gtscript.function
+@function
 def interpolate_uc_vc_to_cell_corners(
     uc_cov, vc_cov, cosa, rsina, uc_contra, vc_contra
 ):

--- a/pyFV3/stencils/d_sw.py
+++ b/pyFV3/stencils/d_sw.py
@@ -2,7 +2,9 @@ from typing import Dict, Mapping
 
 from ndsl import Quantity, QuantityFactory, StencilFactory, orchestrate
 from ndsl.constants import X_DIM, X_INTERFACE_DIM, Y_DIM, Y_INTERFACE_DIM, Z_DIM
-from ndsl.dsl.gt4py import PARALLEL, computation, function, horizontal, interval, region
+from ndsl.dsl.gt4py import PARALLEL, computation
+from ndsl.dsl.gt4py import function as gtfunction
+from ndsl.dsl.gt4py import horizontal, interval, region
 from ndsl.dsl.typing import Float, FloatField, FloatFieldIJ, FloatFieldK
 from ndsl.grid import DampingCoefficients, GridData
 from pyFV3._config import DGridShallowWaterLagrangianDynamicsConfig
@@ -95,7 +97,7 @@ def heat_diss(
             diss_est = heat_source
 
 
-@function
+@gtfunction
 def flux_increment(gx, gy, rarea):
     """
     Args:
@@ -137,7 +139,7 @@ def apply_fluxes(
         q = q * delp + flux_increment(gx, gy, rarea)
 
 
-@function
+@gtfunction
 def apply_pt_delp_fluxes(
     pt_x_flux: FloatField,
     pt_y_flux: FloatField,
@@ -254,7 +256,7 @@ def compute_kinetic_energy(
         )
 
 
-@function
+@gtfunction
 def corner_ke(
     u,
     v,
@@ -279,7 +281,7 @@ def corner_ke(
     )
 
 
-@function
+@gtfunction
 def all_corners_ke(ke, u, v, ut, vt, dt):
     from __externals__ import i_end, i_start, j_end, j_start
 
@@ -379,7 +381,7 @@ def vort_differencing(
 
 
 # TODO: This is untested and the radius may be incorrect
-@function
+@gtfunction
 def coriolis_force_correction(zh, radius):
     return 1.0 + (zh + zh[0, 0, 1]) / radius
 
@@ -400,7 +402,7 @@ def rel_vorticity_to_abs(
         absolute_vorticity = relative_vorticity + f0
 
 
-@function
+@gtfunction
 def u_from_ke(ke, u, dx, fy):
     """
     Described in section 5.2 eq 5.3d and 5.3e of FV3 docs.
@@ -428,7 +430,7 @@ def u_from_ke(ke, u, dx, fy):
     return u * dx + ke - ke[1, 0, 0] + fy
 
 
-@function
+@gtfunction
 def v_from_ke(ke, v, dy, fx):
     # see docstring for u_from_ke
     return v * dy + ke - ke[0, 1, 0] - fx
@@ -475,7 +477,7 @@ def u_and_v_from_ke(
             v = v_from_ke(ke, v, dy, fx)
 
 
-@function
+@gtfunction
 def heat_damping_term(ub, vb, gx, gy, rsin2, cosa_s, u2, v2, du2, dv2):
     return (
         rsin2
@@ -732,7 +734,7 @@ def get_column_namelist(
     return col
 
 
-@function
+@gtfunction
 def interpolate_uc_vc_to_cell_corners(
     uc_cov, vc_cov, cosa, rsina, uc_contra, vc_contra
 ):

--- a/pyFV3/stencils/del2cubed.py
+++ b/pyFV3/stencils/del2cubed.py
@@ -1,4 +1,4 @@
-from gt4py.cartesian.gtscript import PARALLEL, computation, horizontal, interval, region
+from ndsl.dsl.gt4py import PARALLEL, computation, horizontal, interval, region
 
 import ndsl.stencils.corners as corners
 from ndsl import QuantityFactory, StencilFactory, orchestrate

--- a/pyFV3/stencils/del2cubed.py
+++ b/pyFV3/stencils/del2cubed.py
@@ -1,8 +1,7 @@
-from ndsl.dsl.gt4py import PARALLEL, computation, horizontal, interval, region
-
 import ndsl.stencils.corners as corners
 from ndsl import QuantityFactory, StencilFactory, orchestrate
 from ndsl.constants import X_DIM, X_INTERFACE_DIM, Y_DIM, Y_INTERFACE_DIM, Z_DIM
+from ndsl.dsl.gt4py import PARALLEL, computation, horizontal, interval, region
 from ndsl.dsl.stencil import get_stencils_with_varied_bounds
 from ndsl.dsl.typing import Float, FloatField, FloatFieldIJ, cast_to_index3d
 from ndsl.grid import DampingCoefficients

--- a/pyFV3/stencils/delnflux.py
+++ b/pyFV3/stencils/delnflux.py
@@ -2,7 +2,9 @@ from typing import Optional
 
 from ndsl import Quantity, QuantityFactory, StencilFactory, orchestrate
 from ndsl.constants import X_DIM, X_INTERFACE_DIM, Y_DIM, Y_INTERFACE_DIM, Z_DIM
-from ndsl.dsl.gt4py import PARALLEL, computation, function, horizontal, interval, region
+from ndsl.dsl.gt4py import PARALLEL, computation
+from ndsl.dsl.gt4py import function as gtfunction
+from ndsl.dsl.gt4py import horizontal, interval, region
 from ndsl.dsl.stencil import get_stencils_with_varied_bounds
 from ndsl.dsl.typing import Float, FloatField, FloatFieldIJ, FloatFieldK
 from ndsl.grid import DampingCoefficients
@@ -88,22 +90,22 @@ def fy_calc_stencil_column(
             fy = fy_calculation_neg(q, del6_u)
 
 
-@function
+@gtfunction
 def fx_calculation(q: FloatField, del6_v: FloatField):
     return del6_v * (q[-1, 0, 0] - q)
 
 
-@function
+@gtfunction
 def fx_calculation_neg(q: FloatField, del6_v: FloatField):
     return -del6_v * (q[-1, 0, 0] - q)
 
 
-@function
+@gtfunction
 def fy_calculation(q: FloatField, del6_u: FloatField):
     return del6_u * (q[0, -1, 0] - q)
 
 
-@function
+@gtfunction
 def fy_calculation_neg(q: FloatField, del6_u: FloatField):
     return -del6_u * (q[0, -1, 0] - q)
 

--- a/pyFV3/stencils/delnflux.py
+++ b/pyFV3/stencils/delnflux.py
@@ -1,7 +1,7 @@
 from typing import Optional
 
-import gt4py.cartesian.gtscript as gtscript
-from gt4py.cartesian.gtscript import PARALLEL, computation, horizontal, interval, region
+
+from ndsl.dsl.gt4py import PARALLEL, function, computation, horizontal, interval, region
 
 from ndsl import Quantity, QuantityFactory, StencilFactory, orchestrate
 from ndsl.constants import X_DIM, X_INTERFACE_DIM, Y_DIM, Y_INTERFACE_DIM, Z_DIM
@@ -90,22 +90,22 @@ def fy_calc_stencil_column(
             fy = fy_calculation_neg(q, del6_u)
 
 
-@gtscript.function
+@function
 def fx_calculation(q: FloatField, del6_v: FloatField):
     return del6_v * (q[-1, 0, 0] - q)
 
 
-@gtscript.function
+@function
 def fx_calculation_neg(q: FloatField, del6_v: FloatField):
     return -del6_v * (q[-1, 0, 0] - q)
 
 
-@gtscript.function
+@function
 def fy_calculation(q: FloatField, del6_u: FloatField):
     return del6_u * (q[0, -1, 0] - q)
 
 
-@gtscript.function
+@function
 def fy_calculation_neg(q: FloatField, del6_u: FloatField):
     return -del6_u * (q[0, -1, 0] - q)
 

--- a/pyFV3/stencils/delnflux.py
+++ b/pyFV3/stencils/delnflux.py
@@ -1,10 +1,8 @@
 from typing import Optional
 
-
-from ndsl.dsl.gt4py import PARALLEL, function, computation, horizontal, interval, region
-
 from ndsl import Quantity, QuantityFactory, StencilFactory, orchestrate
 from ndsl.constants import X_DIM, X_INTERFACE_DIM, Y_DIM, Y_INTERFACE_DIM, Z_DIM
+from ndsl.dsl.gt4py import PARALLEL, computation, function, horizontal, interval, region
 from ndsl.dsl.stencil import get_stencils_with_varied_bounds
 from ndsl.dsl.typing import Float, FloatField, FloatFieldIJ, FloatFieldK
 from ndsl.grid import DampingCoefficients

--- a/pyFV3/stencils/divergence_damping.py
+++ b/pyFV3/stencils/divergence_damping.py
@@ -1,24 +1,25 @@
 import numpy as np
-from ndsl.dsl.gt4py import (
-    PARALLEL,
-    function,
-    computation,
-    horizontal,
-    interval,
-    region,
-    sqrt,
-)
 
 import ndsl.stencils.basic_operations as basic
 import ndsl.stencils.corners as corners
 from ndsl import Quantity, QuantityFactory, StencilFactory
 from ndsl.constants import X_DIM, X_INTERFACE_DIM, Y_DIM, Y_INTERFACE_DIM, Z_DIM
 from ndsl.dsl.dace.orchestration import dace_inhibitor, orchestrate
+from ndsl.dsl.gt4py import (
+    PARALLEL,
+    computation,
+    function,
+    horizontal,
+    interval,
+    region,
+    sqrt,
+)
 from ndsl.dsl.stencil import get_stencils_with_varied_bounds
 from ndsl.dsl.typing import Float, FloatField, FloatFieldIJ, FloatFieldK
 from ndsl.grid import DampingCoefficients, GridData
 from pyFV3.stencils.a2b_ord4 import AGrid2BGridFourthOrder, doubly_periodic_a2b_ord4
 from pyFV3.stencils.d2a2c_vect import contravariant
+
 
 from gt4py.cartesian.gtscript import __INLINED  # isort:skip
 
@@ -251,7 +252,7 @@ def smagorinsky_diffusion_approx(delpc: FloatField, vort: FloatField, absdt: Flo
         absdt (in): abs(dt)
     """
     with computation(PARALLEL), interval(...):
-        vort = absdt * (delpc**2.0 + vort**2.0) ** 0.5
+        vort = absdt * (delpc ** 2.0 + vort ** 2.0) ** 0.5
 
 
 def smag_corner(
@@ -295,7 +296,7 @@ def smag_corner(
         wk = rarea * (vt2 - vt2[0, 1, 0] + ut2 - ut2[1, 0, 0])
 
         shear = doubly_periodic_a2b_ord4(wk)
-        smag_c = dt * sqrt(shear**2 + smag_c_t**2)
+        smag_c = dt * sqrt(shear ** 2 + smag_c_t ** 2)
 
 
 class DivergenceDamping:

--- a/pyFV3/stencils/divergence_damping.py
+++ b/pyFV3/stencils/divergence_damping.py
@@ -5,15 +5,9 @@ import ndsl.stencils.corners as corners
 from ndsl import Quantity, QuantityFactory, StencilFactory
 from ndsl.constants import X_DIM, X_INTERFACE_DIM, Y_DIM, Y_INTERFACE_DIM, Z_DIM
 from ndsl.dsl.dace.orchestration import dace_inhibitor, orchestrate
-from ndsl.dsl.gt4py import (
-    PARALLEL,
-    computation,
-    function,
-    horizontal,
-    interval,
-    region,
-    sqrt,
-)
+from ndsl.dsl.gt4py import PARALLEL, computation
+from ndsl.dsl.gt4py import function as gtfunction
+from ndsl.dsl.gt4py import horizontal, interval, region, sqrt
 from ndsl.dsl.stencil import get_stencils_with_varied_bounds
 from ndsl.dsl.typing import Float, FloatField, FloatFieldIJ, FloatFieldK
 from ndsl.grid import DampingCoefficients, GridData
@@ -24,7 +18,7 @@ from pyFV3.stencils.d2a2c_vect import contravariant
 from gt4py.cartesian.gtscript import __INLINED  # isort:skip
 
 
-@function
+@gtfunction
 def damp_tmp(q, da_min_c, d2_bg, dddmp):
     mintmp = min(0.2, dddmp * abs(q))
     damp = da_min_c * max(d2_bg, mintmp)

--- a/pyFV3/stencils/divergence_damping.py
+++ b/pyFV3/stencils/divergence_damping.py
@@ -1,8 +1,7 @@
-import gt4py.cartesian.gtscript as gtscript
 import numpy as np
-from gt4py.cartesian.gtscript import (
-    __INLINED,
+from ndsl.dsl.gt4py import (
     PARALLEL,
+    function,
     computation,
     horizontal,
     interval,
@@ -21,8 +20,10 @@ from ndsl.grid import DampingCoefficients, GridData
 from pyFV3.stencils.a2b_ord4 import AGrid2BGridFourthOrder, doubly_periodic_a2b_ord4
 from pyFV3.stencils.d2a2c_vect import contravariant
 
+from gt4py.cartesian.gtscript import __INLINED  # isort:skip
 
-@gtscript.function
+
+@function
 def damp_tmp(q, da_min_c, d2_bg, dddmp):
     mintmp = min(0.2, dddmp * abs(q))
     damp = da_min_c * max(d2_bg, mintmp)
@@ -250,7 +251,7 @@ def smagorinsky_diffusion_approx(delpc: FloatField, vort: FloatField, absdt: Flo
         absdt (in): abs(dt)
     """
     with computation(PARALLEL), interval(...):
-        vort = absdt * (delpc ** 2.0 + vort ** 2.0) ** 0.5
+        vort = absdt * (delpc**2.0 + vort**2.0) ** 0.5
 
 
 def smag_corner(
@@ -294,7 +295,7 @@ def smag_corner(
         wk = rarea * (vt2 - vt2[0, 1, 0] + ut2 - ut2[1, 0, 0])
 
         shear = doubly_periodic_a2b_ord4(wk)
-        smag_c = dt * sqrt(shear ** 2 + smag_c_t ** 2)
+        smag_c = dt * sqrt(shear**2 + smag_c_t**2)
 
 
 class DivergenceDamping:

--- a/pyFV3/stencils/dyn_core.py
+++ b/pyFV3/stencils/dyn_core.py
@@ -2,8 +2,7 @@ from typing import Dict, Mapping, Optional
 
 import numpy as np
 from dace.frontend.python.interface import nounroll as dace_nounroll
-from gt4py.cartesian.gtscript import (
-    __INLINED,
+from ndsl.dsl.gt4py import (
     BACKWARD,
     FORWARD,
     PARALLEL,
@@ -51,6 +50,7 @@ from pyFV3.stencils.pk3_halo import PK3Halo
 from pyFV3.stencils.riem_solver3 import NonhydrostaticVerticalSolver
 from pyFV3.stencils.riem_solver_c import NonhydrostaticVerticalSolverCGrid
 
+from gt4py.cartesian.gtscript import __INLINED  # isort:skip
 
 if Float == np.float32:
     HUGE_R = Float(1.0e8)

--- a/pyFV3/stencils/dyn_core.py
+++ b/pyFV3/stencils/dyn_core.py
@@ -2,15 +2,6 @@ from typing import Dict, Mapping, Optional
 
 import numpy as np
 from dace.frontend.python.interface import nounroll as dace_nounroll
-from ndsl.dsl.gt4py import (
-    BACKWARD,
-    FORWARD,
-    PARALLEL,
-    computation,
-    horizontal,
-    interval,
-    region,
-)
 
 import ndsl.constants as constants
 import ndsl.stencils.basic_operations as basic
@@ -39,6 +30,15 @@ from ndsl.constants import (
     Z_INTERFACE_DIM,
 )
 from ndsl.dsl.dace.orchestration import dace_inhibitor
+from ndsl.dsl.gt4py import (
+    BACKWARD,
+    FORWARD,
+    PARALLEL,
+    computation,
+    horizontal,
+    interval,
+    region,
+)
 from ndsl.dsl.typing import Float, FloatField, FloatFieldIJ
 from ndsl.grid import DampingCoefficients, GridData
 from ndsl.typing import Checkpointer, Communicator
@@ -49,6 +49,7 @@ from pyFV3.stencils.del2cubed import HyperdiffusionDamping
 from pyFV3.stencils.pk3_halo import PK3Halo
 from pyFV3.stencils.riem_solver3 import NonhydrostaticVerticalSolver
 from pyFV3.stencils.riem_solver_c import NonhydrostaticVerticalSolverCGrid
+
 
 from gt4py.cartesian.gtscript import __INLINED  # isort:skip
 

--- a/pyFV3/stencils/fillz.py
+++ b/pyFV3/stencils/fillz.py
@@ -1,11 +1,10 @@
 import typing
 from typing import Dict
 
-from ndsl.dsl.gt4py import BACKWARD, FORWARD, PARALLEL, computation, interval
-
 import ndsl.dsl.gt4py_utils as utils
 from ndsl import Quantity, QuantityFactory, StencilFactory, orchestrate
 from ndsl.constants import X_DIM, Y_DIM, Z_DIM
+from ndsl.dsl.gt4py import BACKWARD, FORWARD, PARALLEL, computation, interval
 from ndsl.dsl.typing import Float, FloatField, FloatFieldIJ, IntFieldIJ
 
 

--- a/pyFV3/stencils/fillz.py
+++ b/pyFV3/stencils/fillz.py
@@ -1,7 +1,7 @@
 import typing
 from typing import Dict
 
-from gt4py.cartesian.gtscript import BACKWARD, FORWARD, PARALLEL, computation, interval
+from ndsl.dsl.gt4py import BACKWARD, FORWARD, PARALLEL, computation, interval
 
 import ndsl.dsl.gt4py_utils as utils
 from ndsl import Quantity, QuantityFactory, StencilFactory, orchestrate

--- a/pyFV3/stencils/fv_dynamics.py
+++ b/pyFV3/stencils/fv_dynamics.py
@@ -2,7 +2,7 @@ from datetime import timedelta
 from typing import Mapping, Optional
 
 from dace.frontend.python.interface import nounroll as dace_no_unroll
-from gt4py.cartesian.gtscript import PARALLEL, computation, interval
+from ndsl.dsl.gt4py import PARALLEL, computation, interval
 
 import ndsl.dsl.gt4py_utils as utils
 import pyFV3.stencils.moist_cv as moist_cv

--- a/pyFV3/stencils/fv_dynamics.py
+++ b/pyFV3/stencils/fv_dynamics.py
@@ -2,7 +2,6 @@ from datetime import timedelta
 from typing import Mapping, Optional
 
 from dace.frontend.python.interface import nounroll as dace_no_unroll
-from ndsl.dsl.gt4py import PARALLEL, computation, interval
 
 import ndsl.dsl.gt4py_utils as utils
 import pyFV3.stencils.moist_cv as moist_cv
@@ -11,6 +10,7 @@ from ndsl.checkpointer import NullCheckpointer
 from ndsl.comm.mpi import MPI
 from ndsl.constants import KAPPA, NQ, X_DIM, Y_DIM, Z_DIM, Z_INTERFACE_DIM, ZVIR
 from ndsl.dsl.dace.orchestration import dace_inhibitor, orchestrate
+from ndsl.dsl.gt4py import PARALLEL, computation, interval
 from ndsl.dsl.typing import Float, FloatField
 from ndsl.grid import DampingCoefficients, GridData
 from ndsl.logging import ndsl_log

--- a/pyFV3/stencils/fv_subgridz.py
+++ b/pyFV3/stencils/fv_subgridz.py
@@ -1,14 +1,6 @@
 # mypy: ignore-errors
 import collections
 
-from ndsl.dsl.gt4py import (
-    function,
-    BACKWARD,
-    PARALLEL,
-    computation,
-    interval,
-)
-
 import ndsl.dsl.gt4py_utils as utils
 from ndsl import Quantity, QuantityFactory, StencilFactory
 from ndsl.constants import (
@@ -25,9 +17,11 @@ from ndsl.constants import (
     Z_DIM,
     ZVIR,
 )
+from ndsl.dsl.gt4py import BACKWARD, PARALLEL, computation, function, interval
 from ndsl.dsl.typing import Float, FloatField
 from ndsl.stencils.basic_operations import dim
 from pyFV3.dycore_state import DycoreState
+
 
 from gt4py.cartesian.gtscript import __INLINED  # isort:skip
 
@@ -63,7 +57,7 @@ def standard_cm(cpm, cvm, q0_vapor, q0_liquid, q0_rain, q0_ice, q0_snow, q0_grau
 
 @function
 def tvol(gz, u0, v0, w0):
-    return gz + 0.5 * (u0**2 + v0**2 + w0**2)
+    return gz + 0.5 * (u0 ** 2 + v0 ** 2 + w0 ** 2)
 
 
 def init(

--- a/pyFV3/stencils/fv_subgridz.py
+++ b/pyFV3/stencils/fv_subgridz.py
@@ -1,9 +1,8 @@
 # mypy: ignore-errors
 import collections
 
-import gt4py.cartesian.gtscript as gtscript
-from gt4py.cartesian.gtscript import (
-    __INLINED,
+from ndsl.dsl.gt4py import (
+    function,
     BACKWARD,
     PARALLEL,
     computation,
@@ -30,6 +29,7 @@ from ndsl.dsl.typing import Float, FloatField
 from ndsl.stencils.basic_operations import dim
 from pyFV3.dycore_state import DycoreState
 
+from gt4py.cartesian.gtscript import __INLINED  # isort:skip
 
 RK = CP_AIR / RDGAS + 1.0
 G2 = 0.5 * GRAV
@@ -42,7 +42,7 @@ RI_MAX = 1.0
 RI_MIN = 0.25
 
 
-@gtscript.function
+@function
 def standard_cm(cpm, cvm, q0_vapor, q0_liquid, q0_rain, q0_ice, q0_snow, q0_graupel):
     q_liq = q0_liquid + q0_rain
     q_sol = q0_ice + q0_snow + q0_graupel
@@ -61,9 +61,9 @@ def standard_cm(cpm, cvm, q0_vapor, q0_liquid, q0_rain, q0_ice, q0_snow, q0_grau
     return cpm, cvm
 
 
-@gtscript.function
+@function
 def tvol(gz, u0, v0, w0):
-    return gz + 0.5 * (u0 ** 2 + v0 ** 2 + w0 ** 2)
+    return gz + 0.5 * (u0**2 + v0**2 + w0**2)
 
 
 def init(
@@ -128,12 +128,12 @@ def init(
         gzh = gzh[0, 0, 1] - GRAV * delz
 
 
-@gtscript.function
+@function
 def qcon_func(q0_liquid, q0_ice, q0_snow, q0_rain, q0_graupel):
     return q0_liquid + q0_ice + q0_snow + q0_rain + q0_graupel
 
 
-@gtscript.function
+@function
 def adjust_cvm(
     cpm,
     cvm,
@@ -163,7 +163,7 @@ def adjust_cvm(
     return cpm, cvm, t0, static_energy
 
 
-@gtscript.function
+@function
 def compute_richardson_number(
     t0, q0_vapor, qcon, pkz, delp, peln, gz, u0, v0, xvir, t_max, t_min
 ):
@@ -193,7 +193,7 @@ def compute_richardson_number(
     return ri, ri_ref
 
 
-@gtscript.function
+@function
 def compute_mass_flux(ri, ri_ref, delp, ratio):
     max_ri_ratio = ri / ri_ref
     mc = 0.0
@@ -210,19 +210,19 @@ def compute_mass_flux(ri, ri_ref, delp, ratio):
     return mc
 
 
-@gtscript.function
+@function
 def kh_adjust_down(mc, delp, q0, h0):
     h0 = mc * (q0 - q0[0, 0, -1])
     return q0 - h0 / delp, h0
 
 
-@gtscript.function
+@function
 def kh_adjust_energy_down(mc, delp, static_energy, total_energy, h0):
     h0 = mc * (static_energy - static_energy[0, 0, -1])
     return total_energy - h0 / delp, h0
 
 
-@gtscript.function
+@function
 def kh_adjust_up(delp, h0, q0):
     return q0 + h0[0, 0, 1] / delp
 
@@ -659,7 +659,7 @@ def m_loop(
             )
 
 
-@gtscript.function
+@function
 def readjust_by_frac(a0, a, fra):
     return a + (a0 - a) * fra
 

--- a/pyFV3/stencils/fv_subgridz.py
+++ b/pyFV3/stencils/fv_subgridz.py
@@ -17,7 +17,9 @@ from ndsl.constants import (
     Z_DIM,
     ZVIR,
 )
-from ndsl.dsl.gt4py import BACKWARD, PARALLEL, computation, function, interval
+from ndsl.dsl.gt4py import BACKWARD, PARALLEL, computation
+from ndsl.dsl.gt4py import function as gtfunction
+from ndsl.dsl.gt4py import interval
 from ndsl.dsl.typing import Float, FloatField
 from ndsl.stencils.basic_operations import dim
 from pyFV3.dycore_state import DycoreState
@@ -36,7 +38,7 @@ RI_MAX = 1.0
 RI_MIN = 0.25
 
 
-@function
+@gtfunction
 def standard_cm(cpm, cvm, q0_vapor, q0_liquid, q0_rain, q0_ice, q0_snow, q0_graupel):
     q_liq = q0_liquid + q0_rain
     q_sol = q0_ice + q0_snow + q0_graupel
@@ -55,7 +57,7 @@ def standard_cm(cpm, cvm, q0_vapor, q0_liquid, q0_rain, q0_ice, q0_snow, q0_grau
     return cpm, cvm
 
 
-@function
+@gtfunction
 def tvol(gz, u0, v0, w0):
     return gz + 0.5 * (u0 ** 2 + v0 ** 2 + w0 ** 2)
 
@@ -122,12 +124,12 @@ def init(
         gzh = gzh[0, 0, 1] - GRAV * delz
 
 
-@function
+@gtfunction
 def qcon_func(q0_liquid, q0_ice, q0_snow, q0_rain, q0_graupel):
     return q0_liquid + q0_ice + q0_snow + q0_rain + q0_graupel
 
 
-@function
+@gtfunction
 def adjust_cvm(
     cpm,
     cvm,
@@ -157,7 +159,7 @@ def adjust_cvm(
     return cpm, cvm, t0, static_energy
 
 
-@function
+@gtfunction
 def compute_richardson_number(
     t0, q0_vapor, qcon, pkz, delp, peln, gz, u0, v0, xvir, t_max, t_min
 ):
@@ -187,7 +189,7 @@ def compute_richardson_number(
     return ri, ri_ref
 
 
-@function
+@gtfunction
 def compute_mass_flux(ri, ri_ref, delp, ratio):
     max_ri_ratio = ri / ri_ref
     mc = 0.0
@@ -204,19 +206,19 @@ def compute_mass_flux(ri, ri_ref, delp, ratio):
     return mc
 
 
-@function
+@gtfunction
 def kh_adjust_down(mc, delp, q0, h0):
     h0 = mc * (q0 - q0[0, 0, -1])
     return q0 - h0 / delp, h0
 
 
-@function
+@gtfunction
 def kh_adjust_energy_down(mc, delp, static_energy, total_energy, h0):
     h0 = mc * (static_energy - static_energy[0, 0, -1])
     return total_energy - h0 / delp, h0
 
 
-@function
+@gtfunction
 def kh_adjust_up(delp, h0, q0):
     return q0 + h0[0, 0, 1] / delp
 
@@ -653,7 +655,7 @@ def m_loop(
             )
 
 
-@function
+@gtfunction
 def readjust_by_frac(a0, a, fra):
     return a + (a0 - a) * fra
 

--- a/pyFV3/stencils/fvtp2d.py
+++ b/pyFV3/stencils/fvtp2d.py
@@ -1,7 +1,6 @@
 from typing import Optional
 
-import gt4py.cartesian.gtscript as gtscript
-from gt4py.cartesian.gtscript import PARALLEL, computation, horizontal, interval, region
+from ndsl.dsl.gt4py import function, PARALLEL, computation, horizontal, interval, region
 
 import ndsl.stencils.corners as corners
 from ndsl import QuantityFactory, StencilFactory, orchestrate
@@ -13,7 +12,7 @@ from pyFV3.stencils.xppm import XPiecewiseParabolic
 from pyFV3.stencils.yppm import YPiecewiseParabolic
 
 
-@gtscript.function
+@function
 def apply_x_flux_divergence(q: FloatField, q_x_flux: FloatField) -> FloatField:
     """
     Update a scalar q according to its flux in the x direction.
@@ -21,7 +20,7 @@ def apply_x_flux_divergence(q: FloatField, q_x_flux: FloatField) -> FloatField:
     return q + q_x_flux - q_x_flux[1, 0, 0]
 
 
-@gtscript.function
+@function
 def apply_y_flux_divergence(q: FloatField, q_y_flux: FloatField) -> FloatField:
     """
     Update a scalar q according to its flux in the x direction.

--- a/pyFV3/stencils/fvtp2d.py
+++ b/pyFV3/stencils/fvtp2d.py
@@ -1,10 +1,9 @@
 from typing import Optional
 
-from ndsl.dsl.gt4py import function, PARALLEL, computation, horizontal, interval, region
-
 import ndsl.stencils.corners as corners
 from ndsl import QuantityFactory, StencilFactory, orchestrate
 from ndsl.constants import X_DIM, Y_DIM, Z_DIM
+from ndsl.dsl.gt4py import PARALLEL, computation, function, horizontal, interval, region
 from ndsl.dsl.typing import Float, FloatField, FloatFieldIJ
 from ndsl.grid import DampingCoefficients, GridData
 from pyFV3.stencils.delnflux import DelnFlux

--- a/pyFV3/stencils/fvtp2d.py
+++ b/pyFV3/stencils/fvtp2d.py
@@ -3,7 +3,9 @@ from typing import Optional
 import ndsl.stencils.corners as corners
 from ndsl import QuantityFactory, StencilFactory, orchestrate
 from ndsl.constants import X_DIM, Y_DIM, Z_DIM
-from ndsl.dsl.gt4py import PARALLEL, computation, function, horizontal, interval, region
+from ndsl.dsl.gt4py import PARALLEL, computation
+from ndsl.dsl.gt4py import function as gtfunction
+from ndsl.dsl.gt4py import horizontal, interval, region
 from ndsl.dsl.typing import Float, FloatField, FloatFieldIJ
 from ndsl.grid import DampingCoefficients, GridData
 from pyFV3.stencils.delnflux import DelnFlux
@@ -11,7 +13,7 @@ from pyFV3.stencils.xppm import XPiecewiseParabolic
 from pyFV3.stencils.yppm import YPiecewiseParabolic
 
 
-@function
+@gtfunction
 def apply_x_flux_divergence(q: FloatField, q_x_flux: FloatField) -> FloatField:
     """
     Update a scalar q according to its flux in the x direction.
@@ -19,7 +21,7 @@ def apply_x_flux_divergence(q: FloatField, q_x_flux: FloatField) -> FloatField:
     return q + q_x_flux - q_x_flux[1, 0, 0]
 
 
-@function
+@gtfunction
 def apply_y_flux_divergence(q: FloatField, q_y_flux: FloatField) -> FloatField:
     """
     Update a scalar q according to its flux in the x direction.

--- a/pyFV3/stencils/fxadv.py
+++ b/pyFV3/stencils/fxadv.py
@@ -1,15 +1,9 @@
-from ndsl.dsl.gt4py import (
-    PARALLEL,
-    computation,
-    horizontal,
-    interval,
-    region,
-)
-
 from ndsl import StencilFactory, orchestrate
+from ndsl.dsl.gt4py import PARALLEL, computation, horizontal, interval, region
 from ndsl.dsl.typing import Float, FloatField, FloatFieldIJ
 from ndsl.grid import GridData
 from pyFV3.stencils.d2a2c_vect import contravariant
+
 
 from gt4py.cartesian.gtscript import __INLINED  # isort:skip
 

--- a/pyFV3/stencils/fxadv.py
+++ b/pyFV3/stencils/fxadv.py
@@ -1,5 +1,4 @@
-from gt4py.cartesian.gtscript import (
-    __INLINED,
+from ndsl.dsl.gt4py import (
     PARALLEL,
     computation,
     horizontal,
@@ -11,6 +10,8 @@ from ndsl import StencilFactory, orchestrate
 from ndsl.dsl.typing import Float, FloatField, FloatFieldIJ
 from ndsl.grid import GridData
 from pyFV3.stencils.d2a2c_vect import contravariant
+
+from gt4py.cartesian.gtscript import __INLINED  # isort:skip
 
 
 def main_uc_vc_contra(

--- a/pyFV3/stencils/map_single.py
+++ b/pyFV3/stencils/map_single.py
@@ -1,6 +1,6 @@
 from typing import Optional, Sequence
 
-from gt4py.cartesian.gtscript import FORWARD, PARALLEL, computation, interval
+from ndsl.dsl.gt4py import FORWARD, PARALLEL, computation, interval
 
 from ndsl import QuantityFactory, StencilFactory, orchestrate
 from ndsl.constants import X_DIM, Y_DIM, Z_DIM

--- a/pyFV3/stencils/map_single.py
+++ b/pyFV3/stencils/map_single.py
@@ -1,9 +1,8 @@
 from typing import Optional, Sequence
 
-from ndsl.dsl.gt4py import FORWARD, PARALLEL, computation, interval
-
 from ndsl import QuantityFactory, StencilFactory, orchestrate
 from ndsl.constants import X_DIM, Y_DIM, Z_DIM
+from ndsl.dsl.gt4py import FORWARD, PARALLEL, computation, interval
 from ndsl.dsl.typing import Float, FloatField, FloatFieldIJ, IntFieldIJ  # noqa: F401
 from ndsl.stencils.basic_operations import copy_defn
 from pyFV3.stencils.remap_profile import RemapProfile

--- a/pyFV3/stencils/moist_cv.py
+++ b/pyFV3/stencils/moist_cv.py
@@ -1,6 +1,5 @@
-import gt4py.cartesian.gtscript as gtscript
-from gt4py.cartesian.gtscript import (
-    __INLINED,
+from ndsl.dsl.gt4py import (
+    function,
     PARALLEL,
     computation,
     exp,
@@ -11,14 +10,16 @@ from gt4py.cartesian.gtscript import (
 import ndsl.constants as constants
 from ndsl.dsl.typing import Float, FloatField
 
+from gt4py.cartesian.gtscript import __INLINED  # isort:skip
 
-@gtscript.function
+
+@function
 def set_cappa(qvapor, cvm, r_vir):
     cappa = constants.RDGAS / (constants.RDGAS + cvm / (1.0 + r_vir * qvapor))
     return cappa
 
 
-@gtscript.function
+@function
 def moist_cvm(qvapor, gz, ql, qs):
     cvm = (
         (1.0 - (qvapor + gz)) * constants.CV_AIR
@@ -29,7 +30,7 @@ def moist_cvm(qvapor, gz, ql, qs):
     return cvm
 
 
-@gtscript.function
+@function
 def moist_cv_nwat6_fn(
     qvapor: FloatField,
     qliquid: FloatField,
@@ -45,7 +46,7 @@ def moist_cv_nwat6_fn(
     return cvm, gz
 
 
-@gtscript.function
+@function
 def moist_pt_func(
     qvapor: FloatField,
     qliquid: FloatField,
@@ -69,7 +70,7 @@ def moist_pt_func(
     return cvm, gz, q_con, cappa, pt
 
 
-@gtscript.function
+@function
 def last_pt(
     pt: FloatField,
     dtmp: Float,
@@ -121,7 +122,7 @@ def moist_pt_last_step(
         #    pt = last_pt(pt, dtmp, pkz, gz, qvapor, zvir)
 
 
-@gtscript.function
+@function
 def compute_pkz_func(delp, delz, pt, cappa):
     # TODO use the exponential form for closer answer matching
     return exp(cappa * log(constants.RDG * delp / delz * pt))

--- a/pyFV3/stencils/moist_cv.py
+++ b/pyFV3/stencils/moist_cv.py
@@ -1,14 +1,7 @@
-from ndsl.dsl.gt4py import (
-    function,
-    PARALLEL,
-    computation,
-    exp,
-    interval,
-    log,
-)
-
 import ndsl.constants as constants
+from ndsl.dsl.gt4py import PARALLEL, computation, exp, function, interval, log
 from ndsl.dsl.typing import Float, FloatField
+
 
 from gt4py.cartesian.gtscript import __INLINED  # isort:skip
 

--- a/pyFV3/stencils/moist_cv.py
+++ b/pyFV3/stencils/moist_cv.py
@@ -1,18 +1,20 @@
 import ndsl.constants as constants
-from ndsl.dsl.gt4py import PARALLEL, computation, exp, function, interval, log
+from ndsl.dsl.gt4py import PARALLEL, computation, exp
+from ndsl.dsl.gt4py import function as gtfunction
+from ndsl.dsl.gt4py import interval, log
 from ndsl.dsl.typing import Float, FloatField
 
 
 from gt4py.cartesian.gtscript import __INLINED  # isort:skip
 
 
-@function
+@gtfunction
 def set_cappa(qvapor, cvm, r_vir):
     cappa = constants.RDGAS / (constants.RDGAS + cvm / (1.0 + r_vir * qvapor))
     return cappa
 
 
-@function
+@gtfunction
 def moist_cvm(qvapor, gz, ql, qs):
     cvm = (
         (1.0 - (qvapor + gz)) * constants.CV_AIR
@@ -23,7 +25,7 @@ def moist_cvm(qvapor, gz, ql, qs):
     return cvm
 
 
-@function
+@gtfunction
 def moist_cv_nwat6_fn(
     qvapor: FloatField,
     qliquid: FloatField,
@@ -39,7 +41,7 @@ def moist_cv_nwat6_fn(
     return cvm, gz
 
 
-@function
+@gtfunction
 def moist_pt_func(
     qvapor: FloatField,
     qliquid: FloatField,
@@ -63,7 +65,7 @@ def moist_pt_func(
     return cvm, gz, q_con, cappa, pt
 
 
-@function
+@gtfunction
 def last_pt(
     pt: FloatField,
     dtmp: Float,
@@ -115,7 +117,7 @@ def moist_pt_last_step(
         #    pt = last_pt(pt, dtmp, pkz, gz, qvapor, zvir)
 
 
-@function
+@gtfunction
 def compute_pkz_func(delp, delz, pt, cappa):
     # TODO use the exponential form for closer answer matching
     return exp(cappa * log(constants.RDG * delp / delz * pt))

--- a/pyFV3/stencils/neg_adj3.py
+++ b/pyFV3/stencils/neg_adj3.py
@@ -1,14 +1,16 @@
 import ndsl.constants as constants
 from ndsl import QuantityFactory, StencilFactory
 from ndsl.constants import X_DIM, Y_DIM
-from ndsl.dsl.gt4py import BACKWARD, FORWARD, PARALLEL, computation, function, interval
+from ndsl.dsl.gt4py import BACKWARD, FORWARD, PARALLEL, computation
+from ndsl.dsl.gt4py import function as gtfunction
+from ndsl.dsl.gt4py import interval
 from ndsl.dsl.typing import Float, FloatField, FloatFieldIJ
 
 
 ZVIR = constants.RVGAS / constants.RDGAS - 1.0
 
 
-@function
+@gtfunction
 def fix_negative_ice(qvapor, qice, qsnow, qgraupel, qrain, qliquid, pt, lcpk, icpk, dq):
     qsum = qice + qsnow
     if qsum > 0.0:
@@ -51,7 +53,7 @@ def fix_negative_ice(qvapor, qice, qsnow, qgraupel, qrain, qliquid, pt, lcpk, ic
     return qvapor, qice, qsnow, qgraupel, qrain, qliquid, pt
 
 
-@function
+@gtfunction
 def fix_negative_liq(qvapor, qice, qsnow, qgraupel, qrain, qliquid, pt, lcpk, icpk, dq):
     qsum = qliquid + qrain
     pos_qgraupel = 0.0 if 0.0 > qgraupel else qgraupel

--- a/pyFV3/stencils/neg_adj3.py
+++ b/pyFV3/stencils/neg_adj3.py
@@ -1,8 +1,7 @@
-from ndsl.dsl.gt4py import function, BACKWARD, FORWARD, PARALLEL, computation, interval
-
 import ndsl.constants as constants
 from ndsl import QuantityFactory, StencilFactory
 from ndsl.constants import X_DIM, Y_DIM
+from ndsl.dsl.gt4py import BACKWARD, FORWARD, PARALLEL, computation, function, interval
 from ndsl.dsl.typing import Float, FloatField, FloatFieldIJ
 
 

--- a/pyFV3/stencils/neg_adj3.py
+++ b/pyFV3/stencils/neg_adj3.py
@@ -1,5 +1,4 @@
-import gt4py.cartesian.gtscript as gtscript
-from gt4py.cartesian.gtscript import BACKWARD, FORWARD, PARALLEL, computation, interval
+from ndsl.dsl.gt4py import function, BACKWARD, FORWARD, PARALLEL, computation, interval
 
 import ndsl.constants as constants
 from ndsl import QuantityFactory, StencilFactory
@@ -10,7 +9,7 @@ from ndsl.dsl.typing import Float, FloatField, FloatFieldIJ
 ZVIR = constants.RVGAS / constants.RDGAS - 1.0
 
 
-@gtscript.function
+@function
 def fix_negative_ice(qvapor, qice, qsnow, qgraupel, qrain, qliquid, pt, lcpk, icpk, dq):
     qsum = qice + qsnow
     if qsum > 0.0:
@@ -53,7 +52,7 @@ def fix_negative_ice(qvapor, qice, qsnow, qgraupel, qrain, qliquid, pt, lcpk, ic
     return qvapor, qice, qsnow, qgraupel, qrain, qliquid, pt
 
 
-@gtscript.function
+@function
 def fix_negative_liq(qvapor, qice, qsnow, qgraupel, qrain, qliquid, pt, lcpk, icpk, dq):
     qsum = qliquid + qrain
     pos_qgraupel = 0.0 if 0.0 > qgraupel else qgraupel

--- a/pyFV3/stencils/nh_p_grad.py
+++ b/pyFV3/stencils/nh_p_grad.py
@@ -1,8 +1,8 @@
 import numpy as np
-from ndsl.dsl.gt4py import PARALLEL, computation, interval
 
 from ndsl import QuantityFactory, StencilFactory, orchestrate
 from ndsl.constants import X_DIM, Y_DIM, Z_INTERFACE_DIM
+from ndsl.dsl.gt4py import PARALLEL, computation, interval
 from ndsl.dsl.typing import Float, FloatField, FloatFieldIJ
 from ndsl.grid import GridData
 from pyFV3.stencils.a2b_ord4 import AGrid2BGridFourthOrder

--- a/pyFV3/stencils/nh_p_grad.py
+++ b/pyFV3/stencils/nh_p_grad.py
@@ -1,5 +1,5 @@
 import numpy as np
-from gt4py.cartesian.gtscript import PARALLEL, computation, interval
+from ndsl.dsl.gt4py import PARALLEL, computation, interval
 
 from ndsl import QuantityFactory, StencilFactory, orchestrate
 from ndsl.constants import X_DIM, Y_DIM, Z_INTERFACE_DIM

--- a/pyFV3/stencils/pe_halo.py
+++ b/pyFV3/stencils/pe_halo.py
@@ -1,4 +1,4 @@
-from gt4py.cartesian.gtscript import FORWARD, computation, horizontal, interval, region
+from ndsl.dsl.gt4py import FORWARD, computation, horizontal, interval, region
 
 from ndsl.dsl.typing import Float, FloatField
 

--- a/pyFV3/stencils/pe_halo.py
+++ b/pyFV3/stencils/pe_halo.py
@@ -1,5 +1,4 @@
 from ndsl.dsl.gt4py import FORWARD, computation, horizontal, interval, region
-
 from ndsl.dsl.typing import Float, FloatField
 
 

--- a/pyFV3/stencils/pk3_halo.py
+++ b/pyFV3/stencils/pk3_halo.py
@@ -1,7 +1,6 @@
-from ndsl.dsl.gt4py import FORWARD, computation, horizontal, interval, region
-
 from ndsl import QuantityFactory, StencilFactory
 from ndsl.constants import X_DIM, Y_DIM
+from ndsl.dsl.gt4py import FORWARD, computation, horizontal, interval, region
 from ndsl.dsl.typing import Float, FloatField, FloatFieldIJ
 
 
@@ -29,7 +28,7 @@ def edge_pe_update(
                 region[local_is - 2 : local_ie + 3, local_je + 1 : local_je + 3],
             ):
                 pe = pe + delp[0, 0, -1]
-                pk3 = pe**akap
+                pk3 = pe ** akap
 
 
 class PK3Halo:

--- a/pyFV3/stencils/pk3_halo.py
+++ b/pyFV3/stencils/pk3_halo.py
@@ -1,4 +1,4 @@
-from gt4py.cartesian.gtscript import FORWARD, computation, horizontal, interval, region
+from ndsl.dsl.gt4py import FORWARD, computation, horizontal, interval, region
 
 from ndsl import QuantityFactory, StencilFactory
 from ndsl.constants import X_DIM, Y_DIM
@@ -29,7 +29,7 @@ def edge_pe_update(
                 region[local_is - 2 : local_ie + 3, local_je + 1 : local_je + 3],
             ):
                 pe = pe + delp[0, 0, -1]
-                pk3 = pe ** akap
+                pk3 = pe**akap
 
 
 class PK3Halo:

--- a/pyFV3/stencils/ppm.py
+++ b/pyFV3/stencils/ppm.py
@@ -1,5 +1,4 @@
 from ndsl.dsl.gt4py import function
-
 from ndsl.dsl.typing import FloatField
 
 
@@ -22,7 +21,7 @@ s15 = 3.0 / 14.0
 def pert_ppm_standard_constraint_fcn(a0: FloatField, al: FloatField, ar: FloatField):
     if al * ar < 0.0:
         da1 = al - ar
-        da2 = da1**2
+        da2 = da1 ** 2
         a6da = 3.0 * (al + ar) * da1
         if a6da < -da2:
             ar = -2.0 * al
@@ -46,7 +45,7 @@ def pert_ppm_positive_definite_constraint_fcn(
         a4 = -3.0 * (ar + al)
         da1 = ar - al
         if abs(da1) < -a4:
-            fmin = a0 + 0.25 / a4 * da1**2 + a4 * (1.0 / 12.0)
+            fmin = a0 + 0.25 / a4 * da1 ** 2 + a4 * (1.0 / 12.0)
             if fmin < 0.0:
                 if ar > 0.0 and al > 0.0:
                     ar = 0.0

--- a/pyFV3/stencils/ppm.py
+++ b/pyFV3/stencils/ppm.py
@@ -1,4 +1,4 @@
-from ndsl.dsl.gt4py import function
+from ndsl.dsl.gt4py import function as gtfunction
 from ndsl.dsl.typing import FloatField
 
 
@@ -17,7 +17,7 @@ s14 = 4.0 / 7.0
 s15 = 3.0 / 14.0
 
 
-@function
+@gtfunction
 def pert_ppm_standard_constraint_fcn(a0: FloatField, al: FloatField, ar: FloatField):
     if al * ar < 0.0:
         da1 = al - ar
@@ -34,7 +34,7 @@ def pert_ppm_standard_constraint_fcn(a0: FloatField, al: FloatField, ar: FloatFi
     return al, ar
 
 
-@function
+@gtfunction
 def pert_ppm_positive_definite_constraint_fcn(
     a0: FloatField, al: FloatField, ar: FloatField
 ):

--- a/pyFV3/stencils/ppm.py
+++ b/pyFV3/stencils/ppm.py
@@ -1,4 +1,4 @@
-from gt4py.cartesian import gtscript
+from ndsl.dsl.gt4py import function
 
 from ndsl.dsl.typing import FloatField
 
@@ -18,11 +18,11 @@ s14 = 4.0 / 7.0
 s15 = 3.0 / 14.0
 
 
-@gtscript.function
+@function
 def pert_ppm_standard_constraint_fcn(a0: FloatField, al: FloatField, ar: FloatField):
     if al * ar < 0.0:
         da1 = al - ar
-        da2 = da1 ** 2
+        da2 = da1**2
         a6da = 3.0 * (al + ar) * da1
         if a6da < -da2:
             ar = -2.0 * al
@@ -35,7 +35,7 @@ def pert_ppm_standard_constraint_fcn(a0: FloatField, al: FloatField, ar: FloatFi
     return al, ar
 
 
-@gtscript.function
+@function
 def pert_ppm_positive_definite_constraint_fcn(
     a0: FloatField, al: FloatField, ar: FloatField
 ):
@@ -46,7 +46,7 @@ def pert_ppm_positive_definite_constraint_fcn(
         a4 = -3.0 * (ar + al)
         da1 = ar - al
         if abs(da1) < -a4:
-            fmin = a0 + 0.25 / a4 * da1 ** 2 + a4 * (1.0 / 12.0)
+            fmin = a0 + 0.25 / a4 * da1**2 + a4 * (1.0 / 12.0)
             if fmin < 0.0:
                 if ar > 0.0 and al > 0.0:
                     ar = 0.0

--- a/pyFV3/stencils/ray_fast.py
+++ b/pyFV3/stencils/ray_fast.py
@@ -1,20 +1,20 @@
+import ndsl.constants as constants
+from ndsl import StencilFactory, orchestrate
+from ndsl.constants import X_INTERFACE_DIM, Y_INTERFACE_DIM, Z_DIM
 from ndsl.dsl.gt4py import (
-    function,
     BACKWARD,
     FORWARD,
     PARALLEL,
     computation,
+    function,
     horizontal,
     interval,
     log,
     region,
     sin,
 )
-
-import ndsl.constants as constants
-from ndsl import StencilFactory, orchestrate
-from ndsl.constants import X_INTERFACE_DIM, Y_INTERFACE_DIM, Z_DIM
 from ndsl.dsl.typing import Float, FloatField, FloatFieldK
+
 
 from gt4py.cartesian.gtscript import __INLINED  # isort:skip
 

--- a/pyFV3/stencils/ray_fast.py
+++ b/pyFV3/stencils/ray_fast.py
@@ -1,18 +1,9 @@
 import ndsl.constants as constants
 from ndsl import StencilFactory, orchestrate
 from ndsl.constants import X_INTERFACE_DIM, Y_INTERFACE_DIM, Z_DIM
-from ndsl.dsl.gt4py import (
-    BACKWARD,
-    FORWARD,
-    PARALLEL,
-    computation,
-    function,
-    horizontal,
-    interval,
-    log,
-    region,
-    sin,
-)
+from ndsl.dsl.gt4py import BACKWARD, FORWARD, PARALLEL, computation
+from ndsl.dsl.gt4py import function as gtfunction
+from ndsl.dsl.gt4py import horizontal, interval, log, region, sin
 from ndsl.dsl.typing import Float, FloatField, FloatFieldK
 
 
@@ -24,7 +15,7 @@ SDAY = 86400.0
 # NOTE: The fortran version of this computes rf in the first timestep only. Then
 # rf_initialized let's you know you can skip it. Here we calculate it every
 # time.
-@function
+@gtfunction
 def compute_rf_vals(pfull, bdt, rf_cutoff, tau0, ptop):
     return (
         bdt
@@ -33,14 +24,14 @@ def compute_rf_vals(pfull, bdt, rf_cutoff, tau0, ptop):
     )
 
 
-@function
+@gtfunction
 def compute_rff_vals(pfull, dt, rf_cutoff, tau0, ptop):
     rffvals = compute_rf_vals(pfull, dt, rf_cutoff, tau0, ptop)
     rffvals = 1.0 / (1.0 + rffvals)
     return rffvals
 
 
-@function
+@gtfunction
 def dm_layer(rf, dp, wind):
     return (1.0 - rf) * dp * wind
 

--- a/pyFV3/stencils/ray_fast.py
+++ b/pyFV3/stencils/ray_fast.py
@@ -1,6 +1,5 @@
-import gt4py.cartesian.gtscript as gtscript
-from gt4py.cartesian.gtscript import (
-    __INLINED,
+from ndsl.dsl.gt4py import (
+    function,
     BACKWARD,
     FORWARD,
     PARALLEL,
@@ -17,6 +16,7 @@ from ndsl import StencilFactory, orchestrate
 from ndsl.constants import X_INTERFACE_DIM, Y_INTERFACE_DIM, Z_DIM
 from ndsl.dsl.typing import Float, FloatField, FloatFieldK
 
+from gt4py.cartesian.gtscript import __INLINED  # isort:skip
 
 SDAY = 86400.0
 
@@ -24,7 +24,7 @@ SDAY = 86400.0
 # NOTE: The fortran version of this computes rf in the first timestep only. Then
 # rf_initialized let's you know you can skip it. Here we calculate it every
 # time.
-@gtscript.function
+@function
 def compute_rf_vals(pfull, bdt, rf_cutoff, tau0, ptop):
     return (
         bdt
@@ -33,14 +33,14 @@ def compute_rf_vals(pfull, bdt, rf_cutoff, tau0, ptop):
     )
 
 
-@gtscript.function
+@function
 def compute_rff_vals(pfull, dt, rf_cutoff, tau0, ptop):
     rffvals = compute_rf_vals(pfull, dt, rf_cutoff, tau0, ptop)
     rffvals = 1.0 / (1.0 + rffvals)
     return rffvals
 
 
-@gtscript.function
+@function
 def dm_layer(rf, dp, wind):
     return (1.0 - rf) * dp * wind
 

--- a/pyFV3/stencils/remap_profile.py
+++ b/pyFV3/stencils/remap_profile.py
@@ -2,35 +2,37 @@ from typing import Sequence
 
 from ndsl import QuantityFactory, StencilFactory, orchestrate
 from ndsl.constants import X_DIM, Y_DIM, Z_DIM, Z_INTERFACE_DIM
-from ndsl.dsl.gt4py import BACKWARD, FORWARD, PARALLEL, computation, function, interval
+from ndsl.dsl.gt4py import BACKWARD, FORWARD, PARALLEL, computation
+from ndsl.dsl.gt4py import function as gtfunction
+from ndsl.dsl.gt4py import interval
 from ndsl.dsl.typing import BoolField, Float, FloatField, FloatFieldIJ
 
 
 from gt4py.cartesian.gtscript import __INLINED  # isort:skip
 
 
-@function
+@gtfunction
 def limit_minmax(q, a4):
     tmp = a4[0, 0, -1] if a4[0, 0, -1] > a4 else a4
     ret = q if q < tmp else tmp
     return ret
 
 
-@function
+@gtfunction
 def limit_maxmin(q, a4):
     tmp2 = a4[0, 0, -1] if a4[0, 0, -1] < a4 else a4
     ret = q if q > tmp2 else tmp2
     return ret
 
 
-@function
+@gtfunction
 def limit_both(q, a4):
     ret = limit_minmax(q, a4)
     ret = limit_maxmin(ret, a4)
     return ret
 
 
-@function
+@gtfunction
 def constrain_interior(q, gam, a4):
     return (
         limit_both(q, a4)
@@ -41,7 +43,7 @@ def constrain_interior(q, gam, a4):
     )
 
 
-@function
+@gtfunction
 def posdef_constraint_iv0(
     a4_1: FloatField,
     a4_2: FloatField,
@@ -77,7 +79,7 @@ def posdef_constraint_iv0(
     return a4_1, a4_2, a4_3, a4_4
 
 
-@function
+@gtfunction
 def posdef_constraint_iv1(
     a4_1: FloatField,
     a4_2: FloatField,
@@ -107,7 +109,7 @@ def posdef_constraint_iv1(
     return a4_1, a4_2, a4_3, a4_4
 
 
-@function
+@gtfunction
 def remap_constraint(
     a4_1: FloatField,
     a4_2: FloatField,

--- a/pyFV3/stencils/remap_profile.py
+++ b/pyFV3/stencils/remap_profile.py
@@ -1,18 +1,10 @@
 from typing import Sequence
 
-import gt4py.cartesian.gtscript as gtscript
-from ndsl.dsl.gt4py import (
-    function,
-    BACKWARD,
-    FORWARD,
-    PARALLEL,
-    computation,
-    interval,
-)
-
 from ndsl import QuantityFactory, StencilFactory, orchestrate
 from ndsl.constants import X_DIM, Y_DIM, Z_DIM, Z_INTERFACE_DIM
+from ndsl.dsl.gt4py import BACKWARD, FORWARD, PARALLEL, computation, function, interval
 from ndsl.dsl.typing import BoolField, Float, FloatField, FloatFieldIJ
+
 
 from gt4py.cartesian.gtscript import __INLINED  # isort:skip
 
@@ -43,7 +35,9 @@ def constrain_interior(q, gam, a4):
     return (
         limit_both(q, a4)
         if (gam[0, 0, -1] * gam[0, 0, 1] > 0.0)
-        else limit_maxmin(q, a4) if (gam[0, 0, -1] > 0.0) else limit_minmax(q, a4)
+        else limit_maxmin(q, a4)
+        if (gam[0, 0, -1] > 0.0)
+        else limit_minmax(q, a4)
     )
 
 
@@ -406,13 +400,17 @@ def set_interpolation_coefficients(
             tmp_min = (
                 a4_1
                 if (a4_1 < pmp_1) and (a4_1 < lac_1)
-                else pmp_1 if pmp_1 < lac_1 else lac_1
+                else pmp_1
+                if pmp_1 < lac_1
+                else lac_1
             )
             tmp_max0 = a4_2 if a4_2 > tmp_min else tmp_min
             tmp_max = (
                 a4_1
                 if (a4_1 > pmp_1) and (a4_1 > lac_1)
-                else pmp_1 if pmp_1 > lac_1 else lac_1
+                else pmp_1
+                if pmp_1 > lac_1
+                else lac_1
             )
             a4_2 = tmp_max0 if tmp_max0 < tmp_max else tmp_max
             # right edges?
@@ -421,13 +419,17 @@ def set_interpolation_coefficients(
             tmp_min = (
                 a4_1
                 if (a4_1 < pmp_2) and (a4_1 < lac_2)
-                else pmp_2 if pmp_2 < lac_2 else lac_2
+                else pmp_2
+                if pmp_2 < lac_2
+                else lac_2
             )
             tmp_max0 = a4_3 if a4_3 > tmp_min else tmp_min
             tmp_max = (
                 a4_1
                 if (a4_1 > pmp_2) and (a4_1 > lac_2)
-                else pmp_2 if pmp_2 > lac_2 else lac_2
+                else pmp_2
+                if pmp_2 > lac_2
+                else lac_2
             )
             a4_3 = tmp_max0 if tmp_max0 < tmp_max else tmp_max
             a4_4 = 3.0 * (2.0 * a4_1 - (a4_2 + a4_3))
@@ -454,25 +456,33 @@ def set_interpolation_coefficients(
                     tmp_min = (
                         a4_1
                         if (a4_1 < pmp_1) and (a4_1 < lac_1)
-                        else pmp_1 if pmp_1 < lac_1 else lac_1
+                        else pmp_1
+                        if pmp_1 < lac_1
+                        else lac_1
                     )
                     tmp_max0 = a4_2 if a4_2 > tmp_min else tmp_min
                     tmp_max = (
                         a4_1
                         if (a4_1 > pmp_1) and (a4_1 > lac_1)
-                        else pmp_1 if pmp_1 > lac_1 else lac_1
+                        else pmp_1
+                        if pmp_1 > lac_1
+                        else lac_1
                     )
                     a4_2 = tmp_max0 if tmp_max0 < tmp_max else tmp_max
                     tmp_min = (
                         a4_1
                         if (a4_1 < pmp_2) and (a4_1 < lac_2)
-                        else pmp_2 if pmp_2 < lac_2 else lac_2
+                        else pmp_2
+                        if pmp_2 < lac_2
+                        else lac_2
                     )
                     tmp_max0 = a4_3 if a4_3 > tmp_min else tmp_min
                     tmp_max = (
                         a4_1
                         if (a4_1 > pmp_2) and (a4_1 > lac_2)
-                        else pmp_2 if pmp_2 > lac_2 else lac_2
+                        else pmp_2
+                        if pmp_2 > lac_2
+                        else lac_2
                     )
                     a4_3 = tmp_max0 if tmp_max0 < tmp_max else tmp_max
                     a4_4 = 6.0 * a4_1 - 3.0 * (a4_2 + a4_3)
@@ -487,12 +497,16 @@ def set_interpolation_coefficients(
             tmp_min2 = (
                 a4_1
                 if (a4_1 < pmp_1) and (a4_1 < lac_1)
-                else pmp_1 if pmp_1 < lac_1 else lac_1
+                else pmp_1
+                if pmp_1 < lac_1
+                else lac_1
             )
             tmp_max2 = (
                 a4_1
                 if (a4_1 > pmp_1) and (a4_1 > lac_1)
-                else pmp_1 if pmp_1 > lac_1 else lac_1
+                else pmp_1
+                if pmp_1 > lac_1
+                else lac_1
             )
             tmp2 = a4_2 if a4_2 > tmp_min2 else tmp_min2
             tmp_min3 = a4_1 if a4_1 < pmp_2 else pmp_2

--- a/pyFV3/stencils/remap_profile.py
+++ b/pyFV3/stencils/remap_profile.py
@@ -1,8 +1,8 @@
 from typing import Sequence
 
 import gt4py.cartesian.gtscript as gtscript
-from gt4py.cartesian.gtscript import (
-    __INLINED,
+from ndsl.dsl.gt4py import (
+    function,
     BACKWARD,
     FORWARD,
     PARALLEL,
@@ -14,40 +14,40 @@ from ndsl import QuantityFactory, StencilFactory, orchestrate
 from ndsl.constants import X_DIM, Y_DIM, Z_DIM, Z_INTERFACE_DIM
 from ndsl.dsl.typing import BoolField, Float, FloatField, FloatFieldIJ
 
+from gt4py.cartesian.gtscript import __INLINED  # isort:skip
 
-@gtscript.function
+
+@function
 def limit_minmax(q, a4):
     tmp = a4[0, 0, -1] if a4[0, 0, -1] > a4 else a4
     ret = q if q < tmp else tmp
     return ret
 
 
-@gtscript.function
+@function
 def limit_maxmin(q, a4):
     tmp2 = a4[0, 0, -1] if a4[0, 0, -1] < a4 else a4
     ret = q if q > tmp2 else tmp2
     return ret
 
 
-@gtscript.function
+@function
 def limit_both(q, a4):
     ret = limit_minmax(q, a4)
     ret = limit_maxmin(ret, a4)
     return ret
 
 
-@gtscript.function
+@function
 def constrain_interior(q, gam, a4):
     return (
         limit_both(q, a4)
         if (gam[0, 0, -1] * gam[0, 0, 1] > 0.0)
-        else limit_maxmin(q, a4)
-        if (gam[0, 0, -1] > 0.0)
-        else limit_minmax(q, a4)
+        else limit_maxmin(q, a4) if (gam[0, 0, -1] > 0.0) else limit_minmax(q, a4)
     )
 
 
-@gtscript.function
+@function
 def posdef_constraint_iv0(
     a4_1: FloatField,
     a4_2: FloatField,
@@ -83,7 +83,7 @@ def posdef_constraint_iv0(
     return a4_1, a4_2, a4_3, a4_4
 
 
-@gtscript.function
+@function
 def posdef_constraint_iv1(
     a4_1: FloatField,
     a4_2: FloatField,
@@ -113,7 +113,7 @@ def posdef_constraint_iv1(
     return a4_1, a4_2, a4_3, a4_4
 
 
-@gtscript.function
+@function
 def remap_constraint(
     a4_1: FloatField,
     a4_2: FloatField,
@@ -406,17 +406,13 @@ def set_interpolation_coefficients(
             tmp_min = (
                 a4_1
                 if (a4_1 < pmp_1) and (a4_1 < lac_1)
-                else pmp_1
-                if pmp_1 < lac_1
-                else lac_1
+                else pmp_1 if pmp_1 < lac_1 else lac_1
             )
             tmp_max0 = a4_2 if a4_2 > tmp_min else tmp_min
             tmp_max = (
                 a4_1
                 if (a4_1 > pmp_1) and (a4_1 > lac_1)
-                else pmp_1
-                if pmp_1 > lac_1
-                else lac_1
+                else pmp_1 if pmp_1 > lac_1 else lac_1
             )
             a4_2 = tmp_max0 if tmp_max0 < tmp_max else tmp_max
             # right edges?
@@ -425,17 +421,13 @@ def set_interpolation_coefficients(
             tmp_min = (
                 a4_1
                 if (a4_1 < pmp_2) and (a4_1 < lac_2)
-                else pmp_2
-                if pmp_2 < lac_2
-                else lac_2
+                else pmp_2 if pmp_2 < lac_2 else lac_2
             )
             tmp_max0 = a4_3 if a4_3 > tmp_min else tmp_min
             tmp_max = (
                 a4_1
                 if (a4_1 > pmp_2) and (a4_1 > lac_2)
-                else pmp_2
-                if pmp_2 > lac_2
-                else lac_2
+                else pmp_2 if pmp_2 > lac_2 else lac_2
             )
             a4_3 = tmp_max0 if tmp_max0 < tmp_max else tmp_max
             a4_4 = 3.0 * (2.0 * a4_1 - (a4_2 + a4_3))
@@ -462,33 +454,25 @@ def set_interpolation_coefficients(
                     tmp_min = (
                         a4_1
                         if (a4_1 < pmp_1) and (a4_1 < lac_1)
-                        else pmp_1
-                        if pmp_1 < lac_1
-                        else lac_1
+                        else pmp_1 if pmp_1 < lac_1 else lac_1
                     )
                     tmp_max0 = a4_2 if a4_2 > tmp_min else tmp_min
                     tmp_max = (
                         a4_1
                         if (a4_1 > pmp_1) and (a4_1 > lac_1)
-                        else pmp_1
-                        if pmp_1 > lac_1
-                        else lac_1
+                        else pmp_1 if pmp_1 > lac_1 else lac_1
                     )
                     a4_2 = tmp_max0 if tmp_max0 < tmp_max else tmp_max
                     tmp_min = (
                         a4_1
                         if (a4_1 < pmp_2) and (a4_1 < lac_2)
-                        else pmp_2
-                        if pmp_2 < lac_2
-                        else lac_2
+                        else pmp_2 if pmp_2 < lac_2 else lac_2
                     )
                     tmp_max0 = a4_3 if a4_3 > tmp_min else tmp_min
                     tmp_max = (
                         a4_1
                         if (a4_1 > pmp_2) and (a4_1 > lac_2)
-                        else pmp_2
-                        if pmp_2 > lac_2
-                        else lac_2
+                        else pmp_2 if pmp_2 > lac_2 else lac_2
                     )
                     a4_3 = tmp_max0 if tmp_max0 < tmp_max else tmp_max
                     a4_4 = 6.0 * a4_1 - 3.0 * (a4_2 + a4_3)
@@ -503,16 +487,12 @@ def set_interpolation_coefficients(
             tmp_min2 = (
                 a4_1
                 if (a4_1 < pmp_1) and (a4_1 < lac_1)
-                else pmp_1
-                if pmp_1 < lac_1
-                else lac_1
+                else pmp_1 if pmp_1 < lac_1 else lac_1
             )
             tmp_max2 = (
                 a4_1
                 if (a4_1 > pmp_1) and (a4_1 > lac_1)
-                else pmp_1
-                if pmp_1 > lac_1
-                else lac_1
+                else pmp_1 if pmp_1 > lac_1 else lac_1
             )
             tmp2 = a4_2 if a4_2 > tmp_min2 else tmp_min2
             tmp_min3 = a4_1 if a4_1 < pmp_2 else pmp_2

--- a/pyFV3/stencils/remapping.py
+++ b/pyFV3/stencils/remapping.py
@@ -1,5 +1,14 @@
 from typing import Dict, Optional
 
+from ndsl import Quantity, QuantityFactory, StencilFactory, orchestrate
+from ndsl.constants import (
+    X_DIM,
+    X_INTERFACE_DIM,
+    Y_DIM,
+    Y_INTERFACE_DIM,
+    Z_DIM,
+    Z_INTERFACE_DIM,
+)
 from ndsl.dsl.gt4py import (
     BACKWARD,
     FORWARD,
@@ -11,16 +20,6 @@ from ndsl.dsl.gt4py import (
     log,
     region,
 )
-
-from ndsl import Quantity, QuantityFactory, StencilFactory, orchestrate
-from ndsl.constants import (
-    X_DIM,
-    X_INTERFACE_DIM,
-    Y_DIM,
-    Y_INTERFACE_DIM,
-    Z_DIM,
-    Z_INTERFACE_DIM,
-)
 from ndsl.dsl.typing import Float, FloatField, FloatFieldIJ, FloatFieldK
 from ndsl.stencils.basic_operations import adjust_divide_stencil
 from ndsl.typing import Checkpointer
@@ -30,6 +29,7 @@ from pyFV3.stencils.map_single import MapSingle
 from pyFV3.stencils.mapn_tracer import MapNTracer
 from pyFV3.stencils.moist_cv import moist_pt_func, moist_pt_last_step
 from pyFV3.stencils.saturation_adjustment import SatAdjust3d
+
 
 from gt4py.cartesian.gtscript import __INLINED  # isort:skip
 

--- a/pyFV3/stencils/remapping.py
+++ b/pyFV3/stencils/remapping.py
@@ -1,7 +1,6 @@
 from typing import Dict, Optional
 
-from gt4py.cartesian.gtscript import (
-    __INLINED,
+from ndsl.dsl.gt4py import (
     BACKWARD,
     FORWARD,
     PARALLEL,
@@ -32,6 +31,7 @@ from pyFV3.stencils.mapn_tracer import MapNTracer
 from pyFV3.stencils.moist_cv import moist_pt_func, moist_pt_last_step
 from pyFV3.stencils.saturation_adjustment import SatAdjust3d
 
+from gt4py.cartesian.gtscript import __INLINED  # isort:skip
 
 # TODO: Should this be set here or in global_constants?
 CONSV_MIN = 0.001

--- a/pyFV3/stencils/riem_solver3.py
+++ b/pyFV3/stencils/riem_solver3.py
@@ -1,22 +1,14 @@
 import math
 import typing
 
-from ndsl.dsl.gt4py import (
-    BACKWARD,
-    FORWARD,
-    PARALLEL,
-    computation,
-    exp,
-    interval,
-    log,
-)
-
 import ndsl.constants as constants
 from ndsl import QuantityFactory, StencilFactory, orchestrate
 from ndsl.constants import X_DIM, Y_DIM, Z_DIM, Z_INTERFACE_DIM
+from ndsl.dsl.gt4py import BACKWARD, FORWARD, PARALLEL, computation, exp, interval, log
 from ndsl.dsl.typing import Float, FloatField, FloatFieldIJ
 from pyFV3._config import RiemannConfig
 from pyFV3.stencils.sim1_solver import Sim1Solver
+
 
 from gt4py.cartesian.gtscript import __INLINED  # isort:skip
 

--- a/pyFV3/stencils/riem_solver3.py
+++ b/pyFV3/stencils/riem_solver3.py
@@ -1,8 +1,7 @@
 import math
 import typing
 
-from gt4py.cartesian.gtscript import (
-    __INLINED,
+from ndsl.dsl.gt4py import (
     BACKWARD,
     FORWARD,
     PARALLEL,
@@ -18,6 +17,8 @@ from ndsl.constants import X_DIM, Y_DIM, Z_DIM, Z_INTERFACE_DIM
 from ndsl.dsl.typing import Float, FloatField, FloatFieldIJ
 from pyFV3._config import RiemannConfig
 from pyFV3.stencils.sim1_solver import Sim1Solver
+
+from gt4py.cartesian.gtscript import __INLINED  # isort:skip
 
 
 @typing.no_type_check

--- a/pyFV3/stencils/riem_solver_c.py
+++ b/pyFV3/stencils/riem_solver_c.py
@@ -1,6 +1,6 @@
 import typing
 
-from gt4py.cartesian.gtscript import (
+from ndsl.dsl.gt4py import (
     BACKWARD,
     FORWARD,
     PARALLEL,

--- a/pyFV3/stencils/riem_solver_c.py
+++ b/pyFV3/stencils/riem_solver_c.py
@@ -1,17 +1,9 @@
 import typing
 
-from ndsl.dsl.gt4py import (
-    BACKWARD,
-    FORWARD,
-    PARALLEL,
-    computation,
-    interval,
-    log,
-)
-
 import ndsl.constants as constants
 from ndsl import QuantityFactory, StencilFactory
 from ndsl.constants import X_DIM, Y_DIM, Z_DIM, Z_INTERFACE_DIM
+from ndsl.dsl.gt4py import BACKWARD, FORWARD, PARALLEL, computation, interval, log
 from ndsl.dsl.typing import Float, FloatField, FloatFieldIJ
 from pyFV3.stencils.sim1_solver import Sim1Solver
 

--- a/pyFV3/stencils/saturation_adjustment.py
+++ b/pyFV3/stencils/saturation_adjustment.py
@@ -2,7 +2,9 @@ import math
 
 import ndsl.constants as constants
 from ndsl import StencilFactory
-from ndsl.dsl.gt4py import PARALLEL, computation, exp, floor, function, interval, log
+from ndsl.dsl.gt4py import PARALLEL, computation, exp, floor
+from ndsl.dsl.gt4py import function as gtfunction
+from ndsl.dsl.gt4py import interval, log
 from ndsl.dsl.typing import Float, FloatField, FloatFieldIJ
 from ndsl.stencils.basic_operations import dim
 from pyFV3._config import SatAdjustConfig
@@ -25,17 +27,17 @@ satmix = {"table": None, "table2": None, "tablew": None, "des2": None, "desw": N
 QS_LENGTH = 2621
 
 
-@function
+@gtfunction
 def tem_lower(i):
     return constants.T_SAT_MIN + DELT * i
 
 
-@function
+@gtfunction
 def tem_upper(i):
     return 253.16 + DELT * i
 
 
-@function
+@gtfunction
 def q_table_oneline(delta_heat_capacity, latent_heat_coefficient, tem):
     return constants.E00 * exp(
         (
@@ -46,19 +48,19 @@ def q_table_oneline(delta_heat_capacity, latent_heat_coefficient, tem):
     )
 
 
-@function
+@gtfunction
 def table_vapor_oneline(tem):
     return q_table_oneline(constants.DC_VAP, constants.LV0, tem)
 
 
-@function
+@gtfunction
 def table_ice_oneline(tem):
     return q_table_oneline(constants.D2ICE, constants.LI2, tem)
 
 
 # TODO Math can be consolidated if we can call gtscript functions from
 # conditionals, fac0 and fac2 functions and others.
-@function
+@gtfunction
 def qs_table_fn(i):
     tem_l = tem_lower(i)
     tem_u = tem_upper(i - 1400)
@@ -77,7 +79,7 @@ def qs_table_fn(i):
 
 # TODO Math can be consolidated if we can call gtscript functions from
 # conditionals, fac0 and fac2 functions and others.
-@function
+@gtfunction
 def qs_table2_fn(i):
     tem0 = tem_lower(i)
     if i < 1600:
@@ -114,13 +116,13 @@ def qs_table2_fn(i):
     return table2
 
 
-@function
+@gtfunction
 def qs_tablew_fn(i):
     tem = tem_lower(i)
     return table_vapor_oneline(tem)
 
 
-@function
+@gtfunction
 def des_end(t, i, z, des2):
     if i == QS_LENGTH - 1:
         t_m1 = qs_table2_fn(i - 1)
@@ -131,7 +133,7 @@ def des_end(t, i, z, des2):
 
 # TODO There might be a cleaner way to set des2[QS_LENGTH - 1] to des2[QS_LENGTH
 # - 2].
-@function
+@gtfunction
 def des2_table(i):
     t = qs_table2_fn(i)
     diff = qs_table2_fn(i + 1) - t
@@ -143,7 +145,7 @@ def des2_table(i):
 
 # TODO There might be a cleaner way to set desw[QS_LENGTH - 1] to desw[QS_LENGTH
 # - 2].
-@function
+@gtfunction
 def desw_table(i):
     t = qs_tablew_fn(i)
     diff = qs_tablew_fn(i + 1) - t
@@ -153,22 +155,22 @@ def desw_table(i):
     return desw
 
 
-@function
+@gtfunction
 def compute_cvm(mc_air, qv, c_vap, q_liq, q_sol):
     return mc_air + qv * c_vap + q_liq * constants.C_LIQ + q_sol * constants.C_ICE
 
 
-@function
+@gtfunction
 def add_src_pt1(pt1, src, lhl, cvm):
     return pt1 + src * lhl / cvm
 
 
-@function
+@gtfunction
 def subtract_sink_pt1(pt1, sink, lhl, cvm):
     return pt1 - sink * lhl / cvm
 
 
-@function
+@gtfunction
 def melt_cloud_ice(
     qv, qi, ql, q_liq, q_sol, pt1, icp2, fac_imlt, mc_air, c_vap, lhi, cvm
 ):
@@ -185,13 +187,13 @@ def melt_cloud_ice(
     return qi, ql, q_liq, q_sol, cvm, pt1
 
 
-@function
+@gtfunction
 def minmax_tmp_h20(qa, qb):
     tmpmax = max(qb, 0.0)
     return min(-qa, tmpmax)
 
 
-@function
+@gtfunction
 def fix_negative_snow(qs, qg):
     if qs < 0.0:
         qg = qg + qs
@@ -204,7 +206,7 @@ def fix_negative_snow(qs, qg):
 
 
 # Fix negative cloud water with rain or rain with available cloud water
-@function
+@gtfunction
 def fix_negative_cloud_water(ql, qr):
     if ql < 0.0:
         tmp = minmax_tmp_h20(ql, qr)
@@ -218,7 +220,7 @@ def fix_negative_cloud_water(ql, qr):
 
 
 # Enforce complete freezing of cloud water to cloud ice below - 48 c
-@function
+@gtfunction
 def complete_freezing(qv, ql, qi, q_liq, q_sol, pt1, cvm, icp2, mc_air, lhi, c_vap):
     dtmp = constants.TICE - 48.0 - pt1
     if ql > 0.0 and dtmp > 0.0:
@@ -232,7 +234,7 @@ def complete_freezing(qv, ql, qi, q_liq, q_sol, pt1, cvm, icp2, mc_air, lhi, c_v
     return ql, qi, q_liq, q_sol, cvm, pt1
 
 
-@function
+@gtfunction
 def homogenous_freezing(qv, ql, qi, q_liq, q_sol, pt1, cvm, icp2, mc_air, lhi, c_vap):
     dtmp = constants.T_WFR - pt1  # [ - 40, - 48]
     if ql > 0.0 and dtmp > 0.0:
@@ -248,7 +250,7 @@ def homogenous_freezing(qv, ql, qi, q_liq, q_sol, pt1, cvm, icp2, mc_air, lhi, c
 
 
 # Bigg mechanism for heterogeneous freezing
-@function
+@gtfunction
 def heterogeneous_freezing(
     exptc, pt1, cvm, ql, qi, q_liq, q_sol, den, icp2, dt_bigg, mc_air, lhi, qv, c_vap
 ):
@@ -266,7 +268,7 @@ def heterogeneous_freezing(
     return ql, qi, q_liq, q_sol, cvm, pt1
 
 
-@function
+@gtfunction
 def make_graupel(pt1, cvm, fac_r2g, qr, qg, q_liq, q_sol, lhi, icp2, mc_air, qv, c_vap):
     dtmp = (constants.TICE - 0.1) - pt1
     if qr > 1e-7 and dtmp > 0.0:
@@ -283,7 +285,7 @@ def make_graupel(pt1, cvm, fac_r2g, qr, qg, q_liq, q_sol, lhi, icp2, mc_air, qv,
     return qr, qg, q_liq, q_sol, cvm, pt1
 
 
-@function
+@gtfunction
 def melt_snow(
     pt1, cvm, fac_smlt, qs, ql, qr, q_liq, q_sol, lhi, icp2, mc_air, qv, c_vap, qs_mlt
 ):
@@ -306,7 +308,7 @@ def melt_snow(
     return qs, ql, qr, q_liq, q_sol, cvm, pt1
 
 
-@function
+@gtfunction
 def autoconversion_cloud_to_rain(ql, qr, fac_l2r, ql0_max):
     if ql > ql0_max:
         sink = fac_l2r * (ql - ql0_max)
@@ -315,7 +317,7 @@ def autoconversion_cloud_to_rain(ql, qr, fac_l2r, ql0_max):
     return ql, qr
 
 
-@function
+@gtfunction
 def sublimation(
     pt1,
     cvm,
@@ -385,52 +387,52 @@ def sublimation(
     return qv, qi, q_sol, cvm, pt1
 
 
-@function
+@gtfunction
 def update_latent_heat_coefficient_i(pt1, cvm):
     lhi = constants.LI00 + constants.DC_ICE * pt1
     icp2 = lhi / cvm
     return lhi, icp2
 
 
-@function
+@gtfunction
 def update_latent_heat_coefficient_l(pt1, cvm, lv00, d0_vap):
     lhl = lv00 + d0_vap * pt1
     lcp2 = lhl / cvm
     return lhl, lcp2
 
 
-@function
+@gtfunction
 def update_latent_heat_coefficient(pt1, cvm, lv00, d0_vap):
     lhl, lcp2 = update_latent_heat_coefficient_l(pt1, cvm, lv00, d0_vap)
     lhi, icp2 = update_latent_heat_coefficient_i(pt1, cvm)
     return lhl, lhi, lcp2, icp2
 
 
-@function
+@gtfunction
 def compute_dq0(qv, wqsat, dq2dt, tcp3):
     return (qv - wqsat) / (1.0 + tcp3 * dq2dt)
 
 
-@function
+@gtfunction
 def get_factor(wqsat, qv, fac_l2v):
     factor = -min(1, fac_l2v * 10.0 * (1.0 - qv / wqsat))
     return factor
 
 
-@function
+@gtfunction
 def get_src(ql, factor, dq0):
     src = -min(ql, factor * dq0)
     return src
 
 
-@function
+@gtfunction
 def ql_evaporation(wqsat, qv, ql, dq0, fac_l2v):
     factor = get_factor(wqsat, qv, fac_l2v)
     src = get_src(ql, factor, dq0)
     return factor, src
 
 
-@function
+@gtfunction
 def wqsat_correct(src, pt1, lhl, qv, ql, q_liq, q_sol, mc_air, c_vap):
     qv = qv - src
     ql = ql + src
@@ -440,18 +442,18 @@ def wqsat_correct(src, pt1, lhl, qv, ql, q_liq, q_sol, mc_air, c_vap):
     return qv, ql, q_liq, cvm, pt1
 
 
-@function
+@gtfunction
 def ap1_for_wqs2(ta):
     ap1 = 10.0 * dim(ta, constants.T_SAT_MIN) + 1.0
     return min(ap1, QS_LENGTH) - 1
 
 
-@function
+@gtfunction
 def ap1_index(ap1):
     return floor(ap1)
 
 
-@function
+@gtfunction
 def ap1_indices(ap1):
     it = ap1_index(ap1)
     it2 = floor(ap1 - 0.5)
@@ -459,21 +461,21 @@ def ap1_indices(ap1):
     return it, it2, it2_p1
 
 
-@function
+@gtfunction
 def ap1_and_indices(ta):
     ap1 = ap1_for_wqs2(ta)
     it, it2, it2_p1 = ap1_indices(ap1)
     return ap1, it, it2, it2_p1
 
 
-@function
+@gtfunction
 def ap1_and_index(ta):
     ap1 = ap1_for_wqs2(ta)
     it = ap1_index(ap1)
     return it, ap1
 
 
-@function
+@gtfunction
 def wqsat_and_dqdt(tablew, desw, desw2, desw_p1, ap1, it, it2, ta, den):
     es = tablew + (ap1 - it) * desw
     denom = constants.RVGAS * ta * den
@@ -483,13 +485,13 @@ def wqsat_and_dqdt(tablew, desw, desw2, desw_p1, ap1, it, it2, ta, den):
     return wqsat, dqdt
 
 
-@function
+@gtfunction
 def wqsat_wsq1(table, des, ap1, it, ta, den):
     es = table + (ap1 - it) * des
     return es / (constants.RVGAS * ta * den)
 
 
-@function
+@gtfunction
 def wqs2_fn_2(ta, den):
     ap1, it, it2, it2_p1 = ap1_and_indices(ta)
     table2 = qs_table2_fn(it)
@@ -500,7 +502,7 @@ def wqs2_fn_2(ta, den):
     return wqsat, dqdt
 
 
-@function
+@gtfunction
 def wqs2_fn_w(ta, den):
     ap1, it, it2, it2_p1 = ap1_and_indices(ta)
     tablew = qs_tablew_fn(it)
@@ -511,14 +513,14 @@ def wqs2_fn_w(ta, den):
     return wqsat, dqdt
 
 
-@function
+@gtfunction
 def wqs1_fn_w(it, ap1, ta, den):
     tablew = qs_tablew_fn(it)
     desw = desw_table(it)
     return wqsat_wsq1(tablew, desw, ap1, it, ta, den)
 
 
-@function
+@gtfunction
 def wqs1_fn_2(it, ap1, ta, den):
     table2 = qs_table2_fn(it)
     des2 = des2_table(it)

--- a/pyFV3/stencils/saturation_adjustment.py
+++ b/pyFV3/stencils/saturation_adjustment.py
@@ -1,21 +1,13 @@
 import math
 
-from ndsl.dsl.gt4py import (
-    function,
-    PARALLEL,
-    computation,
-    exp,
-    floor,
-    interval,
-    log,
-)
-
 import ndsl.constants as constants
 from ndsl import StencilFactory
+from ndsl.dsl.gt4py import PARALLEL, computation, exp, floor, function, interval, log
 from ndsl.dsl.typing import Float, FloatField, FloatFieldIJ
 from ndsl.stencils.basic_operations import dim
 from pyFV3._config import SatAdjustConfig
 from pyFV3.stencils.moist_cv import compute_pkz_func
+
 
 from gt4py.cartesian.gtscript import __INLINED  # isort:skip
 
@@ -262,7 +254,7 @@ def heterogeneous_freezing(
 ):
     tc = constants.TICE0 - pt1
     if ql > 0.0 and tc > 0.0:
-        sink = 3.3333e-10 * dt_bigg * (exptc - 1.0) * den * ql**2
+        sink = 3.3333e-10 * dt_bigg * (exptc - 1.0) * den * ql ** 2
         sink = min(ql, sink)
         sink = min(sink, tc / icp2)
         ql = ql - sink
@@ -360,7 +352,10 @@ def sublimation(
                 * 349138.78
                 * expsubl
                 / (
-                    iqs2 * den * constants.LAT2 / (0.0243 * constants.RVGAS * pt1**2.0)
+                    iqs2
+                    * den
+                    * constants.LAT2
+                    / (0.0243 * constants.RVGAS * pt1 ** 2.0)
                     + 4.42478e4
                 )
             )
@@ -895,7 +890,7 @@ def satadjust(
             mindw = min(1.0, abs(hs) / (10.0 * constants.GRAV))
             dw = dw_ocean + (dw_land - dw_ocean) * mindw
             # "scale - aware" subgrid variability: 100 - km as the base
-            dbl_sqrt_area = dw * (area**0.5 / 100.0e3) ** 0.5
+            dbl_sqrt_area = dw * (area ** 0.5 / 100.0e3) ** 0.5
             maxtmp = max(0.01, dbl_sqrt_area)
             hvar = min(0.2, maxtmp)
             # partial cloudiness by pdf:

--- a/pyFV3/stencils/saturation_adjustment.py
+++ b/pyFV3/stencils/saturation_adjustment.py
@@ -1,8 +1,7 @@
 import math
 
-import gt4py.cartesian.gtscript as gtscript
-from gt4py.cartesian.gtscript import (
-    __INLINED,
+from ndsl.dsl.gt4py import (
+    function,
     PARALLEL,
     computation,
     exp,
@@ -18,6 +17,7 @@ from ndsl.stencils.basic_operations import dim
 from pyFV3._config import SatAdjustConfig
 from pyFV3.stencils.moist_cv import compute_pkz_func
 
+from gt4py.cartesian.gtscript import __INLINED  # isort:skip
 
 # TODO: This code could be reduced greatly with abstraction, but first gt4py
 # needs to support gtscript function calls of arbitrary depth embedded in
@@ -33,17 +33,17 @@ satmix = {"table": None, "table2": None, "tablew": None, "des2": None, "desw": N
 QS_LENGTH = 2621
 
 
-@gtscript.function
+@function
 def tem_lower(i):
     return constants.T_SAT_MIN + DELT * i
 
 
-@gtscript.function
+@function
 def tem_upper(i):
     return 253.16 + DELT * i
 
 
-@gtscript.function
+@function
 def q_table_oneline(delta_heat_capacity, latent_heat_coefficient, tem):
     return constants.E00 * exp(
         (
@@ -54,19 +54,19 @@ def q_table_oneline(delta_heat_capacity, latent_heat_coefficient, tem):
     )
 
 
-@gtscript.function
+@function
 def table_vapor_oneline(tem):
     return q_table_oneline(constants.DC_VAP, constants.LV0, tem)
 
 
-@gtscript.function
+@function
 def table_ice_oneline(tem):
     return q_table_oneline(constants.D2ICE, constants.LI2, tem)
 
 
 # TODO Math can be consolidated if we can call gtscript functions from
 # conditionals, fac0 and fac2 functions and others.
-@gtscript.function
+@function
 def qs_table_fn(i):
     tem_l = tem_lower(i)
     tem_u = tem_upper(i - 1400)
@@ -85,7 +85,7 @@ def qs_table_fn(i):
 
 # TODO Math can be consolidated if we can call gtscript functions from
 # conditionals, fac0 and fac2 functions and others.
-@gtscript.function
+@function
 def qs_table2_fn(i):
     tem0 = tem_lower(i)
     if i < 1600:
@@ -122,13 +122,13 @@ def qs_table2_fn(i):
     return table2
 
 
-@gtscript.function
+@function
 def qs_tablew_fn(i):
     tem = tem_lower(i)
     return table_vapor_oneline(tem)
 
 
-@gtscript.function
+@function
 def des_end(t, i, z, des2):
     if i == QS_LENGTH - 1:
         t_m1 = qs_table2_fn(i - 1)
@@ -139,7 +139,7 @@ def des_end(t, i, z, des2):
 
 # TODO There might be a cleaner way to set des2[QS_LENGTH - 1] to des2[QS_LENGTH
 # - 2].
-@gtscript.function
+@function
 def des2_table(i):
     t = qs_table2_fn(i)
     diff = qs_table2_fn(i + 1) - t
@@ -151,7 +151,7 @@ def des2_table(i):
 
 # TODO There might be a cleaner way to set desw[QS_LENGTH - 1] to desw[QS_LENGTH
 # - 2].
-@gtscript.function
+@function
 def desw_table(i):
     t = qs_tablew_fn(i)
     diff = qs_tablew_fn(i + 1) - t
@@ -161,22 +161,22 @@ def desw_table(i):
     return desw
 
 
-@gtscript.function
+@function
 def compute_cvm(mc_air, qv, c_vap, q_liq, q_sol):
     return mc_air + qv * c_vap + q_liq * constants.C_LIQ + q_sol * constants.C_ICE
 
 
-@gtscript.function
+@function
 def add_src_pt1(pt1, src, lhl, cvm):
     return pt1 + src * lhl / cvm
 
 
-@gtscript.function
+@function
 def subtract_sink_pt1(pt1, sink, lhl, cvm):
     return pt1 - sink * lhl / cvm
 
 
-@gtscript.function
+@function
 def melt_cloud_ice(
     qv, qi, ql, q_liq, q_sol, pt1, icp2, fac_imlt, mc_air, c_vap, lhi, cvm
 ):
@@ -193,13 +193,13 @@ def melt_cloud_ice(
     return qi, ql, q_liq, q_sol, cvm, pt1
 
 
-@gtscript.function
+@function
 def minmax_tmp_h20(qa, qb):
     tmpmax = max(qb, 0.0)
     return min(-qa, tmpmax)
 
 
-@gtscript.function
+@function
 def fix_negative_snow(qs, qg):
     if qs < 0.0:
         qg = qg + qs
@@ -212,7 +212,7 @@ def fix_negative_snow(qs, qg):
 
 
 # Fix negative cloud water with rain or rain with available cloud water
-@gtscript.function
+@function
 def fix_negative_cloud_water(ql, qr):
     if ql < 0.0:
         tmp = minmax_tmp_h20(ql, qr)
@@ -226,7 +226,7 @@ def fix_negative_cloud_water(ql, qr):
 
 
 # Enforce complete freezing of cloud water to cloud ice below - 48 c
-@gtscript.function
+@function
 def complete_freezing(qv, ql, qi, q_liq, q_sol, pt1, cvm, icp2, mc_air, lhi, c_vap):
     dtmp = constants.TICE - 48.0 - pt1
     if ql > 0.0 and dtmp > 0.0:
@@ -240,7 +240,7 @@ def complete_freezing(qv, ql, qi, q_liq, q_sol, pt1, cvm, icp2, mc_air, lhi, c_v
     return ql, qi, q_liq, q_sol, cvm, pt1
 
 
-@gtscript.function
+@function
 def homogenous_freezing(qv, ql, qi, q_liq, q_sol, pt1, cvm, icp2, mc_air, lhi, c_vap):
     dtmp = constants.T_WFR - pt1  # [ - 40, - 48]
     if ql > 0.0 and dtmp > 0.0:
@@ -256,13 +256,13 @@ def homogenous_freezing(qv, ql, qi, q_liq, q_sol, pt1, cvm, icp2, mc_air, lhi, c
 
 
 # Bigg mechanism for heterogeneous freezing
-@gtscript.function
+@function
 def heterogeneous_freezing(
     exptc, pt1, cvm, ql, qi, q_liq, q_sol, den, icp2, dt_bigg, mc_air, lhi, qv, c_vap
 ):
     tc = constants.TICE0 - pt1
     if ql > 0.0 and tc > 0.0:
-        sink = 3.3333e-10 * dt_bigg * (exptc - 1.0) * den * ql ** 2
+        sink = 3.3333e-10 * dt_bigg * (exptc - 1.0) * den * ql**2
         sink = min(ql, sink)
         sink = min(sink, tc / icp2)
         ql = ql - sink
@@ -274,7 +274,7 @@ def heterogeneous_freezing(
     return ql, qi, q_liq, q_sol, cvm, pt1
 
 
-@gtscript.function
+@function
 def make_graupel(pt1, cvm, fac_r2g, qr, qg, q_liq, q_sol, lhi, icp2, mc_air, qv, c_vap):
     dtmp = (constants.TICE - 0.1) - pt1
     if qr > 1e-7 and dtmp > 0.0:
@@ -291,7 +291,7 @@ def make_graupel(pt1, cvm, fac_r2g, qr, qg, q_liq, q_sol, lhi, icp2, mc_air, qv,
     return qr, qg, q_liq, q_sol, cvm, pt1
 
 
-@gtscript.function
+@function
 def melt_snow(
     pt1, cvm, fac_smlt, qs, ql, qr, q_liq, q_sol, lhi, icp2, mc_air, qv, c_vap, qs_mlt
 ):
@@ -314,7 +314,7 @@ def melt_snow(
     return qs, ql, qr, q_liq, q_sol, cvm, pt1
 
 
-@gtscript.function
+@function
 def autoconversion_cloud_to_rain(ql, qr, fac_l2r, ql0_max):
     if ql > ql0_max:
         sink = fac_l2r * (ql - ql0_max)
@@ -323,7 +323,7 @@ def autoconversion_cloud_to_rain(ql, qr, fac_l2r, ql0_max):
     return ql, qr
 
 
-@gtscript.function
+@function
 def sublimation(
     pt1,
     cvm,
@@ -360,10 +360,7 @@ def sublimation(
                 * 349138.78
                 * expsubl
                 / (
-                    iqs2
-                    * den
-                    * constants.LAT2
-                    / (0.0243 * constants.RVGAS * pt1 ** 2.0)
+                    iqs2 * den * constants.LAT2 / (0.0243 * constants.RVGAS * pt1**2.0)
                     + 4.42478e4
                 )
             )
@@ -393,52 +390,52 @@ def sublimation(
     return qv, qi, q_sol, cvm, pt1
 
 
-@gtscript.function
+@function
 def update_latent_heat_coefficient_i(pt1, cvm):
     lhi = constants.LI00 + constants.DC_ICE * pt1
     icp2 = lhi / cvm
     return lhi, icp2
 
 
-@gtscript.function
+@function
 def update_latent_heat_coefficient_l(pt1, cvm, lv00, d0_vap):
     lhl = lv00 + d0_vap * pt1
     lcp2 = lhl / cvm
     return lhl, lcp2
 
 
-@gtscript.function
+@function
 def update_latent_heat_coefficient(pt1, cvm, lv00, d0_vap):
     lhl, lcp2 = update_latent_heat_coefficient_l(pt1, cvm, lv00, d0_vap)
     lhi, icp2 = update_latent_heat_coefficient_i(pt1, cvm)
     return lhl, lhi, lcp2, icp2
 
 
-@gtscript.function
+@function
 def compute_dq0(qv, wqsat, dq2dt, tcp3):
     return (qv - wqsat) / (1.0 + tcp3 * dq2dt)
 
 
-@gtscript.function
+@function
 def get_factor(wqsat, qv, fac_l2v):
     factor = -min(1, fac_l2v * 10.0 * (1.0 - qv / wqsat))
     return factor
 
 
-@gtscript.function
+@function
 def get_src(ql, factor, dq0):
     src = -min(ql, factor * dq0)
     return src
 
 
-@gtscript.function
+@function
 def ql_evaporation(wqsat, qv, ql, dq0, fac_l2v):
     factor = get_factor(wqsat, qv, fac_l2v)
     src = get_src(ql, factor, dq0)
     return factor, src
 
 
-@gtscript.function
+@function
 def wqsat_correct(src, pt1, lhl, qv, ql, q_liq, q_sol, mc_air, c_vap):
     qv = qv - src
     ql = ql + src
@@ -448,18 +445,18 @@ def wqsat_correct(src, pt1, lhl, qv, ql, q_liq, q_sol, mc_air, c_vap):
     return qv, ql, q_liq, cvm, pt1
 
 
-@gtscript.function
+@function
 def ap1_for_wqs2(ta):
     ap1 = 10.0 * dim(ta, constants.T_SAT_MIN) + 1.0
     return min(ap1, QS_LENGTH) - 1
 
 
-@gtscript.function
+@function
 def ap1_index(ap1):
     return floor(ap1)
 
 
-@gtscript.function
+@function
 def ap1_indices(ap1):
     it = ap1_index(ap1)
     it2 = floor(ap1 - 0.5)
@@ -467,21 +464,21 @@ def ap1_indices(ap1):
     return it, it2, it2_p1
 
 
-@gtscript.function
+@function
 def ap1_and_indices(ta):
     ap1 = ap1_for_wqs2(ta)
     it, it2, it2_p1 = ap1_indices(ap1)
     return ap1, it, it2, it2_p1
 
 
-@gtscript.function
+@function
 def ap1_and_index(ta):
     ap1 = ap1_for_wqs2(ta)
     it = ap1_index(ap1)
     return it, ap1
 
 
-@gtscript.function
+@function
 def wqsat_and_dqdt(tablew, desw, desw2, desw_p1, ap1, it, it2, ta, den):
     es = tablew + (ap1 - it) * desw
     denom = constants.RVGAS * ta * den
@@ -491,13 +488,13 @@ def wqsat_and_dqdt(tablew, desw, desw2, desw_p1, ap1, it, it2, ta, den):
     return wqsat, dqdt
 
 
-@gtscript.function
+@function
 def wqsat_wsq1(table, des, ap1, it, ta, den):
     es = table + (ap1 - it) * des
     return es / (constants.RVGAS * ta * den)
 
 
-@gtscript.function
+@function
 def wqs2_fn_2(ta, den):
     ap1, it, it2, it2_p1 = ap1_and_indices(ta)
     table2 = qs_table2_fn(it)
@@ -508,7 +505,7 @@ def wqs2_fn_2(ta, den):
     return wqsat, dqdt
 
 
-@gtscript.function
+@function
 def wqs2_fn_w(ta, den):
     ap1, it, it2, it2_p1 = ap1_and_indices(ta)
     tablew = qs_tablew_fn(it)
@@ -519,14 +516,14 @@ def wqs2_fn_w(ta, den):
     return wqsat, dqdt
 
 
-@gtscript.function
+@function
 def wqs1_fn_w(it, ap1, ta, den):
     tablew = qs_tablew_fn(it)
     desw = desw_table(it)
     return wqsat_wsq1(tablew, desw, ap1, it, ta, den)
 
 
-@gtscript.function
+@function
 def wqs1_fn_2(it, ap1, ta, den):
     table2 = qs_table2_fn(it)
     des2 = des2_table(it)
@@ -898,7 +895,7 @@ def satadjust(
             mindw = min(1.0, abs(hs) / (10.0 * constants.GRAV))
             dw = dw_ocean + (dw_land - dw_ocean) * mindw
             # "scale - aware" subgrid variability: 100 - km as the base
-            dbl_sqrt_area = dw * (area ** 0.5 / 100.0e3) ** 0.5
+            dbl_sqrt_area = dw * (area**0.5 / 100.0e3) ** 0.5
             maxtmp = max(0.01, dbl_sqrt_area)
             hvar = min(0.2, maxtmp)
             # partial cloudiness by pdf:

--- a/pyFV3/stencils/sim1_solver.py
+++ b/pyFV3/stencils/sim1_solver.py
@@ -1,6 +1,6 @@
 import typing
 
-from gt4py.cartesian.gtscript import (
+from ndsl.dsl.gt4py import (
     BACKWARD,
     FORWARD,
     PARALLEL,

--- a/pyFV3/stencils/sim1_solver.py
+++ b/pyFV3/stencils/sim1_solver.py
@@ -1,18 +1,9 @@
 import typing
 
-from ndsl.dsl.gt4py import (
-    BACKWARD,
-    FORWARD,
-    PARALLEL,
-    computation,
-    exp,
-    interval,
-    log,
-)
-
 import ndsl.constants as constants
 from ndsl import StencilFactory
 from ndsl.constants import X_DIM, Y_DIM, Z_INTERFACE_DIM
+from ndsl.dsl.gt4py import BACKWARD, FORWARD, PARALLEL, computation, exp, interval, log
 from ndsl.dsl.typing import Float, FloatField, FloatFieldIJ
 
 

--- a/pyFV3/stencils/temperature_adjust.py
+++ b/pyFV3/stencils/temperature_adjust.py
@@ -1,6 +1,5 @@
-from ndsl.dsl.gt4py import PARALLEL, computation, exp, interval, log
-
 import ndsl.constants as constants
+from ndsl.dsl.gt4py import PARALLEL, computation, exp, interval, log
 from ndsl.dsl.typing import Float, FloatField
 from ndsl.stencils.basic_operations import sign
 

--- a/pyFV3/stencils/temperature_adjust.py
+++ b/pyFV3/stencils/temperature_adjust.py
@@ -1,4 +1,4 @@
-from gt4py.cartesian.gtscript import PARALLEL, computation, exp, interval, log
+from ndsl.dsl.gt4py import PARALLEL, computation, exp, interval, log
 
 import ndsl.constants as constants
 from ndsl.dsl.typing import Float, FloatField

--- a/pyFV3/stencils/tracer_2d_1l.py
+++ b/pyFV3/stencils/tracer_2d_1l.py
@@ -16,13 +16,15 @@ from ndsl.constants import (
     Y_INTERFACE_DIM,
     Z_DIM,
 )
-from ndsl.dsl.gt4py import PARALLEL, computation, function, horizontal, interval, region
+from ndsl.dsl.gt4py import PARALLEL, computation
+from ndsl.dsl.gt4py import function as gtfunction
+from ndsl.dsl.gt4py import horizontal, interval, region
 from ndsl.dsl.typing import Float, FloatField, FloatFieldIJ
 from ndsl.typing import Communicator
 from pyFV3.stencils.fvtp2d import FiniteVolumeTransport
 
 
-@function
+@gtfunction
 def flux_x(cx, dxa, dy, sin_sg3, sin_sg1, xfx):
     from __externals__ import local_ie, local_is, local_je, local_js
 
@@ -33,7 +35,7 @@ def flux_x(cx, dxa, dy, sin_sg3, sin_sg1, xfx):
     return xfx
 
 
-@function
+@gtfunction
 def flux_y(cy, dya, dx, sin_sg4, sin_sg2, yfx):
     from __externals__ import local_ie, local_is, local_je, local_js
 

--- a/pyFV3/stencils/tracer_2d_1l.py
+++ b/pyFV3/stencils/tracer_2d_1l.py
@@ -1,8 +1,6 @@
 import math
 from typing import Dict
 
-from ndsl.dsl.gt4py import function, PARALLEL, computation, horizontal, interval, region
-
 from ndsl import (
     Quantity,
     QuantityFactory,
@@ -18,6 +16,7 @@ from ndsl.constants import (
     Y_INTERFACE_DIM,
     Z_DIM,
 )
+from ndsl.dsl.gt4py import PARALLEL, computation, function, horizontal, interval, region
 from ndsl.dsl.typing import Float, FloatField, FloatFieldIJ
 from ndsl.typing import Communicator
 from pyFV3.stencils.fvtp2d import FiniteVolumeTransport

--- a/pyFV3/stencils/tracer_2d_1l.py
+++ b/pyFV3/stencils/tracer_2d_1l.py
@@ -1,8 +1,7 @@
 import math
 from typing import Dict
 
-import gt4py.cartesian.gtscript as gtscript
-from gt4py.cartesian.gtscript import PARALLEL, computation, horizontal, interval, region
+from ndsl.dsl.gt4py import function, PARALLEL, computation, horizontal, interval, region
 
 from ndsl import (
     Quantity,
@@ -24,7 +23,7 @@ from ndsl.typing import Communicator
 from pyFV3.stencils.fvtp2d import FiniteVolumeTransport
 
 
-@gtscript.function
+@function
 def flux_x(cx, dxa, dy, sin_sg3, sin_sg1, xfx):
     from __externals__ import local_ie, local_is, local_je, local_js
 
@@ -35,7 +34,7 @@ def flux_x(cx, dxa, dy, sin_sg3, sin_sg1, xfx):
     return xfx
 
 
-@gtscript.function
+@function
 def flux_y(cy, dya, dx, sin_sg4, sin_sg2, yfx):
     from __externals__ import local_ie, local_is, local_je, local_js
 

--- a/pyFV3/stencils/updatedzc.py
+++ b/pyFV3/stencils/updatedzc.py
@@ -1,5 +1,4 @@
-import gt4py.cartesian.gtscript as gtscript
-from gt4py.cartesian.gtscript import BACKWARD, FORWARD, PARALLEL, computation, interval
+from ndsl.dsl.gt4py import function, BACKWARD, FORWARD, PARALLEL, computation, interval
 
 import ndsl.constants as constants
 from ndsl import Quantity, QuantityFactory, StencilFactory
@@ -11,26 +10,26 @@ from ndsl.stencils import corners
 DZ_MIN = constants.DZ_MIN
 
 
-@gtscript.function
+@function
 def p_weighted_average_top(vel, dp0):
     # TODO: ratio is a constant, where should this be placed?
     ratio = dp0 / (dp0 + dp0[1])
     return vel + (vel - vel[0, 0, 1]) * ratio
 
 
-@gtscript.function
+@function
 def p_weighted_average_bottom(vel, dp0):
     ratio = dp0[-1] / (dp0[-2] + dp0[-1])
     return vel[0, 0, -1] + (vel[0, 0, -1] - vel[0, 0, -2]) * ratio
 
 
-@gtscript.function
+@function
 def p_weighted_average_domain(vel, dp0):
     int_ratio = 1.0 / (dp0[-1] + dp0)
     return (dp0 * vel[0, 0, -1] + dp0[-1] * vel) * int_ratio
 
 
-@gtscript.function
+@function
 def xy_flux(gz_x, gz_y, xfx, yfx):
     """
     Compute first-order upwind fluxes of gz in x and y directions.

--- a/pyFV3/stencils/updatedzc.py
+++ b/pyFV3/stencils/updatedzc.py
@@ -1,8 +1,7 @@
-from ndsl.dsl.gt4py import function, BACKWARD, FORWARD, PARALLEL, computation, interval
-
 import ndsl.constants as constants
 from ndsl import Quantity, QuantityFactory, StencilFactory
 from ndsl.constants import X_DIM, Y_DIM, Z_DIM
+from ndsl.dsl.gt4py import BACKWARD, FORWARD, PARALLEL, computation, function, interval
 from ndsl.dsl.typing import Float, FloatField, FloatFieldIJ, FloatFieldK
 from ndsl.stencils import corners
 

--- a/pyFV3/stencils/updatedzc.py
+++ b/pyFV3/stencils/updatedzc.py
@@ -1,7 +1,9 @@
 import ndsl.constants as constants
 from ndsl import Quantity, QuantityFactory, StencilFactory
 from ndsl.constants import X_DIM, Y_DIM, Z_DIM
-from ndsl.dsl.gt4py import BACKWARD, FORWARD, PARALLEL, computation, function, interval
+from ndsl.dsl.gt4py import BACKWARD, FORWARD, PARALLEL, computation
+from ndsl.dsl.gt4py import function as gtfunction
+from ndsl.dsl.gt4py import interval
 from ndsl.dsl.typing import Float, FloatField, FloatFieldIJ, FloatFieldK
 from ndsl.stencils import corners
 
@@ -9,26 +11,26 @@ from ndsl.stencils import corners
 DZ_MIN = constants.DZ_MIN
 
 
-@function
+@gtfunction
 def p_weighted_average_top(vel, dp0):
     # TODO: ratio is a constant, where should this be placed?
     ratio = dp0 / (dp0 + dp0[1])
     return vel + (vel - vel[0, 0, 1]) * ratio
 
 
-@function
+@gtfunction
 def p_weighted_average_bottom(vel, dp0):
     ratio = dp0[-1] / (dp0[-2] + dp0[-1])
     return vel[0, 0, -1] + (vel[0, 0, -1] - vel[0, 0, -2]) * ratio
 
 
-@function
+@gtfunction
 def p_weighted_average_domain(vel, dp0):
     int_ratio = 1.0 / (dp0[-1] + dp0)
     return (dp0 * vel[0, 0, -1] + dp0[-1] * vel) * int_ratio
 
 
-@function
+@gtfunction
 def xy_flux(gz_x, gz_y, xfx, yfx):
     """
     Compute first-order upwind fluxes of gz in x and y directions.

--- a/pyFV3/stencils/updatedzd.py
+++ b/pyFV3/stencils/updatedzd.py
@@ -1,7 +1,6 @@
 from typing import Tuple
 
-import gt4py.cartesian.gtscript as gtscript
-from gt4py.cartesian.gtscript import BACKWARD, FORWARD, PARALLEL, computation, interval
+from ndsl.dsl.gt4py import function, BACKWARD, FORWARD, PARALLEL, computation, interval
 
 import ndsl.constants as constants
 from ndsl import Quantity, QuantityFactory, StencilFactory, orchestrate
@@ -22,7 +21,7 @@ from pyFV3.stencils.fvtp2d import FiniteVolumeTransport
 DZ_MIN = constants.DZ_MIN
 
 
-@gtscript.function
+@function
 def _apply_height_advective_flux(
     height: FloatField,
     area: FloatFieldIJ,

--- a/pyFV3/stencils/updatedzd.py
+++ b/pyFV3/stencils/updatedzd.py
@@ -10,7 +10,9 @@ from ndsl.constants import (
     Z_DIM,
     Z_INTERFACE_DIM,
 )
-from ndsl.dsl.gt4py import BACKWARD, FORWARD, PARALLEL, computation, function, interval
+from ndsl.dsl.gt4py import BACKWARD, FORWARD, PARALLEL, computation
+from ndsl.dsl.gt4py import function as gtfunction
+from ndsl.dsl.gt4py import interval
 from ndsl.dsl.typing import Float, FloatField, FloatFieldIJ, FloatFieldK
 from ndsl.grid import DampingCoefficients, GridData
 from pyFV3.stencils.delnflux import DelnFluxNoSG
@@ -20,7 +22,7 @@ from pyFV3.stencils.fvtp2d import FiniteVolumeTransport
 DZ_MIN = constants.DZ_MIN
 
 
-@function
+@gtfunction
 def _apply_height_advective_flux(
     height: FloatField,
     area: FloatFieldIJ,

--- a/pyFV3/stencils/updatedzd.py
+++ b/pyFV3/stencils/updatedzd.py
@@ -1,7 +1,5 @@
 from typing import Tuple
 
-from ndsl.dsl.gt4py import function, BACKWARD, FORWARD, PARALLEL, computation, interval
-
 import ndsl.constants as constants
 from ndsl import Quantity, QuantityFactory, StencilFactory, orchestrate
 from ndsl.constants import (
@@ -12,6 +10,7 @@ from ndsl.constants import (
     Z_DIM,
     Z_INTERFACE_DIM,
 )
+from ndsl.dsl.gt4py import BACKWARD, FORWARD, PARALLEL, computation, function, interval
 from ndsl.dsl.typing import Float, FloatField, FloatFieldIJ, FloatFieldK
 from ndsl.grid import DampingCoefficients, GridData
 from pyFV3.stencils.delnflux import DelnFluxNoSG

--- a/pyFV3/stencils/xppm.py
+++ b/pyFV3/stencils/xppm.py
@@ -1,17 +1,17 @@
+from ndsl import StencilFactory, orchestrate
 from ndsl.dsl.gt4py import (
     PARALLEL,
-    function,
+    compile_assert,
     computation,
+    function,
     horizontal,
     interval,
-    compile_assert,
     region,
 )
-
-from ndsl import StencilFactory, orchestrate
 from ndsl.dsl.typing import FloatField, FloatFieldIJ, Index3D
 from ndsl.stencils.basic_operations import sign
 from pyFV3.stencils import ppm
+
 
 from gt4py.cartesian.gtscript import __INLINED  # isort:skip
 

--- a/pyFV3/stencils/xppm.py
+++ b/pyFV3/stencils/xppm.py
@@ -1,13 +1,7 @@
 from ndsl import StencilFactory, orchestrate
-from ndsl.dsl.gt4py import (
-    PARALLEL,
-    compile_assert,
-    computation,
-    function,
-    horizontal,
-    interval,
-    region,
-)
+from ndsl.dsl.gt4py import PARALLEL, compile_assert, computation
+from ndsl.dsl.gt4py import function as gtfunction
+from ndsl.dsl.gt4py import horizontal, interval, region
 from ndsl.dsl.typing import FloatField, FloatFieldIJ, Index3D
 from ndsl.stencils.basic_operations import sign
 from pyFV3.stencils import ppm
@@ -16,7 +10,7 @@ from pyFV3.stencils import ppm
 from gt4py.cartesian.gtscript import __INLINED  # isort:skip
 
 
-@function
+@gtfunction
 def apply_flux(courant, q, fx1, mask):
     """
     Args:
@@ -29,7 +23,7 @@ def apply_flux(courant, q, fx1, mask):
     return q[-1, 0, 0] + fx1 * mask if courant > 0.0 else q + fx1 * mask
 
 
-@function
+@gtfunction
 def fx1_fn(courant, br, b0, bl):
     """
     Args:
@@ -45,7 +39,7 @@ def fx1_fn(courant, br, b0, bl):
     return ret
 
 
-@function
+@gtfunction
 def get_advection_mask(bl, b0, br):
     from __externals__ import mord
 
@@ -62,7 +56,7 @@ def get_advection_mask(bl, b0, br):
     return advection_mask
 
 
-@function
+@gtfunction
 def get_flux(q: FloatField, courant: FloatField, al: FloatField):
     bl = al[0, 0, 0] - q[0, 0, 0]
     br = al[1, 0, 0] - q[0, 0, 0]
@@ -73,7 +67,7 @@ def get_flux(q: FloatField, courant: FloatField, al: FloatField):
     return apply_flux(courant, q, fx1, advection_mask)  # noqa
 
 
-@function
+@gtfunction
 def get_flux_ord8plus(
     q: FloatField, courant: FloatField, bl: FloatField, br: FloatField
 ):
@@ -82,7 +76,7 @@ def get_flux_ord8plus(
     return apply_flux(courant, q, fx1, 1.0)
 
 
-@function
+@gtfunction
 def dm_iord8plus(q: FloatField):
     xt = 0.25 * (q[1, 0, 0] - q[-1, 0, 0])
     dqr = max(max(q, q[-1, 0, 0]), q[1, 0, 0]) - q
@@ -90,12 +84,12 @@ def dm_iord8plus(q: FloatField):
     return sign(min(min(abs(xt), dqr), dql), xt)
 
 
-@function
+@gtfunction
 def al_iord8plus(q: FloatField, dm: FloatField):
     return 0.5 * (q[-1, 0, 0] + q) + 1.0 / 3.0 * (dm[-1, 0, 0] - dm)
 
 
-@function
+@gtfunction
 def blbr_iord8(q: FloatField, al: FloatField, dm: FloatField):
     xt = 2.0 * dm
     bl = -1.0 * sign(min(abs(xt), abs(al - q)), xt)
@@ -103,7 +97,7 @@ def blbr_iord8(q: FloatField, al: FloatField, dm: FloatField):
     return bl, br
 
 
-@function
+@gtfunction
 def xt_dxa_edge_0_base(q, dxa):
     return 0.5 * (
         ((2.0 * dxa + dxa[-1, 0]) * q - dxa * q[-1, 0, 0]) / (dxa[-1, 0] + dxa)
@@ -112,7 +106,7 @@ def xt_dxa_edge_0_base(q, dxa):
     )
 
 
-@function
+@gtfunction
 def xt_dxa_edge_1_base(q, dxa):
     return 0.5 * (
         ((2.0 * dxa[-1, 0] + dxa[-2, 0]) * q[-1, 0, 0] - dxa[-1, 0] * q[-2, 0, 0])
@@ -121,7 +115,7 @@ def xt_dxa_edge_1_base(q, dxa):
     )
 
 
-@function
+@gtfunction
 def xt_dxa_edge_0(q, dxa):
     from __externals__ import xt_minmax
 
@@ -133,7 +127,7 @@ def xt_dxa_edge_0(q, dxa):
     return xt
 
 
-@function
+@gtfunction
 def xt_dxa_edge_1(q, dxa):
     from __externals__ import xt_minmax
 
@@ -145,7 +139,7 @@ def xt_dxa_edge_1(q, dxa):
     return xt
 
 
-@function
+@gtfunction
 def compute_al(q: FloatField, dxa: FloatFieldIJ):
     """
     Interpolate q at interface.
@@ -186,7 +180,7 @@ def compute_al(q: FloatField, dxa: FloatFieldIJ):
     return al
 
 
-@function
+@gtfunction
 def bl_br_edges(bl, br, q, dxa, al, dm):
     from __externals__ import i_end, i_start
 
@@ -251,7 +245,7 @@ def bl_br_edges(bl, br, q, dxa, al, dm):
     return bl, br
 
 
-@function
+@gtfunction
 def compute_blbr_ord8plus(q: FloatField, dxa: FloatFieldIJ):
     from __externals__ import grid_type, i_end, i_start, iord
 

--- a/pyFV3/stencils/xppm.py
+++ b/pyFV3/stencils/xppm.py
@@ -1,11 +1,10 @@
-from gt4py.cartesian import gtscript
-from gt4py.cartesian.gtscript import (
-    __INLINED,
+from ndsl.dsl.gt4py import (
     PARALLEL,
-    compile_assert,
+    function,
     computation,
     horizontal,
     interval,
+    compile_assert,
     region,
 )
 
@@ -14,8 +13,10 @@ from ndsl.dsl.typing import FloatField, FloatFieldIJ, Index3D
 from ndsl.stencils.basic_operations import sign
 from pyFV3.stencils import ppm
 
+from gt4py.cartesian.gtscript import __INLINED  # isort:skip
 
-@gtscript.function
+
+@function
 def apply_flux(courant, q, fx1, mask):
     """
     Args:
@@ -28,7 +29,7 @@ def apply_flux(courant, q, fx1, mask):
     return q[-1, 0, 0] + fx1 * mask if courant > 0.0 else q + fx1 * mask
 
 
-@gtscript.function
+@function
 def fx1_fn(courant, br, b0, bl):
     """
     Args:
@@ -44,7 +45,7 @@ def fx1_fn(courant, br, b0, bl):
     return ret
 
 
-@gtscript.function
+@function
 def get_advection_mask(bl, b0, br):
     from __externals__ import mord
 
@@ -61,7 +62,7 @@ def get_advection_mask(bl, b0, br):
     return advection_mask
 
 
-@gtscript.function
+@function
 def get_flux(q: FloatField, courant: FloatField, al: FloatField):
     bl = al[0, 0, 0] - q[0, 0, 0]
     br = al[1, 0, 0] - q[0, 0, 0]
@@ -72,7 +73,7 @@ def get_flux(q: FloatField, courant: FloatField, al: FloatField):
     return apply_flux(courant, q, fx1, advection_mask)  # noqa
 
 
-@gtscript.function
+@function
 def get_flux_ord8plus(
     q: FloatField, courant: FloatField, bl: FloatField, br: FloatField
 ):
@@ -81,7 +82,7 @@ def get_flux_ord8plus(
     return apply_flux(courant, q, fx1, 1.0)
 
 
-@gtscript.function
+@function
 def dm_iord8plus(q: FloatField):
     xt = 0.25 * (q[1, 0, 0] - q[-1, 0, 0])
     dqr = max(max(q, q[-1, 0, 0]), q[1, 0, 0]) - q
@@ -89,12 +90,12 @@ def dm_iord8plus(q: FloatField):
     return sign(min(min(abs(xt), dqr), dql), xt)
 
 
-@gtscript.function
+@function
 def al_iord8plus(q: FloatField, dm: FloatField):
     return 0.5 * (q[-1, 0, 0] + q) + 1.0 / 3.0 * (dm[-1, 0, 0] - dm)
 
 
-@gtscript.function
+@function
 def blbr_iord8(q: FloatField, al: FloatField, dm: FloatField):
     xt = 2.0 * dm
     bl = -1.0 * sign(min(abs(xt), abs(al - q)), xt)
@@ -102,7 +103,7 @@ def blbr_iord8(q: FloatField, al: FloatField, dm: FloatField):
     return bl, br
 
 
-@gtscript.function
+@function
 def xt_dxa_edge_0_base(q, dxa):
     return 0.5 * (
         ((2.0 * dxa + dxa[-1, 0]) * q - dxa * q[-1, 0, 0]) / (dxa[-1, 0] + dxa)
@@ -111,7 +112,7 @@ def xt_dxa_edge_0_base(q, dxa):
     )
 
 
-@gtscript.function
+@function
 def xt_dxa_edge_1_base(q, dxa):
     return 0.5 * (
         ((2.0 * dxa[-1, 0] + dxa[-2, 0]) * q[-1, 0, 0] - dxa[-1, 0] * q[-2, 0, 0])
@@ -120,7 +121,7 @@ def xt_dxa_edge_1_base(q, dxa):
     )
 
 
-@gtscript.function
+@function
 def xt_dxa_edge_0(q, dxa):
     from __externals__ import xt_minmax
 
@@ -132,7 +133,7 @@ def xt_dxa_edge_0(q, dxa):
     return xt
 
 
-@gtscript.function
+@function
 def xt_dxa_edge_1(q, dxa):
     from __externals__ import xt_minmax
 
@@ -144,7 +145,7 @@ def xt_dxa_edge_1(q, dxa):
     return xt
 
 
-@gtscript.function
+@function
 def compute_al(q: FloatField, dxa: FloatFieldIJ):
     """
     Interpolate q at interface.
@@ -185,7 +186,7 @@ def compute_al(q: FloatField, dxa: FloatFieldIJ):
     return al
 
 
-@gtscript.function
+@function
 def bl_br_edges(bl, br, q, dxa, al, dm):
     from __externals__ import i_end, i_start
 
@@ -250,7 +251,7 @@ def bl_br_edges(bl, br, q, dxa, al, dm):
     return bl, br
 
 
-@gtscript.function
+@function
 def compute_blbr_ord8plus(q: FloatField, dxa: FloatFieldIJ):
     from __externals__ import grid_type, i_end, i_start, iord
 

--- a/pyFV3/stencils/xtp_u.py
+++ b/pyFV3/stencils/xtp_u.py
@@ -1,11 +1,10 @@
-from gt4py.cartesian import gtscript
-from gt4py.cartesian.gtscript import __INLINED, compile_assert, horizontal, region
+from ndsl.dsl.gt4py import function, compile_assert, horizontal, region
 
 from ndsl.dsl.typing import Float, FloatField, FloatFieldIJ
 from pyFV3.stencils import ppm, xppm
 
 
-@gtscript.function
+@function
 def get_bl_br(u, dx, dxa):
     """
     Args:
@@ -53,7 +52,7 @@ def get_bl_br(u, dx, dxa):
     return bl, br
 
 
-@gtscript.function
+@function
 def advect_u_along_x(
     u: FloatField,
     ub_contra: FloatField,

--- a/pyFV3/stencils/xtp_u.py
+++ b/pyFV3/stencils/xtp_u.py
@@ -1,4 +1,6 @@
-from ndsl.dsl.gt4py import compile_assert, function, horizontal, region
+from ndsl.dsl.gt4py import compile_assert
+from ndsl.dsl.gt4py import function as gtfunction
+from ndsl.dsl.gt4py import horizontal, region
 from ndsl.dsl.typing import Float, FloatField, FloatFieldIJ
 from pyFV3.stencils import ppm, xppm
 
@@ -6,7 +8,7 @@ from pyFV3.stencils import ppm, xppm
 from gt4py.cartesian.gtscript import __INLINED  # isort:skip
 
 
-@function
+@gtfunction
 def get_bl_br(u, dx, dxa):
     """
     Args:
@@ -54,7 +56,7 @@ def get_bl_br(u, dx, dxa):
     return bl, br
 
 
-@function
+@gtfunction
 def advect_u_along_x(
     u: FloatField,
     ub_contra: FloatField,

--- a/pyFV3/stencils/xtp_u.py
+++ b/pyFV3/stencils/xtp_u.py
@@ -1,7 +1,9 @@
-from ndsl.dsl.gt4py import function, compile_assert, horizontal, region
-
+from ndsl.dsl.gt4py import compile_assert, function, horizontal, region
 from ndsl.dsl.typing import Float, FloatField, FloatFieldIJ
 from pyFV3.stencils import ppm, xppm
+
+
+from gt4py.cartesian.gtscript import __INLINED  # isort:skip
 
 
 @function

--- a/pyFV3/stencils/yppm.py
+++ b/pyFV3/stencils/yppm.py
@@ -1,17 +1,17 @@
+from ndsl import StencilFactory, orchestrate
 from ndsl.dsl.gt4py import (
     PARALLEL,
-    function,
     compile_assert,
     computation,
+    function,
     horizontal,
     interval,
     region,
 )
-
-from ndsl import StencilFactory, orchestrate
 from ndsl.dsl.typing import FloatField, FloatFieldIJ, Index3D
 from ndsl.stencils.basic_operations import sign
 from pyFV3.stencils import ppm
+
 
 from gt4py.cartesian.gtscript import __INLINED  # isort:skip
 

--- a/pyFV3/stencils/yppm.py
+++ b/pyFV3/stencils/yppm.py
@@ -1,7 +1,6 @@
-from gt4py.cartesian import gtscript
-from gt4py.cartesian.gtscript import (
-    __INLINED,
+from ndsl.dsl.gt4py import (
     PARALLEL,
+    function,
     compile_assert,
     computation,
     horizontal,
@@ -14,8 +13,10 @@ from ndsl.dsl.typing import FloatField, FloatFieldIJ, Index3D
 from ndsl.stencils.basic_operations import sign
 from pyFV3.stencils import ppm
 
+from gt4py.cartesian.gtscript import __INLINED  # isort:skip
 
-@gtscript.function
+
+@function
 def apply_flux(courant, q, fx1, mask):
     """
     Args:
@@ -28,7 +29,7 @@ def apply_flux(courant, q, fx1, mask):
     return q[0, -1, 0] + fx1 * mask if courant > 0.0 else q + fx1 * mask
 
 
-@gtscript.function
+@function
 def fx1_fn(courant, br, b0, bl):
     """
     Args:
@@ -44,7 +45,7 @@ def fx1_fn(courant, br, b0, bl):
     return ret
 
 
-@gtscript.function
+@function
 def get_advection_mask(bl, b0, br):
     from __externals__ import mord
 
@@ -61,7 +62,7 @@ def get_advection_mask(bl, b0, br):
     return advection_mask
 
 
-@gtscript.function
+@function
 def get_flux(q: FloatField, courant: FloatField, al: FloatField):
     bl = al[0, 0, 0] - q[0, 0, 0]
     br = al[0, 1, 0] - q[0, 0, 0]
@@ -72,7 +73,7 @@ def get_flux(q: FloatField, courant: FloatField, al: FloatField):
     return apply_flux(courant, q, fx1, advection_mask)  # noqa
 
 
-@gtscript.function
+@function
 def get_flux_ord8plus(
     q: FloatField, courant: FloatField, bl: FloatField, br: FloatField
 ):
@@ -81,7 +82,7 @@ def get_flux_ord8plus(
     return apply_flux(courant, q, fx1, 1.0)
 
 
-@gtscript.function
+@function
 def dm_jord8plus(q: FloatField):
     yt = 0.25 * (q[0, 1, 0] - q[0, -1, 0])
     dqr = max(max(q, q[0, -1, 0]), q[0, 1, 0]) - q
@@ -89,12 +90,12 @@ def dm_jord8plus(q: FloatField):
     return sign(min(min(abs(yt), dqr), dql), yt)
 
 
-@gtscript.function
+@function
 def al_jord8plus(q: FloatField, dm: FloatField):
     return 0.5 * (q[0, -1, 0] + q) + 1.0 / 3.0 * (dm[0, -1, 0] - dm)
 
 
-@gtscript.function
+@function
 def blbr_jord8(q: FloatField, al: FloatField, dm: FloatField):
     yt = 2.0 * dm
     bl = -1.0 * sign(min(abs(yt), abs(al - q)), yt)
@@ -102,7 +103,7 @@ def blbr_jord8(q: FloatField, al: FloatField, dm: FloatField):
     return bl, br
 
 
-@gtscript.function
+@function
 def yt_dya_edge_0_base(q, dya):
     return 0.5 * (
         ((2.0 * dya + dya[0, -1]) * q - dya * q[0, -1, 0]) / (dya[0, -1] + dya)
@@ -111,7 +112,7 @@ def yt_dya_edge_0_base(q, dya):
     )
 
 
-@gtscript.function
+@function
 def yt_dya_edge_1_base(q, dya):
     return 0.5 * (
         ((2.0 * dya[0, -1] + dya[0, -2]) * q[0, -1, 0] - dya[0, -1] * q[0, -2, 0])
@@ -120,7 +121,7 @@ def yt_dya_edge_1_base(q, dya):
     )
 
 
-@gtscript.function
+@function
 def yt_dya_edge_0(q, dya):
     from __externals__ import yt_minmax
 
@@ -132,7 +133,7 @@ def yt_dya_edge_0(q, dya):
     return yt
 
 
-@gtscript.function
+@function
 def yt_dya_edge_1(q, dya):
     from __externals__ import yt_minmax
 
@@ -144,7 +145,7 @@ def yt_dya_edge_1(q, dya):
     return yt
 
 
-@gtscript.function
+@function
 def compute_al(q: FloatField, dya: FloatFieldIJ):
     """
     Interpolate q at interface.
@@ -185,7 +186,7 @@ def compute_al(q: FloatField, dya: FloatFieldIJ):
     return al
 
 
-@gtscript.function
+@function
 def bl_br_edges(bl, br, q, dya, al, dm):
     from __externals__ import j_end, j_start
 
@@ -250,7 +251,7 @@ def bl_br_edges(bl, br, q, dya, al, dm):
     return bl, br
 
 
-@gtscript.function
+@function
 def compute_blbr_ord8plus(q: FloatField, dya: FloatFieldIJ):
     from __externals__ import grid_type, j_end, j_start, jord
 

--- a/pyFV3/stencils/yppm.py
+++ b/pyFV3/stencils/yppm.py
@@ -1,13 +1,7 @@
 from ndsl import StencilFactory, orchestrate
-from ndsl.dsl.gt4py import (
-    PARALLEL,
-    compile_assert,
-    computation,
-    function,
-    horizontal,
-    interval,
-    region,
-)
+from ndsl.dsl.gt4py import PARALLEL, compile_assert, computation
+from ndsl.dsl.gt4py import function as gtfunction
+from ndsl.dsl.gt4py import horizontal, interval, region
 from ndsl.dsl.typing import FloatField, FloatFieldIJ, Index3D
 from ndsl.stencils.basic_operations import sign
 from pyFV3.stencils import ppm
@@ -16,7 +10,7 @@ from pyFV3.stencils import ppm
 from gt4py.cartesian.gtscript import __INLINED  # isort:skip
 
 
-@function
+@gtfunction
 def apply_flux(courant, q, fx1, mask):
     """
     Args:
@@ -29,7 +23,7 @@ def apply_flux(courant, q, fx1, mask):
     return q[0, -1, 0] + fx1 * mask if courant > 0.0 else q + fx1 * mask
 
 
-@function
+@gtfunction
 def fx1_fn(courant, br, b0, bl):
     """
     Args:
@@ -45,7 +39,7 @@ def fx1_fn(courant, br, b0, bl):
     return ret
 
 
-@function
+@gtfunction
 def get_advection_mask(bl, b0, br):
     from __externals__ import mord
 
@@ -62,7 +56,7 @@ def get_advection_mask(bl, b0, br):
     return advection_mask
 
 
-@function
+@gtfunction
 def get_flux(q: FloatField, courant: FloatField, al: FloatField):
     bl = al[0, 0, 0] - q[0, 0, 0]
     br = al[0, 1, 0] - q[0, 0, 0]
@@ -73,7 +67,7 @@ def get_flux(q: FloatField, courant: FloatField, al: FloatField):
     return apply_flux(courant, q, fx1, advection_mask)  # noqa
 
 
-@function
+@gtfunction
 def get_flux_ord8plus(
     q: FloatField, courant: FloatField, bl: FloatField, br: FloatField
 ):
@@ -82,7 +76,7 @@ def get_flux_ord8plus(
     return apply_flux(courant, q, fx1, 1.0)
 
 
-@function
+@gtfunction
 def dm_jord8plus(q: FloatField):
     yt = 0.25 * (q[0, 1, 0] - q[0, -1, 0])
     dqr = max(max(q, q[0, -1, 0]), q[0, 1, 0]) - q
@@ -90,12 +84,12 @@ def dm_jord8plus(q: FloatField):
     return sign(min(min(abs(yt), dqr), dql), yt)
 
 
-@function
+@gtfunction
 def al_jord8plus(q: FloatField, dm: FloatField):
     return 0.5 * (q[0, -1, 0] + q) + 1.0 / 3.0 * (dm[0, -1, 0] - dm)
 
 
-@function
+@gtfunction
 def blbr_jord8(q: FloatField, al: FloatField, dm: FloatField):
     yt = 2.0 * dm
     bl = -1.0 * sign(min(abs(yt), abs(al - q)), yt)
@@ -103,7 +97,7 @@ def blbr_jord8(q: FloatField, al: FloatField, dm: FloatField):
     return bl, br
 
 
-@function
+@gtfunction
 def yt_dya_edge_0_base(q, dya):
     return 0.5 * (
         ((2.0 * dya + dya[0, -1]) * q - dya * q[0, -1, 0]) / (dya[0, -1] + dya)
@@ -112,7 +106,7 @@ def yt_dya_edge_0_base(q, dya):
     )
 
 
-@function
+@gtfunction
 def yt_dya_edge_1_base(q, dya):
     return 0.5 * (
         ((2.0 * dya[0, -1] + dya[0, -2]) * q[0, -1, 0] - dya[0, -1] * q[0, -2, 0])
@@ -121,7 +115,7 @@ def yt_dya_edge_1_base(q, dya):
     )
 
 
-@function
+@gtfunction
 def yt_dya_edge_0(q, dya):
     from __externals__ import yt_minmax
 
@@ -133,7 +127,7 @@ def yt_dya_edge_0(q, dya):
     return yt
 
 
-@function
+@gtfunction
 def yt_dya_edge_1(q, dya):
     from __externals__ import yt_minmax
 
@@ -145,7 +139,7 @@ def yt_dya_edge_1(q, dya):
     return yt
 
 
-@function
+@gtfunction
 def compute_al(q: FloatField, dya: FloatFieldIJ):
     """
     Interpolate q at interface.
@@ -186,7 +180,7 @@ def compute_al(q: FloatField, dya: FloatFieldIJ):
     return al
 
 
-@function
+@gtfunction
 def bl_br_edges(bl, br, q, dya, al, dm):
     from __externals__ import j_end, j_start
 
@@ -251,7 +245,7 @@ def bl_br_edges(bl, br, q, dya, al, dm):
     return bl, br
 
 
-@function
+@gtfunction
 def compute_blbr_ord8plus(q: FloatField, dya: FloatFieldIJ):
     from __externals__ import grid_type, j_end, j_start, jord
 

--- a/pyFV3/stencils/ytp_v.py
+++ b/pyFV3/stencils/ytp_v.py
@@ -1,11 +1,12 @@
-from gt4py.cartesian import gtscript
-from gt4py.cartesian.gtscript import __INLINED, compile_assert, horizontal, region
+from ndsl.dsl.gt4py import function, compile_assert, horizontal, region
 
 from ndsl.dsl.typing import Float, FloatField, FloatFieldIJ
 from pyFV3.stencils import ppm, yppm
 
+from gt4py.cartesian.gtscript import __INLINED  # isort:skip
 
-@gtscript.function
+
+@function
 def get_bl_br(v, dy, dya):
     """
     Args:
@@ -53,7 +54,7 @@ def get_bl_br(v, dy, dya):
     return bl, br
 
 
-@gtscript.function
+@function
 def advect_v_along_y(
     v: FloatField,
     vb_contra: FloatField,

--- a/pyFV3/stencils/ytp_v.py
+++ b/pyFV3/stencils/ytp_v.py
@@ -1,7 +1,7 @@
-from ndsl.dsl.gt4py import function, compile_assert, horizontal, region
-
+from ndsl.dsl.gt4py import compile_assert, function, horizontal, region
 from ndsl.dsl.typing import Float, FloatField, FloatFieldIJ
 from pyFV3.stencils import ppm, yppm
+
 
 from gt4py.cartesian.gtscript import __INLINED  # isort:skip
 

--- a/pyFV3/stencils/ytp_v.py
+++ b/pyFV3/stencils/ytp_v.py
@@ -1,4 +1,6 @@
-from ndsl.dsl.gt4py import compile_assert, function, horizontal, region
+from ndsl.dsl.gt4py import compile_assert
+from ndsl.dsl.gt4py import function as gtfunction
+from ndsl.dsl.gt4py import horizontal, region
 from ndsl.dsl.typing import Float, FloatField, FloatFieldIJ
 from pyFV3.stencils import ppm, yppm
 
@@ -6,7 +8,7 @@ from pyFV3.stencils import ppm, yppm
 from gt4py.cartesian.gtscript import __INLINED  # isort:skip
 
 
-@function
+@gtfunction
 def get_bl_br(v, dy, dya):
     """
     Args:
@@ -54,7 +56,7 @@ def get_bl_br(v, dy, dya):
     return bl, br
 
 
-@function
+@gtfunction
 def advect_v_along_y(
     v: FloatField,
     vb_contra: FloatField,


### PR DESCRIPTION
All references to GT4Py have been removed and replaced with imports from NDSL, bringing this repository in compliance with the changes made to NDSL [here](https://github.com/NOAA-GFDL/NDSL/pull/126).

All future references to GT4Py tools should be references via `ndsl.dsl.gt4py` instead of `gt4py.cartesian.gtscript`.