### PR TITLE
docs: automatically deploy to GitHub pages

### DIFF
--- a/.github/workflows/gh_pages_doc.yml
+++ b/.github/workflows/gh_pages_doc.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - develop
+      - fix/mkdocs # to be removed after testing
 
 # Security: Restrict permissions of this workflow to whats needed.
 permissions:

--- a/.github/workflows/gh_pages_doc.yml
+++ b/.github/workflows/gh_pages_doc.yml
@@ -5,7 +5,6 @@ on:
   push:
     branches:
       - develop
-      - fix/mkdocs # to be removed after testing
 
 # Security: Restrict permissions of this workflow to whats needed.
 permissions:
@@ -26,6 +25,8 @@ jobs:
 
       - name: Setup python
         uses: actions/setup-python@v5
+        with:
+          python-version: 3.11
 
       - name: Install dependencies
         run: pip install mkdocs-material mkdocstrings[python]

--- a/.github/workflows/gh_pages_doc.yml
+++ b/.github/workflows/gh_pages_doc.yml
@@ -1,38 +1,33 @@
-name: website
+name: "PyFV3 documentation"
 
-# build the documentation whenever there are new commits on main
+# Documentation automatically updates upon merge to develop
 on:
   push:
     branches:
       - develop
-      - feature/documentation
-    workflow_dispatch:
 
-# security: restrict permissions for CI jobs.
+# Security: Restrict permissions of this workflow to whats needed.
 permissions:
   contents: write
 
 jobs:
   deploy:
     runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: ./pyFV3/pyFV3_docs
+
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
       - name: Configure Git Credentials
         run: |
           git config user.name github-actions[bot]
           git config user.email github-actions[bot]@users.noreply.github.com
-      - uses: actions/setup-python@v5
-        with:
-          python-version: 3.x
-      - run: echo "cache_id=$(date --utc '+%V')" >> $GITHUB_ENV
-      - uses: actions/cache@v4
-        with:
-          key: mkdocs-material-${{ env.cache_id }}
-          path: .cache
-          restore-keys: |
-            mkdocs-material-
-      - run: pip install mkdocs-material mkdocs-drawio
-      - run: mkdocs gh-deploy --force
+
+      - name: Setup python
+        uses: actions/setup-python@v5
+
+      - name: Install dependencies
+        run: pip install mkdocs-material mkdocstrings[python]
+
+      - name: Deploy to GitHub Pages
+        run: mkdocs gh-deploy --force

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,11 @@
 # Welcome to the PyFV3 Documentation
 
-:warning: This documentation is a work in progress - questions should go to oliver.elbert@nasa.gov or florian.g.deconinck@nasa.gov
+!!! warning "Work in progress"
+
+    This documentation is a work in progress. If you have questions, please direct them to
+
+    - oliver.elbert@noaa.gov
+    - or florian.g.deconinck@nasa.gov
 
 The PyFV3 repository can be found [here](https://github.com/NOAA-GFDL/PyFV3).
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,13 +1,18 @@
 site_name: PyFV3 Documentation
+site_url: https://noaa-gfdl.github.io/PyFV3/
 theme:
   name: material
+  features:
+    - search.suggest
+    - search.highlight
+    - search.share
 
 plugins:
   - search
   - mkdocstrings:
       handlers:
         python:
-          paths: [./pyFV3]  # Adjust this path to where your Python modules are
+          paths: [./pyfv3]  # Adjust this path to where your Python modules are
           options:
             show_source: false
             show_root_heading: false
@@ -59,3 +64,24 @@ nav:
       - "functional_validation": utils/functional_validation.md
   - Wrappers:
       - "geos_wrapper": wrappers/geos_wrapper.md
+
+markdown_extensions:
+  # simple glossary file
+  - abbr
+  # support for colored notes / warnings / tips / examples
+  - admonition
+  # emoji support
+  - attr_list
+  # support for footnotes
+  - footnotes
+  # supercharges admonitions by making them collapsible
+  - pymdownx.details
+  # support for syntax highlighting
+  - pymdownx.highlight:
+      anchor_linenums: true
+      line_spans: __span
+      pygments_lang_class: true
+  - pymdownx.inlinehilite
+  # support for task list of the form `- [ ] task name`
+  - pymdownx.tasklist:
+      custom_checkbox: false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,15 +26,19 @@ version = "0.2.0"
 
 [project.optional-dependencies]
 dev = [
-  "pyfv3[test]",
-  "pyfv3[ndsl]",
+  "pyfv3[docs,ndsl,test]",
   "pre-commit",
   "flake8-pyproject"
 ]
+docs = [
+  "mkdocs-material",
+  "mkdocstrings[python]"
+]
 extras = [
-  "pyfv3[test]",
+  "pyfv3[dev]",
+  "pyfv3[docs]",
   "pyfv3[ndsl]",
-  "pyfv3[dev]"
+  "pyfv3[test]"
 ]
 ndsl = ["ndsl @ git+https://github.com/NOAA-GFDL/NDSL.git@develop"]
 test = [


### PR DESCRIPTION
**Description**

Follow-up from PR #70 to automatically deploy `mkdocs` to GitHub Actions. You can see it live now at https://noaa-gfdl.github.io/PyFV3/.

**How Has This Been Tested?**

Running `mkdocs` locally and by test-deploying from this branch.

**Checklist:**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules: N/A
- [ ] New check tests, if applicable, are included: N/A
- [ ] Targeted model if this changed was triggered by a model need/shortcoming: N/A
