### PR TITLE
Dockerfile: pip install [dev] instead of [develop]

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,7 @@ RUN which pip
 COPY . /pyfv3
 
 # Install pyFV3 and the full dependencies
-RUN cd /pyfv3 && pip install -e .[develop]
+RUN cd /pyfv3 && pip install -e .[dev]
 
 RUN pip install \
     matplotlib \


### PR DESCRIPTION
**Description**
This modifies the Dockerfile to use `pip install -e .[dev]` rather than `[develop]`.

**How Has This Been Tested?**
This was tested on an amd machine by running:
`make get_test_data`
`make build`
`make dev`

Once inside the container:
`root@996760dead1c:/pyfv3# python -m pytest tests/savepoint/ --data_path=test_data/8.1.3/c12_6ranks_standard/dycore/ --backend=numpy --which_rank=0 --threshold_overrides_file=tests/savepoint/translate/overrides/standard.yaml`

The results appeared reasonable.

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] New check tests, if applicable, are included
- [ ] Targeted model if this changed was triggered by a model need/shortcoming
