### PR TITLE
ci: make "create cache" a reusable workflow

### DIFF
--- a/.github/workflows/create_cache.yml
+++ b/.github/workflows/create_cache.yml
@@ -89,4 +89,4 @@ jobs:
   pySHiELD-test-data:
     # Downstream calls may not need this. If so, they should fetch it explicitly.
     if: ${{!inputs.external-call}}
-    uses: romanc/pySHiELD/.github/workflows/create_cache.yml@develop
+    uses: NOAA-GFDL/pySHiELD/.github/workflows/create_cache.yml@develop

--- a/.github/workflows/create_cache.yml
+++ b/.github/workflows/create_cache.yml
@@ -9,6 +9,16 @@ name: "Create GHA cache"
 # branch (which is where almost all PRs merge into).
 
 on:
+  workflow_call: # when called from a downstream repo
+    inputs:
+      # GHA doesn't seem to provide a simple way to detect workflow_call events
+      # so we are using an extra input (which is only available when this workflow
+      # is called from another workflow) with a default value (such that we don't
+      # have to set it every time)
+      external-call:
+        type: boolean
+        default: true
+        required: false
   push:
     branches: [develop]
 
@@ -20,6 +30,8 @@ concurrency:
 jobs:
   # GitHub Actions cache of the pre-commit environment
   pre-commit:
+    # Downstream repos have their own pre-commit environment
+    if: ${{!inputs.external-call}}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -73,3 +85,8 @@ jobs:
           wget ${{ env.TEST_DATA_URL }}
           tar -xzvf 8.1.3_c12_6ranks_standard.tar.gz
           rm 8.1.3_c12_6ranks_standard.tar.gz
+
+  pySHiELD-test-data:
+    # Downstream calls may not need this. If so, they should fetch it explicitly.
+    if: ${{!inputs.external-call}}
+    uses: romanc/pySHiELD/.github/workflows/create_cache.yml@develop

--- a/.github/workflows/create_cache.yml
+++ b/.github/workflows/create_cache.yml
@@ -24,7 +24,7 @@ on:
 
 # Cancel running jobs if there's a newer push
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.repository }}-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
**Description**

Recent (planned) downtime of NCCS portal showed a whole in our translate test data caching strategy. When we run pyFV3 tests as re-usable workflow in e.g. NDSL tests, we don't cache the translate test data. To do so, we can "upgrade" the "create cache" workflow to be re-usable such that we can call it from e.g. NDSL when we create the cache there.

GHA doesn't provide a way to detect `workflow_call` as an event (e.g. `github.event` will be `workflow_dispatch` in that case, which is the same as for a manual dispatch). We thus create an artificial input in case the workflow is called from another workflow. That way we know. The artificial input has a default value such that we don't need to set it from the calling workflow.

**How Has This Been Tested?**

Tested on my fork, e.g. https://github.com/romanc/NDSL/pull/5.

**Checklist:**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation: N/A
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
  Depends on https://github.com/NOAA-GFDL/PySHiELD/pull/69
- [ ] New check tests, if applicable, are included: N/A
- [ ] Targeted model if this changed was triggered by a model need/shortcoming: N/A
