### PR TITLE
Avoid deprecated floating_point_precision()

### DIFF
--- a/pyFV3/wrappers/geos_wrapper.py
+++ b/pyFV3/wrappers/geos_wrapper.py
@@ -29,7 +29,7 @@ from ndsl import (
 from ndsl.comm.comm_abc import Comm
 from ndsl.dsl.dace.build import set_distributed_caches
 from ndsl.dsl.gt4py_utils import is_gpu_backend
-from ndsl.dsl.typing import floating_point_precision
+from ndsl.dsl.typing import get_precision
 from ndsl.grid import DampingCoefficients, GridData, MetricTerms
 from ndsl.logging import ndsl_log
 from ndsl.optional_imports import cupy as cp
@@ -217,7 +217,7 @@ class GeosDycoreWrapper:
             f"             dt : {self.dycore_state.bdt}\n"
             f"         bridge : {self._fortran_mem_space} > {self._pace_mem_space}\n"
             f"        backend : {backend}\n"
-            f"          float : {floating_point_precision()}bit"
+            f"          float : {get_precision()}bit"
             f"  orchestration : {self._is_orchestrated}\n"
             f"          sizer : {sizer.nx}x{sizer.ny}x{sizer.nz}"
             f"(halo: {sizer.n_halo})\n"


### PR DESCRIPTION
**Description**

With PR https://github.com/NOAA-GFDL/NDSL/pull/104/ that function was deprecated in favor of `get_precision()`. The new function is a drop-in replacement for the old one. Since we use NDSL version `2025.03.00` now, we can use the new function name.

**How Has This Been Tested?**

Should be covered by CI.

**Checklist:**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas: N/A
- [ ] I have made corresponding changes to the documentation: N/A
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [ ] New check tests, if applicable, are included: N/A
- [ ] Targeted model if this changed was triggered by a model need/shortcoming: N/A
