### PR TITLE
ci: prepare for using a merge queue in PyFV3

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,6 +1,12 @@
 name: "Lint"
+
+# Run these these whenever ...
 on:
-  pull_request:
+  pull_request: # ... a PR is opened / updated
+  merge_group: # ... the PR is added to the merge queue
+  push:
+    branches:
+      - main # ... when merging into the main branch
 
 jobs:
   lint:

--- a/.github/workflows/pace_tests.yaml
+++ b/.github/workflows/pace_tests.yaml
@@ -1,6 +1,12 @@
 name: "pace main tests"
+
+# Run these these whenever ...
 on:
-  pull_request:
+  pull_request: # ... a PR is opened / updated
+  merge_group: # ... the PR is added to the merge queue
+  push:
+    branches:
+      - main # ... when merging into the main branch
 
 jobs:
   pace_main_tests:

--- a/.github/workflows/pyshield_tests.yaml
+++ b/.github/workflows/pyshield_tests.yaml
@@ -1,6 +1,12 @@
 name: "pySHiELD translate tests"
+
+# Run these these whenever ...
 on:
-  pull_request:
+  pull_request: # ... a PR is opened / updated
+  merge_group: # ... the PR is added to the merge queue
+  push:
+    branches:
+      - main # ... when merging into the main branch
 
 jobs:
   pyshield_translate_tests:

--- a/.github/workflows/translate.yaml
+++ b/.github/workflows/translate.yaml
@@ -1,6 +1,8 @@
 name: "pyFV3 translate tests (subset)"
+
+# Run these these whenever ...
 on:
-  workflow_call:
+  workflow_call: # ... called from a downstream repo
     inputs:
       component_trigger:
         type: boolean
@@ -10,7 +12,11 @@ on:
         type: string
         default: ''
         required: false
-  pull_request:
+  pull_request: # ... a PR is opened / updated
+  merge_group: # ... the PR is added to the merge queue
+  push:
+    branches:
+      - main # ... when merging into the main branch
 
 # cancel running jobs if theres a newer push
 concurrency:


### PR DESCRIPTION
**Description**

Using merge queues was talked about in the pace meeting in August. No concerns were raised and we've successfully adopted merge queues in NDSL with https://github.com/NOAA-GFDL/NDSL/pull/194.

This PR configures PyFV3 tests to not only run on pull requests, but also in the merge queue (and when merging back into main - just for good measure). @fmalatino would you help me again as repo admin to do the repo configuration? Should be one-to-one from what we did in NDSL.

**How Has This Been Tested?**

Similar to what we have configured in NDSL. The new behavior will be apparent once we merge. I'll keep an eye out of oddities for the first couple PRs that get merged with the merge queue.

**Checklist:**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation: N/A
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules: N/A
- [x] New check tests, if applicable, are included
- [ ] Targeted model if this changed was triggered by a model need/shortcoming: N/A
