### PR TITLE
NDSL Issue#64: Use from_yaml_dict instead of from_f90nml in GEOS wrapper

### DIFF
--- a/pyfv3/_config.py
+++ b/pyfv3/_config.py
@@ -387,12 +387,13 @@ class DynamicalCoreConfig:
         )
 
     @classmethod
-    def from_yaml(cls, yaml_config: str) -> "DynamicalCoreConfig":
+    def from_yaml_dict(cls, yaml_dict: dict) -> "DynamicalCoreConfig":
+        """Creates a DynamicalCoreConfig from a dict that was loaded
+        from a YAML file (for example, safe_load)
+        """
         config = cls()
-        with open(yaml_config, "r") as f:
-            raw_config = yaml.safe_load(f)
         flat_config: dict = {}
-        timestep = timedelta(seconds=raw_config["dt_atmos"])
+        timestep = timedelta(seconds=yaml_dict["dt_atmos"])
         runtime = {
             "days": 0.0,
             "hours": 0.0,
@@ -400,8 +401,8 @@ class DynamicalCoreConfig:
             "seconds": 0.0,
         }
         for key in runtime.keys():
-            if key in raw_config.keys():
-                runtime[key] = raw_config[key]
+            if key in yaml_dict.keys():
+                runtime[key] = yaml_dict[key]
 
         total_time = timedelta(
             days=runtime["days"],
@@ -409,7 +410,60 @@ class DynamicalCoreConfig:
             minutes=runtime["minutes"],
             seconds=runtime["seconds"],
         )
-        for key, value in raw_config.items():
+        for key, value in yaml_dict.items():
+            if isinstance(value, dict):
+                for subkey, subvalue in value.items():
+                    if subkey in config.__annotations__.keys():
+                        if subkey in flat_config:
+                            if subvalue != flat_config[subkey]:
+                                raise ValueError(
+                                    "Cannot flatten this config ",
+                                    f"duplicate keys: {subkey}",
+                                )
+                        flat_config[subkey] = subvalue
+            else:
+                if key == "nx_tile":
+                    flat_config["npx"] = value + 1
+                    flat_config["npy"] = value + 1
+                elif key == "nz":
+                    flat_config["npz"] = value
+                else:
+                    if key in config.__annotations__.keys():
+                        flat_config[key] = value
+        for field in dataclasses.fields(config):
+            if field.name in flat_config.keys():
+                setattr(config, field.name, flat_config[field.name])
+        config.n_steps = floor(total_time.total_seconds() / timestep.total_seconds())
+        return config
+
+    @classmethod
+    def from_yaml(cls, yaml_config: str) -> "DynamicalCoreConfig":
+        with open(yaml_config, "r") as f:
+            yaml_dict = yaml.safe_load(f)
+        return cls.from_yaml_dict(yaml_dict)
+
+    @classmethod
+    def from_yaml_dict(cls, yaml_dict: dict) -> "DynamicalCoreConfig":
+        config = cls()
+        flat_config: dict = {}
+        timestep = timedelta(seconds=yaml_dict["dt_atmos"])
+        runtime = {
+            "days": 0.0,
+            "hours": 0.0,
+            "minutes": 0.0,
+            "seconds": 0.0,
+        }
+        for key in runtime.keys():
+            if key in yaml_dict.keys():
+                runtime[key] = yaml_dict[key]
+
+        total_time = timedelta(
+            days=runtime["days"],
+            hours=runtime["hours"],
+            minutes=runtime["minutes"],
+            seconds=runtime["seconds"],
+        )
+        for key, value in yaml_dict.items():
             if isinstance(value, dict):
                 for subkey, subvalue in value.items():
                     if subkey in config.__annotations__.keys():

--- a/pyfv3/_config.py
+++ b/pyfv3/_config.py
@@ -387,56 +387,6 @@ class DynamicalCoreConfig:
         )
 
     @classmethod
