### PR TITLE
ci: remove container, install mpi from python wheel

### DIFF
--- a/.github/workflows/translate.yaml
+++ b/.github/workflows/translate.yaml
@@ -20,13 +20,19 @@ concurrency:
 jobs:
   pyFV3_translate_tests:
     runs-on: ubuntu-latest
-    container:
-      image: ghcr.io/noaa-gfdl/miniforge:mpich
     env:
       DATA_PATH: ./test_data/8.1.3/c12_6ranks_standard/dycore
       DATA_URL: "https://portal.nccs.nasa.gov/datashare/astg/smt/pace-regression-data/8.1.3_c12_6ranks_standard.tar.gz"
 
     steps:
+      - name: Setup Python 3.11
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install mpi (MPICH flavor)
+        run: pip3 install mpich
+
       - name: External trigger Checkout pyFV3
         if: ${{inputs.component_trigger}}
         uses: actions/checkout@v4
@@ -107,7 +113,7 @@ jobs:
           export PACE_FLOAT_PRECISION=64
           export OMP_NUM_THREADS=1
           export PACE_LOGLEVEL=Debug
-          mpiexec -mca orte_abort_on_non_zero_status 1 -np 6 --oversubscribe coverage run --rcfile=pyproject.toml -m mpi4py -m pytest \
+          mpiexec -mca orte_abort_on_non_zero_status 1 -np 6 coverage run --rcfile=pyproject.toml -m mpi4py -m pytest \
             -v -s --data_path=${{ env.DATA_PATH }} \
             --backend=dace:cpu \
             -m parallel \

--- a/.github/workflows/translate.yaml
+++ b/.github/workflows/translate.yaml
@@ -113,7 +113,7 @@ jobs:
           export PACE_FLOAT_PRECISION=64
           export OMP_NUM_THREADS=1
           export PACE_LOGLEVEL=Debug
-          mpiexec -mca orte_abort_on_non_zero_status 1 -np 6 coverage run --rcfile=pyproject.toml -m mpi4py -m pytest \
+          mpiexec -np 6 coverage run --rcfile=pyproject.toml -m mpi4py -m pytest \
             -v -s --data_path=${{ env.DATA_PATH }} \
             --backend=dace:cpu \
             -m parallel \


### PR DESCRIPTION
**Description**

This is a follow-up from https://github.com/NOAA-GFDL/NDSL/pull/184/ (mpi4py >= 4.1), similar to https://github.com/NOAA-GFDL/pace/pull/131, removing the mpi container in favor of installing a python wheel on the bare-metal Ubuntu runner. This allows the MPI tests in this testsuite to run again.

**How Has This Been Tested?**

By running CI and observing that  "Orchestrated dace-cpu Acoustics" is now running again. Previously, that was just skipped.

**Checklist:**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas: N/A
- [ ] I have made corresponding changes to the documentation: N/A
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [ ] New check tests, if applicable, are included: N/A (old ones are restored though ...)
- [ ] Targeted model if this changed was triggered by a model need/shortcoming: N/A
