### PR TITLE
No boost dependency anymore

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,6 @@ RUN apt-get update -y && \
     libgeos-dev \
     libopenmpi3 \
     libopenmpi-dev \
-    libboost-all-dev \
     libhdf5-serial-dev \
     libffi-dev \
     netcdf-bin \


### PR DESCRIPTION
**Description**

Newer GT4Py versions ship with a vendored in version of the boost header file that it needs. And since NDSL updated its GT4Py version, we don't need to install boost anymore in the `Dockerfile` for PyFV3. Not sure if anyone uses the docker version, but it's easy enough to just clean up.

For the record: The relevant GT4Py update in NDSL was done in https://github.com/NOAA-GFDL/NDSL/pull/150.

**How Has This Been Tested?**

By doing a self-review of the code changes.

**Checklist:**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas: N/A
- [ ] I have made corresponding changes to the documentation: N/A
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [ ] New check tests, if applicable, are included: N/A
- [ ] Targeted model if this changed was triggered by a model need/shortcoming: N/A
