### PR TITLE
Type fix: tuple to list in DynamicalCoreConfig

### DIFF
--- a/pyfv3/_config.py
+++ b/pyfv3/_config.py
@@ -319,7 +319,8 @@ class DynamicalCoreConfig:
                 use when initializing the DynamicalCoreConfig. If None, all
                 groups will be used. (Default: DEFAULT_DYCORE_NML_GROUPS)
         """
-        nml_dict = f90nml_as_dict(nml, flatten=True, target_groups=target_groups)
+        groups = list(target_groups) if target_groups is not None else None
+        nml_dict = f90nml_as_dict(nml, flatten=True, target_groups=groups)
         nml_dict["target_nml_groups"] = target_groups
         return cls.from_dict(nml_dict)
 


### PR DESCRIPTION
**Description**
A type fix in `DynamicalCoreConfig.from_f90nml()`.

Without this fix, there are failures in [Pace linting checks](https://github.com/NOAA-GFDL/pace/actions/runs/18698460429/job/53321753063).

**How Has This Been Tested?**
CI tests

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] New check tests, if applicable, are included
- [ ] Targeted model if this changed was triggered by a model need/shortcoming