-    def from_yaml_dict(cls, yaml_dict: dict) -> "DynamicalCoreConfig":
-        """Creates a DynamicalCoreConfig from a dict that was loaded
-        from a YAML file (for example, safe_load)
-        """
-        config = cls()
-        flat_config: dict = {}
-        timestep = timedelta(seconds=yaml_dict["dt_atmos"])
-        runtime = {
-            "days": 0.0,
-            "hours": 0.0,
-            "minutes": 0.0,
-            "seconds": 0.0,
-        }
-        for key in runtime.keys():
-            if key in yaml_dict.keys():
-                runtime[key] = yaml_dict[key]
-
-        total_time = timedelta(
-            days=runtime["days"],
-            hours=runtime["hours"],
-            minutes=runtime["minutes"],
-            seconds=runtime["seconds"],
-        )
-        for key, value in yaml_dict.items():
-            if isinstance(value, dict):
-                for subkey, subvalue in value.items():
-                    if subkey in config.__annotations__.keys():
-                        if subkey in flat_config:
-                            if subvalue != flat_config[subkey]:
-                                raise ValueError(
-                                    "Cannot flatten this config ",
-                                    f"duplicate keys: {subkey}",
-                                )
-                        flat_config[subkey] = subvalue
-            else:
-                if key == "nx_tile":
-                    flat_config["npx"] = value + 1
-                    flat_config["npy"] = value + 1
-                elif key == "nz":
-                    flat_config["npz"] = value
-                else:
-                    if key in config.__annotations__.keys():
-                        flat_config[key] = value
-        for field in dataclasses.fields(config):
-            if field.name in flat_config.keys():
-                setattr(config, field.name, flat_config[field.name])
-        config.n_steps = floor(total_time.total_seconds() / timestep.total_seconds())
-        return config
-
-    @classmethod
     def from_yaml(cls, yaml_config: str) -> "DynamicalCoreConfig":
         with open(yaml_config, "r") as f:
             yaml_dict = yaml.safe_load(f)

--- a/pyfv3/wrappers/geos_wrapper.py
+++ b/pyfv3/wrappers/geos_wrapper.py
@@ -116,7 +116,7 @@ class GeosDycoreWrapper:
 
         self.backend = backend
         self.namelist = namelist
-        self.dycore_config = pyfv3.DynamicalCoreConfig.from_f90nml(self.namelist)
+        self.dycore_config = pyfv3.DynamicalCoreConfig.from_yaml_dict(self.namelist)
         self.dycore_config.dt_atmos = bdt
         assert self.dycore_config.dt_atmos != 0
 


### PR DESCRIPTION
**Description**
This is part of the Namelist Refactor work, though a bit indirectly related.

_Changes include the following:_
- Pulls out the bulk of the the `DynamicalCoreConfig.from_yaml` functionality into a new `from_yaml_dict` function.
- Uses the newly created `from_yaml_dict` function in the GEOS wrapper instead of using`from_f90nml`.

_Why use `from_yaml_dict`?_
The GEOS wrapper is the one case I found where the YAML structure is used to create a `f90nml.Namelist`, so I wanted to instead use the `from_yaml` code to process it instead of the `from_f90nml`.  

The GEOS wrapper is tested in an existing Pace unit test ([`tests/main/fv3core/test_init_from_geos.py`](https://github.com/NOAA-GFDL/pace/blob/e902a3843244746734cf5598cd4b3294de545aad/tests/main/fv3core/test_init_from_geos.py)). The test uses a `namelist_dict` that follows the YAML configuration structure. This `namelist_dict` is then turned into a `f90nml.Namelist` and used to initialize a dycore config object. 

If I can keep YAML and Namelist processing more distinct, I think this will help make the Namelist refactoring simpler. I can then expect all of the `Namelist` objects to use a typical Fortran Namelist group structure. I plan to eventually change the `ndsl.Namelist` to behave much more like the `f90nml.Namelist` and not have to worry about being able to handle Namelists with either YAML structure or `input.nml` structure.

Fixes: https://github.com/NOAA-GFDL/NDSL/issues/64 (partially)

**How Has This Been Tested?**
PyFV3 and PySHiELD translate tests run as expected compared to the `develop` branch. Pace unit tests also pass as expected.

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [ ] New check tests, if applicable, are included
- [ ] Targeted model if this changed was triggered by a model need/shortcoming
