### PR TITLE
ci: Update actions/checkout v4 -> v5

### DIFF
--- a/.github/workflows/gh_pages_doc.yml
+++ b/.github/workflows/gh_pages_doc.yml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Configure Git Credentials
         run: |

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Python 3.11
         uses: actions/setup-python@v5

--- a/.github/workflows/translate.yaml
+++ b/.github/workflows/translate.yaml
@@ -41,14 +41,14 @@ jobs:
 
       - name: External trigger Checkout pyFV3
         if: ${{inputs.component_trigger}}
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           submodules: 'recursive'
           repository: noaa-gfdl/pyFV3
           path: pyFV3
 
       - name: Checkout hash that triggered CI
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           submodules: 'recursive'
           path: pyFV3/${{inputs.component_name}}


### PR DESCRIPTION
**Description**

This PR updates actions/checkout from @v4 to @v5. The major version number update was only necessary because of new requirements on the runners (which is a breaking change). Since we use runners provided by GitHub, we don't have to worry.

**How Has This Been Tested?**

All good as long as CI is still running (and green).

**Checklist:**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas: N/A
- [ ] I have made corresponding changes to the documentation: N/A
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules: N/A
- [ ] New check tests, if applicable, are included: N/A
- [ ] Targeted model if this changed was triggered by a model need/shortcoming: N/A
