### PR TITLE
ci: no test extra for NDSL in external trigger

### DIFF
--- a/.github/workflows/translate.yaml
+++ b/.github/workflows/translate.yaml
@@ -57,7 +57,7 @@ jobs:
         if: ${{inputs.component_trigger}}
         run: |
           cd ${GITHUB_WORKSPACE}/pyFV3
-          cd NDSL && pip3 install .[test] && cd ../
+          cd NDSL && pip3 install . && cd ../
           pip3 install .[test]
 
       - name: Install pyFV3 packages


### PR DESCRIPTION
**Description**

Translate tests of pyFV3 run as hook in other repositories like NDSL. When pyFV3 tests run as part of NDSL's CI, we use the NDSL version that is about to be merged, to check that the changes in NDSL don't break pyFV3. When we do this, we don't need to install NDSL with the "test" extra because that should only be necessary to run NDSL tests (which we don't run as part of pyFV3 CI).

/cc @FlorianDeconinck FYI

**How Has This Been Tested?**

All good as long as CI is still green... 

**Checklist:**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas: N/A
- [ ] I have made corresponding changes to the documentation: N/A
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules: N/A
- [ ] New check tests, if applicable, are included: N/A
- [ ] Targeted model if this changed was triggered by a model need/shortcoming: N/A
