### PR TITLE
refactor: use new versions of environment variables

### DIFF
--- a/.github/workflows/translate.yaml
+++ b/.github/workflows/translate.yaml
@@ -116,9 +116,9 @@ jobs:
         run: |
           cd ${GITHUB_WORKSPACE}/pyFV3
           export FV3_DACEMODE=BuildAndRun
-          export PACE_FLOAT_PRECISION=64
+          export NDSL_LITERAL_PRECISION=64
           export OMP_NUM_THREADS=1
-          export PACE_LOGLEVEL=Debug
+          export NDSL_LOGLEVEL=Debug
           mpiexec -np 6 coverage run --rcfile=pyproject.toml -m mpi4py -m pytest \
             -v -s --data_path=${{ env.DATA_PATH }} \
             --backend=dace:cpu \

--- a/README.md
+++ b/README.md
@@ -30,7 +30,6 @@ $ pre-commit install
 ## Getting started, in more detail
 If you want to build the main fv3core docker image, run
 
-```shell
 $ make build
 ```
 

--- a/pyfv3/version.py
+++ b/pyfv3/version.py
@@ -1,6 +1,6 @@
 from ndsl.constants import CONST_VERSION, ConstantVersions
 
 
-# By selecting the GEOS constant using (PACE_CONSTANT env var)
+# By selecting the GEOS constant using (NDSL_CONSTANTS env var)
 # we select the GEOS flavor of numerics
 IS_GEOS = ConstantVersions.GEOS == CONST_VERSION


### PR DESCRIPTION
**Description**

The old ones are currently deprecated and expected to be removed in the future (after a grace period). See https://github.com/NOAA-GFDL/NDSL/pull/193 for more details.

**How Has This Been Tested?**

All good as long as CI is still green.

**Checklist:**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas: N/A
- [ ] I have made corresponding changes to the documentation: N/A
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [ ] New check tests, if applicable, are included: N/A
- [ ] Targeted model if this changed was triggered by a model need/shortcoming: N/A
