### PR TITLE
Fix: Pull NDSL from `develop` branch

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ test_requirements = [
     "serialbox",
 ]
 
-ndsl_requirements = ["ndsl @ git+https://github.com/NOAA-GFDL/NDSL.git@2025.03.00"]
+ndsl_requirements = ["ndsl @ git+https://github.com/NOAA-GFDL/NDSL.git@develop"]
 
 develop_requirements = [
     *ndsl_requirements,


### PR DESCRIPTION
**Description**
This PR changes the `setup.py` `NDSL` requirement to pull from its `develop` branch instead of the release branch. This matches the behavior in `pySHiELD`.

**How Has This Been Tested?**
Tested using the current GitHub CI

**Checklist:**
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] New check tests, if applicable, are included
- [ ] Targeted model if this changed was triggered by a model need/shortcoming
