### PR TITLE
ci: recent versions of linting tools and new-style license information in `pyproject.toml`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,19 +3,19 @@ default_language_version:
 
 repos:
 -   repo: https://github.com/psf/black
-    rev: 20.8b1
+    rev: 25.1.0
     hooks:
     - id: black
       additional_dependencies: ["click==8.0.4"]
 
 -   repo: https://github.com/pre-commit/mirrors-isort
-    rev: v5.4.2
+    rev: v5.10.1
     hooks:
     - id: isort
       args: ["--profile", "black"]
 
 -   repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.4.1
+    rev: v1.17.0
     hooks:
     - id: mypy
       name: mypy-fv3core
@@ -28,14 +28,14 @@ repos:
         pyFV3/tests/conftest.py
         )$
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v2.3.0
+    rev: v5.0.0
     hooks:
     - id: check-toml
     - id: check-yaml
     - id: end-of-file-fixer
     - id: trailing-whitespace
 -   repo: https://github.com/pycqa/flake8
-    rev: 3.9.2
+    rev: 7.3.0
     hooks:
     - id: flake8
       name: flake8

--- a/pyfv3/initialization/init_utils.py
+++ b/pyfv3/initialization/init_utils.py
@@ -208,7 +208,7 @@ def initialize_kappa_pressures(pe, peln, ptop):
     """
     pk = np.zeros(pe.shape)
     pkz = np.zeros(pe.shape)
-    pk[:, :, 0] = ptop ** constants.KAPPA
+    pk[:, :, 0] = ptop**constants.KAPPA
     pk[:, :, 1:] = np.exp(constants.KAPPA * np.log(pe[:, :, 1:]))
     pkz[:, :, :-1] = (pk[:, :, 1:] - pk[:, :, :-1]) / (
         constants.KAPPA * (peln[:, :, 1:] - peln[:, :, :-1])

--- a/pyfv3/initialization/test_cases/initialize_tc.py
+++ b/pyfv3/initialization/test_cases/initialize_tc.py
@@ -15,7 +15,7 @@ def _calculate_distance_from_tc_center(pe_v, ps_v, muv, calc, tc_properties):
         muv["midpoint"][:, :, 0] - calc["p0"][0]
     )
     d2 = np.cos(calc["p0"][1]) * np.sin(muv["midpoint"][:, :, 0] - calc["p0"][0])
-    d = np.sqrt(d1 ** 2 + d2 ** 2)
+    d = np.sqrt(d1**2 + d2**2)
     d[d < 1e-15] = 1e-15
 
     r = great_circle_distance_lon_lat(

--- a/pyfv3/stencils/divergence_damping.py
+++ b/pyfv3/stencils/divergence_damping.py
@@ -246,7 +246,7 @@ def smagorinsky_diffusion_approx(delpc: FloatField, vort: FloatField, absdt: Flo
         absdt (in): abs(dt)
     """
     with computation(PARALLEL), interval(...):
