### PR TITLE
Updating base container image to python:3.11-slim-bookworm to match Pace + cleanup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11
+FROM python:3.11-slim-bookworm@sha256:7cd3fa11d619688317226bc93dc59bc8966e9aec6bc2a6abb847e8ab7d656706
 
 RUN apt-get update &&\
     apt install -y --no-install-recommends \

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ SHELL=/bin/bash
 CWD=$(shell pwd)
 CMD ?= bash
 DEV ?=y
-ROOT_DIR ?= /pyFV3
+ROOT_DIR ?= /pyfv3
 IMAGE_NAME ?= noaa-gfdl/pyfv3
 
 NUM_RANKS ?=6


### PR DESCRIPTION
**Description**
Updating base container image to python:3.11-slim-bookworm to match Pace. The previous base container was failing to build with errors:

```
Error: Unable to locate package software-properties-common
Error: building at STEP "RUN apt-get update &&    apt install -y --no-install-recommends     software-properties-common": while running runtime: exit status 100
make: *** [Makefile:45: build] Error 100
```
Also, I added a small clean up in the Makefile to update `ROOT_DIR ?= /pyfv3`. This is so `make savepoint_tests` can run through the container.

**How Has This Been Tested?**
```
#Tested on AMD box:
make build
make dev
cd pyfv3
python -m pytest -v -s --data_path=./test_data/8.1.3/c12_6ranks_standard/dycore  --backend=numpy   --threshold_overrides_file=./tests/savepoint/translate/overrides/standard.yaml  ./tests/savepoint

make safepoint_tests

# Results match expected: = 117 failed, 408 pa- lint and merge with updated develop branches
ssed, 1 skipped, 60 xfailed, 3 warnings, 1155 subtests passed in 261.18s (0:04:21) =
```

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas (not applicable)
- [ ] I have made corresponding changes to the documentation (not applicable)
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules (not applicable)
- [ ] New check tests, if applicable, are included (not applicable)
- [ ] Targeted model if this changed was triggered by a model need/shortcoming (not applicable)
