### PR TITLE
refactor: avoid deprecation warnings around extra dims

### DIFF
--- a/examples/notebook/test_functionality.ipynb
+++ b/examples/notebook/test_functionality.ipynb
@@ -128,7 +128,6 @@
     "    ny_tile=ny,\n",
     "    nz=nz,\n",
     "    n_halo=nhalo,\n",
-    "    extra_dim_lengths={},\n",
     "    layout=layout,\n",
     "    tile_partitioner=partitioner.tile,\n",
     "    tile_rank=cs_communicator.tile.rank,\n",

--- a/tests/mpi/test_doubly_periodic.py
+++ b/tests/mpi/test_doubly_periodic.py
@@ -88,7 +88,6 @@ def setup_dycore() -> Tuple[DynamicalCore, List[Any]]:
         ny_tile=config.npy - 1,
         nz=config.npz,
         n_halo=3,
-        extra_dim_lengths={},
         layout=config.layout,
         tile_partitioner=partitioner,
         tile_rank=communicator.rank,

--- a/tests/savepoint/translate/translate_init_case.py
+++ b/tests/savepoint/translate/translate_init_case.py
@@ -220,7 +220,6 @@ class TranslateInitCase(ParallelTranslateBaseSlicing):
             ny_tile=self.config.nx_tile,
             nz=self.config.nz,
             n_halo=N_HALO_DEFAULT,
-            extra_dim_lengths={},
             layout=self.config.layout,
             tile_partitioner=communicator.partitioner.tile,
             tile_rank=communicator.tile.rank,


### PR DESCRIPTION
**Description**

"extra dims" have been renamed to "data dimensions" in NDSL [1] and after doing so we figured that we need to be careful with mutable default values [2]. Togehter, these two PRs make specifying `extra_dim_lengths` unnecessary if they are the default empty dictionary.

[1]: https://github.com/NOAA-GFDL/NDSL/pull/272
[2]: https://github.com/NOAA-GFDL/NDSL/pull/277

**How Has This Been Tested?**

All good as long as CI is happy.

**Checklist:**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas: N/A
- [ ] I have made corresponding changes to the documentation: N/A
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [ ] New check tests, if applicable, are included: N/A
- [ ] Targeted model if this changed was triggered by a model need/shortcoming: N/A
