### PR TITLE
ci: only download test data if not already cached

### DIFF
--- a/.github/workflows/create_cache.yml
+++ b/.github/workflows/create_cache.yml
@@ -67,7 +67,7 @@ jobs:
           lookup-only: true  # don't actually download the cache
 
       - name: Download test_data (if not already cached)
-        if: steps.cache-restore.outputs.cache-hit != 'true'
+        if: steps.cache.outputs.cache-hit != 'true'
         run: |
           mkdir -p pyFV3/test_data  && cd pyFV3/test_data
           wget ${{ env.TEST_DATA_URL }}


### PR DESCRIPTION
**Description**

Follow-up from https://github.com/NOAA-GFDL/PyFV3/pull/80 to only download test data in case that data isn't already cached. That behavior was already configured, but the step id was wrong, thus the data was downloaded even if the cache was hit (and thus there's not need to download and cache new data).

@fmalatino looks like I messed something small up when creating the cache.

**How Has This Been Tested?**

Self review of code.

**Checklist:**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas: N/A
- [ ] I have made corresponding changes to the documentation: N/A
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules: N/A
- [ ] New check tests, if applicable, are included: N/A
- [ ] Targeted model if this changed was triggered by a model need/shortcoming: N/A
