### PR TITLE
refactor: small cleanups in FvTp2d

### DIFF
--- a/pyfv3/stencils/fvtp2d.py
+++ b/pyfv3/stencils/fvtp2d.py
@@ -1,6 +1,5 @@
 from typing import Optional
 
-import ndsl.stencils.corners as corners
 from ndsl import QuantityFactory, StencilFactory, orchestrate
 from ndsl.constants import X_DIM, Y_DIM, Z_DIM
 from ndsl.dsl.gt4py import PARALLEL, computation
@@ -8,6 +7,7 @@ from ndsl.dsl.gt4py import function as gtfunction
 from ndsl.dsl.gt4py import horizontal, interval, region
 from ndsl.dsl.typing import Float, FloatField, FloatFieldIJ
 from ndsl.grid import DampingCoefficients, GridData
+from ndsl.stencils import corners
 from pyfv3.stencils.delnflux import DelnFlux
 from pyfv3.stencils.xppm import XPiecewiseParabolic
 from pyfv3.stencils.yppm import YPiecewiseParabolic
@@ -143,7 +143,6 @@ class FiniteVolumeTransport:
         # use a shorter alias for grid_indexing here to avoid very verbose lines
         idx = stencil_factory.grid_indexing
         self._area = grid_data.area
-        origin = idx.origin_compute()
 
         def make_quantity():
             return quantity_factory.zeros(
@@ -179,9 +178,7 @@ class FiniteVolumeTransport:
             # self.delnflux = None
             self._do_delnflux = False
 
-        self._copy_corners_y: corners.CopyCorners = corners.CopyCorners(
-            "y", stencil_factory
-        )
+        self._copy_corners_y = corners.CopyCorners("y", stencil_factory)
         self.y_piecewise_parabolic_inner = YPiecewiseParabolic(
             stencil_factory=stencil_factory,
             dya=grid_data.dya,
@@ -204,9 +201,7 @@ class FiniteVolumeTransport:
             domain=idx.domain_compute(add=(1, 1, 1)),
         )
 
-        self._copy_corners_x: corners.CopyCorners = corners.CopyCorners(
-            "x", stencil_factory
-        )
+        self._copy_corners_x = corners.CopyCorners("x", stencil_factory)
         self.x_piecewise_parabolic_inner = XPiecewiseParabolic(
             stencil_factory=stencil_factory,
             dxa=grid_data.dxa,


### PR DESCRIPTION
**Description**

I was looking at the FvTp2d stencil yesterday (for other reasons) and the here's a quick cleanup PR:

- simplify import statement
- `origin` is defined, but never used. We turn this rule off in `flake8` because of outfields in stencils
- copy corners had a redundant type annotation (can easily be inferred from the constructor on the other side of `=`)

**How Has This Been Tested?**

Covered by translate tests of `FvTp2d`.

**Checklist:**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas: N/A
- [ ] I have made corresponding changes to the documentation: N/A
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules: N/A
- [ ] New check tests, if applicable, are included: N/A
- [ ] Targeted model if this changed was triggered by a model need/shortcoming: N/A