-        vort = absdt * (delpc ** 2.0 + vort ** 2.0) ** 0.5
+        vort = absdt * (delpc**2.0 + vort**2.0) ** 0.5
 
 
 def smag_corner(
@@ -290,7 +290,7 @@ def smag_corner(
         wk = rarea * (vt2 - vt2[0, 1, 0] + ut2 - ut2[1, 0, 0])
 
         shear = doubly_periodic_a2b_ord4(wk)
-        smag_c = dt * sqrt(shear ** 2 + smag_c_t ** 2)
+        smag_c = dt * sqrt(shear**2 + smag_c_t**2)
 
 
 class DivergenceDamping:

--- a/pyfv3/stencils/fv_subgridz.py
+++ b/pyfv3/stencils/fv_subgridz.py
@@ -59,7 +59,7 @@ def standard_cm(cpm, cvm, q0_vapor, q0_liquid, q0_rain, q0_ice, q0_snow, q0_grau
 
 @gtfunction
 def tvol(gz, u0, v0, w0):
-    return gz + 0.5 * (u0 ** 2 + v0 ** 2 + w0 ** 2)
+    return gz + 0.5 * (u0**2 + v0**2 + w0**2)
 
 
 def init(

--- a/pyfv3/stencils/pk3_halo.py
+++ b/pyfv3/stencils/pk3_halo.py
@@ -28,7 +28,7 @@ def edge_pe_update(
                 region[local_is - 2 : local_ie + 3, local_je + 1 : local_je + 3],
             ):
                 pe = pe + delp[0, 0, -1]
-                pk3 = pe ** akap
+                pk3 = pe**akap
 
 
 class PK3Halo:

--- a/pyfv3/stencils/ppm.py
+++ b/pyfv3/stencils/ppm.py
@@ -21,7 +21,7 @@ s15 = 3.0 / 14.0
 def pert_ppm_standard_constraint_fcn(a0: FloatField, al: FloatField, ar: FloatField):
     if al * ar < 0.0:
         da1 = al - ar
-        da2 = da1 ** 2
+        da2 = da1**2
         a6da = 3.0 * (al + ar) * da1
         if a6da < -da2:
             ar = -2.0 * al
@@ -45,7 +45,7 @@ def pert_ppm_positive_definite_constraint_fcn(
         a4 = -3.0 * (ar + al)
         da1 = ar - al
         if abs(da1) < -a4:
-            fmin = a0 + 0.25 / a4 * da1 ** 2 + a4 * (1.0 / 12.0)
+            fmin = a0 + 0.25 / a4 * da1**2 + a4 * (1.0 / 12.0)
             if fmin < 0.0:
                 if ar > 0.0 and al > 0.0:
                     ar = 0.0

--- a/pyfv3/stencils/remap_profile.py
+++ b/pyfv3/stencils/remap_profile.py
@@ -37,9 +37,7 @@ def constrain_interior(q, gam, a4):
     return (
         limit_both(q, a4)
         if (gam[0, 0, -1] * gam[0, 0, 1] > 0.0)
-        else limit_maxmin(q, a4)
-        if (gam[0, 0, -1] > 0.0)
-        else limit_minmax(q, a4)
+        else limit_maxmin(q, a4) if (gam[0, 0, -1] > 0.0) else limit_minmax(q, a4)
     )
 
 
@@ -402,17 +400,13 @@ def set_interpolation_coefficients(
             tmp_min = (
                 a4_1
                 if (a4_1 < pmp_1) and (a4_1 < lac_1)
-                else pmp_1
-                if pmp_1 < lac_1
-                else lac_1
+                else pmp_1 if pmp_1 < lac_1 else lac_1
             )
             tmp_max0 = a4_2 if a4_2 > tmp_min else tmp_min
             tmp_max = (
                 a4_1
                 if (a4_1 > pmp_1) and (a4_1 > lac_1)
-                else pmp_1
-                if pmp_1 > lac_1
-                else lac_1
+                else pmp_1 if pmp_1 > lac_1 else lac_1
             )
             a4_2 = tmp_max0 if tmp_max0 < tmp_max else tmp_max
             # right edges?
@@ -421,17 +415,13 @@ def set_interpolation_coefficients(
             tmp_min = (
                 a4_1
                 if (a4_1 < pmp_2) and (a4_1 < lac_2)
-                else pmp_2
-                if pmp_2 < lac_2
-                else lac_2
+                else pmp_2 if pmp_2 < lac_2 else lac_2
             )
             tmp_max0 = a4_3 if a4_3 > tmp_min else tmp_min
             tmp_max = (
                 a4_1
                 if (a4_1 > pmp_2) and (a4_1 > lac_2)
-                else pmp_2
-                if pmp_2 > lac_2
-                else lac_2
+                else pmp_2 if pmp_2 > lac_2 else lac_2
             )
             a4_3 = tmp_max0 if tmp_max0 < tmp_max else tmp_max
             a4_4 = 3.0 * (2.0 * a4_1 - (a4_2 + a4_3))
@@ -458,33 +448,25 @@ def set_interpolation_coefficients(
                     tmp_min = (
                         a4_1
                         if (a4_1 < pmp_1) and (a4_1 < lac_1)
-                        else pmp_1
-                        if pmp_1 < lac_1
-                        else lac_1
+                        else pmp_1 if pmp_1 < lac_1 else lac_1
                     )
                     tmp_max0 = a4_2 if a4_2 > tmp_min else tmp_min
                     tmp_max = (
                         a4_1
                         if (a4_1 > pmp_1) and (a4_1 > lac_1)
-                        else pmp_1
-                        if pmp_1 > lac_1
-                        else lac_1
+                        else pmp_1 if pmp_1 > lac_1 else lac_1
                     )
                     a4_2 = tmp_max0 if tmp_max0 < tmp_max else tmp_max
                     tmp_min = (
                         a4_1
                         if (a4_1 < pmp_2) and (a4_1 < lac_2)
-                        else pmp_2
-                        if pmp_2 < lac_2
-                        else lac_2
+                        else pmp_2 if pmp_2 < lac_2 else lac_2
                     )
                     tmp_max0 = a4_3 if a4_3 > tmp_min else tmp_min
                     tmp_max = (
                         a4_1
                         if (a4_1 > pmp_2) and (a4_1 > lac_2)
-                        else pmp_2
-                        if pmp_2 > lac_2
-                        else lac_2
+                        else pmp_2 if pmp_2 > lac_2 else lac_2
                     )
                     a4_3 = tmp_max0 if tmp_max0 < tmp_max else tmp_max
                     a4_4 = 6.0 * a4_1 - 3.0 * (a4_2 + a4_3)
@@ -499,16 +481,12 @@ def set_interpolation_coefficients(
             tmp_min2 = (
                 a4_1
                 if (a4_1 < pmp_1) and (a4_1 < lac_1)
-                else pmp_1
-                if pmp_1 < lac_1
-                else lac_1
+                else pmp_1 if pmp_1 < lac_1 else lac_1
             )
             tmp_max2 = (
                 a4_1
                 if (a4_1 > pmp_1) and (a4_1 > lac_1)
-                else pmp_1
-                if pmp_1 > lac_1
-                else lac_1
+                else pmp_1 if pmp_1 > lac_1 else lac_1
             )
             tmp2 = a4_2 if a4_2 > tmp_min2 else tmp_min2
             tmp_min3 = a4_1 if a4_1 < pmp_2 else pmp_2

--- a/pyfv3/stencils/saturation_adjustment.py
+++ b/pyfv3/stencils/saturation_adjustment.py
@@ -256,7 +256,7 @@ def heterogeneous_freezing(
 ):
     tc = constants.TICE0 - pt1
     if ql > 0.0 and tc > 0.0:
-        sink = 3.3333e-10 * dt_bigg * (exptc - 1.0) * den * ql ** 2
+        sink = 3.3333e-10 * dt_bigg * (exptc - 1.0) * den * ql**2
         sink = min(ql, sink)
         sink = min(sink, tc / icp2)
         ql = ql - sink
@@ -354,10 +354,7 @@ def sublimation(
                 * 349138.78
                 * expsubl
                 / (
-                    iqs2
-                    * den
-                    * constants.LAT2
-                    / (0.0243 * constants.RVGAS * pt1 ** 2.0)
+                    iqs2 * den * constants.LAT2 / (0.0243 * constants.RVGAS * pt1**2.0)
                     + 4.42478e4
                 )
             )
@@ -892,7 +889,7 @@ def satadjust(
             mindw = min(1.0, abs(hs) / (10.0 * constants.GRAV))
             dw = dw_ocean + (dw_land - dw_ocean) * mindw
             # "scale - aware" subgrid variability: 100 - km as the base
-            dbl_sqrt_area = dw * (area ** 0.5 / 100.0e3) ** 0.5
+            dbl_sqrt_area = dw * (area**0.5 / 100.0e3) ** 0.5
             maxtmp = max(0.01, dbl_sqrt_area)
             hvar = min(0.2, maxtmp)
             # partial cloudiness by pdf:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools >= 64"]
+requires = ["setuptools >= 77.0.3"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -14,11 +14,11 @@ requires-python = ">=3.11,<3.12"
 authors = [{name = "NOAA - Geophysical Fluid Dynamics Laboratory", email = "oliver.elbert@noaa.gov"}]
 description = "PyFV3 is a NDSL-based FV3 dynamical core for atmospheric models."
 readme = "README.md"
-license = {file = "LICENSE.md"}
+license = "Apache-2.0"
+license-files = ["LICENSE.md"]
 classifiers = [
     "Development Status :: 2 - Pre-Alpha",
     "Intended Audience :: Developers",
-    "License :: OSI Approved :: Apache Software License",
     "Natural Language :: English",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.11",
@@ -54,4 +54,4 @@ include-package-data = true
 
 [tool.black]
 line-length = 88
-target_version = ['py38']
+target_version = ['py311']

--- a/tests/savepoint/translate/translate_tracer2d1l.py
+++ b/tests/savepoint/translate/translate_tracer2d1l.py
@@ -77,9 +77,9 @@ class TranslateTracer2D1L(ParallelTranslate):
         inputs["mfyd"] = inputs.pop("y_mass_flux")
         inputs["cxd"] = inputs.pop("x_courant")
         inputs["cyd"] = inputs.pop("y_courant")
-        inputs[
-            "tracers"
-        ] = all_tracers  # some aren't advected, still need to be validated
+        inputs["tracers"] = (
+            all_tracers  # some aren't advected, still need to be validated
+        )
         # need to convert tracers dict to [x, y, z, n_tracer] array before subsetting
         outputs = self._base.slice_output(inputs)
         outputs["tracers"] = self.subset_output("tracers", outputs["tracers"])


### PR DESCRIPTION
**Description**

Following up on PR https://github.com/NOAA-GFDL/PyFV3/pull/60, this PR updates the `pyproject.toml` with 

- new-style license information to avoid warnings
- python 3.11 target for `black`

It also updates linting tools to recent versions such that `black` can target python 3.11 in the first place :wink:

**How Has This Been Tested?**

- Running new linting tools locally.
- Covered by existing CI workflows.

**Checklist:**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas: N/A
- [ ] I have made corresponding changes to the documentation: N/A
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules: N/A
- [ ] New check tests, if applicable, are included: N/A
- [ ] Targeted model if this changed was triggered by a model need/shortcoming: N/A
