### PR TITLE
ci: Effective cache sharing between PRs

### DIFF
--- a/.github/workflows/create_cache.yml
+++ b/.github/workflows/create_cache.yml
@@ -1,0 +1,82 @@
+name: "Create GHA cache"
+
+# GitHub puts the following restrictions on cache sharing. PRs can access
+#
+# - caches that were created by the PR / earlier runs of the PR
+# - caches that were created on the target branch
+#
+# To get effective cache sharing between PRs, we create caches on the `develop`
+# branch (which is where almost all PRs merge into).
+
+on:
+  push:
+    branches: [develop]
+
+# Cancel running jobs if there's a newer push
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  # GitHub Actions cache of the pre-commit environment
+  pre-commit:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+
+      - name: Setup Python 3.11
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - uses: actions/cache@v4
+        id: cache
+        with:
+          path: ~/.cache/pre-commit
+          key: pre-commit_${{ env.pythonLocation }}_${{ hashFiles('.pre-commit-config.yaml') }}
+          lookup-only: true  # don't actually download the cache
+
+      - name: Populate pre-commit environment (if not cached)
+        if: steps.cache.outputs.cache-hit != 'true'
+        run: |
+          pip install pre-commit
+          pre-commit install --install-hooks
+
+  # GitHub Actions cache of the translate test data
+  test-data:
+    runs-on: ubuntu-latest
+    env:
+      TEST_DATA_PATH: ./test_data/8.1.3/c12_6ranks_standard/dycore
+      TEST_DATA_URL: "https://portal.nccs.nasa.gov/datashare/astg/smt/pace-regression-data/8.1.3_c12_6ranks_standard.tar.gz"
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+
+      - name: Setup Python 3.11
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - uses: actions/cache@v4
+        id: cache
+        with:
+          path: pyFV3/test_data
+          key: ${{ env.TEST_DATA_PATH }}
+          lookup-only: true  # don't actually download the cache
+
+      - name: Download test_data (if not already cached)
+        if: steps.cache-restore.outputs.cache-hit != 'true'
+        run: |
+          mkdir -p pyFV3/test_data  && cd pyFV3/test_data
+          wget ${{ env.TEST_DATA_URL }}
+          tar -xzvf 8.1.3_c12_6ranks_standard.tar.gz
+          rm 8.1.3_c12_6ranks_standard.tar.gz
+
+      - name: Cache test_data (if not already cached)
+        if: steps.cache-restore.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: pyFV3/test_data
+          key: ${{ steps.cache-restore.outputs.cache-primary-key }}

--- a/.github/workflows/create_cache.yml
+++ b/.github/workflows/create_cache.yml
@@ -73,10 +73,3 @@ jobs:
           wget ${{ env.TEST_DATA_URL }}
           tar -xzvf 8.1.3_c12_6ranks_standard.tar.gz
           rm 8.1.3_c12_6ranks_standard.tar.gz
-
-      - name: Cache test_data (if not already cached)
-        if: steps.cache-restore.outputs.cache-hit != 'true'
-        uses: actions/cache/save@v4
-        with:
-          path: pyFV3/test_data
-          key: ${{ steps.cache-restore.outputs.cache-primary-key }}

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -20,12 +20,18 @@ jobs:
         with:
           python-version: '3.11'
 
+      # Only restore (don't save) caches on PRs. New caches created from PRs won't be
+      # accessible from other PRs, see workflows/create_cache.yaml.
+      - uses: actions/cache/restore@v4
+        with:
+          path: ~/.cache/pre-commit
+          key: pre-commit_${{ env.pythonLocation }}_${{ hashFiles('.pre-commit-config.yaml') }}
+
       - name: Install pre-commit
-        run: |
-          pip install pre-commit
+        run: pip install pre-commit
+
       - name: Run lint via pre-commit
-        run: |
-          pre-commit run --all-files
+        run: pre-commit run --all-files
 
       - name: Check advection code consistency
         run: |

--- a/.github/workflows/translate.yaml
+++ b/.github/workflows/translate.yaml
@@ -66,6 +66,8 @@ jobs:
           cd ${GITHUB_WORKSPACE}/pyFV3
           pip install .[ndsl,test]
 
+      # Only restore (don't save) caches on PRs. New caches created from PRs won't be
+      # accessible from other PRs, see workflows/create_cache.yaml.
       - name: Restore test_data (if cached)
         id: cache-restore
         uses: actions/cache/restore@v4
@@ -76,11 +78,9 @@ jobs:
       - name: Download test_data (if not cached)
         if: steps.cache-restore.outputs.cache-hit != 'true'
         run: |
-          cd ${GITHUB_WORKSPACE}/pyFV3
-          mkdir -p test_data  && cd test_data
+          mkdir -p pyFV3/test_data  && cd pyFV3/test_data
           wget ${{ env.DATA_URL }}
-          tar -xzvf 8.1.3_c12_6ranks_standard.tar.gz --no-same-owner
-          cd ..
+          tar -xzvf 8.1.3_c12_6ranks_standard.tar.gz
 
       - name: NumPy FvTp2d
         run: |
@@ -127,10 +127,3 @@ jobs:
             --which_modules=DynCore \
             --threshold_overrides_file=./tests/savepoint/translate/overrides/standard.yaml \
             ./tests/savepoint
-
-      - name: Cache test_data
-        if: steps.cache-restore.outputs.cache-hit != 'true'
-        uses: actions/cache/save@v4
-        with:
-          path: pyFV3/test_data
-          key: ${{ steps.cache-restore.outputs.cache-primary-key }}


### PR DESCRIPTION
**Description**

Caching in GHA workflows is currently sub-optimal because we didn't understand the rules of when to create caches that can be reused. GitHub imposes the following rules on cache sharing. Caches can be restored by a workflow if

1. they were created by a previous run of the workflow
2. they were created by the target branch of this PR

We currently save and restore caches from PRs, which means we get the cache boost from 1) starting with the second run of a PR. Since we use a merge queue, we never run PR workflows on merge to `develop`. We thus never profit from the second case. This PR "solves" the issue by having an explicit cache creation workflow that runs when ever we merge into `develop`. This PR will create caches that can be reused (as intended by 2) above) by any PR targeting the `develop` branch.

The translate test workflow of this repository is re-used in other repository as a hook. This PR should (if I understand the docs correctly) generate translate test data caches that can be re-used by workflows from other repositories.

**How Has This Been Tested?**

This is a propagation of PR https://github.com/NOAA-GFDL/NDSL/pull/202 in NDSL, which works as advertised. I'll double check after the first run that this also works as intended in this repository. If not, I'll do follow-up PRs in a timely manner.

**Checklist:**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation: N/A
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules: N/A
- [ ] New check tests, if applicable, are included: N/A
- [ ] Targeted model if this changed was triggered by a model need/shortcoming: N/A
