### PR TITLE
ci: Remove `PACE_TEST_N_THRESHOLD_SAMPLES` in translate tests

### DIFF
--- a/.github/workflows/translate.yaml
+++ b/.github/workflows/translate.yaml
@@ -105,7 +105,6 @@ jobs:
           cd ${GITHUB_WORKSPACE}/pyFV3
           export FV3_DACEMODE=BuildAndRun
           export PACE_FLOAT_PRECISION=64
-          export PACE_TEST_N_THRESHOLD_SAMPLES=0
           export OMP_NUM_THREADS=1
           export PACE_LOGLEVEL=Debug
           mpiexec -mca orte_abort_on_non_zero_status 1 -np 6 --oversubscribe coverage run --rcfile=setup.cfg -m mpi4py -m pytest \


### PR DESCRIPTION
**Description**

Don't set `PACE_TEST_N_THRESHOLD_SAMPLES` in translate tests anymore since the environment variable was renamed in PR https://github.com/NOAA-GFDL/NDSL/pull/134 and the default changed to match the currently configured behavior.

Now that `develop` of `PyFV3` tracks `develop` of `NDSL`, we can do this change without waiting for a release of `NDSL` (which is incoming anyway).

**How Has This Been Tested?**

By running the CI.

**Checklist:**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas: N/A
- [ ] I have made corresponding changes to the documentation: N/A
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [ ] New check tests, if applicable, are included: N/A
- [ ] Targeted model if this changed was triggered by a model need/shortcoming: N/A
