### PR TITLE
ci: stricter type checks with `mypy`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,7 +19,8 @@ repos:
       - id: mypy
         name: mypy-fv3core
         args: [--config-file, pyproject.toml]
-        files: pyFV3
+        additional_dependencies: [types-PyYAML]
+        files: pyfv3
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v5.0.0
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@ default_language_version:
 
 repos:
   - repo: https://github.com/psf/black
-    rev: 25.1.0
+    rev: 25.9.0
     hooks:
       - id: black
 
@@ -14,7 +14,7 @@ repos:
         args: ["--profile", "black"]
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.17.0
+    rev: v1.18.2
     hooks:
       - id: mypy
         name: mypy-fv3core
@@ -22,7 +22,7 @@ repos:
         additional_dependencies: [types-PyYAML]
         files: pyfv3
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v5.0.0
+    rev: v6.0.0
     hooks:
       - id: check-toml
       - id: check-yaml

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,7 +34,7 @@ repos:
       - id: flake8
         name: flake8
         language_version: python3
-        additional_dependencies: [Flake8-pyproject]
+        additional_dependencies: [Flake8-pyproject, flake8-bugbear]
 
   - repo: https://github.com/macisamuele/language-formatters-pre-commit-hooks
     rev: v2.15.0

--- a/pyfv3/_config.py
+++ b/pyfv3/_config.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import dataclasses
 from datetime import timedelta
 from math import floor
-from typing import Optional, Tuple
 
 import f90nml
 import yaml
@@ -203,7 +202,7 @@ class DynamicalCoreConfig:
     vtdm4: float = DEFAULT_FLOAT
     z_tracer: bool = DEFAULT_BOOL
     do_qa: bool = DEFAULT_BOOL
-    layout: Tuple[int, int] = (1, 1)
+    layout: tuple[int, int] = (1, 1)
     grid_type: int = 0
     u_max: float = 350.0
     """max windspeed for dp config"""
@@ -285,8 +284,8 @@ class DynamicalCoreConfig:
     n_sponge: int = 1
     sw_dynamics: bool = False
     """shallow water conditions"""
-    namelist_override: Optional[str] = None
-    target_nml_groups: Optional[Tuple[str, ...]] = DEFAULT_DYCORE_NML_GROUPS
+    namelist_override: str | None = None
+    target_nml_groups: tuple[str, ...] | None = DEFAULT_DYCORE_NML_GROUPS
 
     def __post_init__(self) -> None:
         if self.namelist_override is not None:
@@ -308,13 +307,13 @@ class DynamicalCoreConfig:
     def from_f90nml(
         cls,
         nml: f90nml.Namelist,
-        target_groups: Tuple[str, ...] | None = DEFAULT_DYCORE_NML_GROUPS,
+        target_groups: tuple[str, ...] | None = DEFAULT_DYCORE_NML_GROUPS,
     ) -> DynamicalCoreConfig:
         """Uses the nml to create a DynamicalCoreConfig.
 
         Args:
             nml: f90nml.Namelist
-            target_groups: Tuple[str,...] | None
+            target_groups: tuple[str,...] | None
                 This list will be used to specify which groups in the nml to
                 use when initializing the DynamicalCoreConfig. If None, all
                 groups will be used. (Default: DEFAULT_DYCORE_NML_GROUPS)
@@ -340,8 +339,8 @@ class DynamicalCoreConfig:
         dacite_config = Config(
             strict=False,
             type_hooks={
-                Tuple[int, int]: lambda x: tuple(x),
-                Tuple[str, ...]: lambda x: tuple(x) if x is not None else None,
+                tuple[int, int]: lambda x: tuple(x),
+                tuple[str, ...]: lambda x: tuple(x) if x is not None else None,
             },
         )
         dycore_config = from_dict(

--- a/pyfv3/_config.py
+++ b/pyfv3/_config.py
@@ -288,7 +288,7 @@ class DynamicalCoreConfig:
     namelist_override: Optional[str] = None
     target_nml_groups: Optional[Tuple[str, ...]] = DEFAULT_DYCORE_NML_GROUPS
 
-    def __post_init__(self):
+    def __post_init__(self) -> None:
         if self.namelist_override is not None:
             try:
                 f90_nml = f90nml.read(self.namelist_override)

--- a/pyfv3/dycore_state.py
+++ b/pyfv3/dycore_state.py
@@ -1,5 +1,6 @@
+from collections.abc import Mapping
 from dataclasses import asdict, dataclass, field, fields
-from typing import Any, Dict, Mapping, Union
+from typing import Any, Self
 
 import xarray as xr
 
@@ -295,7 +296,7 @@ class DycoreState:
     bdt: float = field(default=0.0)
     mdt: float = field(default=0.0)
 
-    def __post_init__(self):
+    def __post_init__(self) -> None:
         for _field in fields(self):
             for check_name in ["units", "dims"]:
                 if check_name in _field.metadata:
@@ -310,7 +311,7 @@ class DycoreState:
                         )
 
     @classmethod
-    def init_zeros(cls, quantity_factory: QuantityFactory):
+    def init_zeros(cls, quantity_factory: QuantityFactory) -> Self:
         initial_storages = {}
         for _field in fields(cls):
             if "dims" in _field.metadata.keys():
@@ -325,8 +326,8 @@ class DycoreState:
 
     @classmethod
     def init_from_numpy_arrays(
-        cls, dict_of_numpy_arrays, sizer: GridSizer, backend: str
-    ):
+        cls, dict_of_numpy_arrays: dict, sizer: GridSizer, backend: str
+    ) -> Self:
         field_names = [_field.name for _field in fields(cls)]
         for variable_name in dict_of_numpy_arrays.keys():
             if variable_name not in field_names:
@@ -355,7 +356,7 @@ class DycoreState:
         sizer: GridSizer,
         bdt: float = 0.0,
         mdt: float = 0.0,
-    ):
+    ) -> Self:
         inputs = {}
         for _field in fields(cls):
             if "dims" in _field.metadata.keys():
@@ -377,7 +378,7 @@ class DycoreState:
         quantity_factory: QuantityFactory,
         communicator: Communicator,
         path: str,
-    ):
+    ) -> Self:
         state_dict: Mapping[str, Quantity] = open_restart(
             dirname=path,
             communicator=communicator,
@@ -440,10 +441,10 @@ class DycoreState:
         return new
 
     @property
-    def xr_dataset(self):
+    def xr_dataset(self) -> xr.Dataset:
         data_vars = {}
         for name, field_info in self.__dataclass_fields__.items():
-            if issubclass(field_info.type, Quantity):
+            if issubclass(field_info.type, Quantity):  # type: ignore[arg-type]
                 dims = [
                     f"{dim_name}_{name}" for dim_name in field_info.metadata["dims"]
                 ]
@@ -457,14 +458,14 @@ class DycoreState:
                 )
         return xr.Dataset(data_vars=data_vars)
 
-    def __getitem__(self, item):
+    def __getitem__(self, item: str) -> Any:
         return getattr(self, item)
 
-    def as_dict(self, quantity_only=True) -> Dict[str, Union[Quantity, int]]:
+    def as_dict(self, quantity_only: bool = True) -> dict[str, Quantity | int]:
         if quantity_only:
             return {k: v for k, v in asdict(self).items() if isinstance(v, Quantity)}
-        else:
-            return {k: v for k, v in asdict(self).items()}
+
+        return {k: v for k, v in asdict(self).items()}
 
 
 TRACER_PROPERTIES = {

--- a/pyfv3/dycore_state.py
+++ b/pyfv3/dycore_state.py
@@ -345,7 +345,7 @@ class DycoreState:
                     extent=sizer.get_extent(dims),
                     gt4py_backend=backend,
                 )
-        state = cls(**dict_state)  # type: ignore
+        state = cls(**dict_state)
         return state
 
     @classmethod

--- a/pyfv3/initialization/analytic_init.py
+++ b/pyfv3/initialization/analytic_init.py
@@ -48,7 +48,7 @@ def init_analytic_state(
         AnalyticCase.rossby,
     ]
 
-    if analytic_init_case in spherical_cases:  # type: ignore
+    if analytic_init_case in spherical_cases:
         # TODO: Consider CubedSphereCommunicator check within individual init_*() calls
         if not isinstance(comm, CubedSphereCommunicator):
             raise TypeError(
@@ -56,7 +56,7 @@ def init_analytic_state(
                 f"got {type(comm).__name__} instead."
             )
 
-        if analytic_init_case == AnalyticCase.baroclinic_instability:  # type: ignore
+        if analytic_init_case == AnalyticCase.baroclinic_instability:
             return bc.init_baroclinic_state(
                 grid_data=grid_data,
                 quantity_factory=quantity_factory,
@@ -66,7 +66,7 @@ def init_analytic_state(
                 is_steady=False,
                 comm=comm,
             )
-        elif analytic_init_case == AnalyticCase.baroclinic_steady:  # type: ignore
+        elif analytic_init_case == AnalyticCase.baroclinic_steady:
             return bc.init_baroclinic_state(
                 grid_data=grid_data,
                 quantity_factory=quantity_factory,
@@ -76,14 +76,14 @@ def init_analytic_state(
                 is_steady=True,
                 comm=comm,
             )
-        elif analytic_init_case == AnalyticCase.tropicalcyclone:  # type: ignore
+        elif analytic_init_case == AnalyticCase.tropicalcyclone:
             return tc.init_tc_state(
                 grid_data=grid_data,
                 quantity_factory=quantity_factory,
                 hydrostatic=hydrostatic,
                 comm=comm,
             )
-        elif analytic_init_case == AnalyticCase.rossby:  # type: ignore
+        elif analytic_init_case == AnalyticCase.rossby:
             # TODO sw_dynamics check is awkward here, and should be moved.
             if sw_dynamics is False:
                 raise ValueError(

--- a/pyfv3/stencils/d_sw.py
+++ b/pyfv3/stencils/d_sw.py
@@ -1,4 +1,4 @@
-from typing import Dict, Mapping
+from collections.abc import Mapping
 
 from ndsl import Quantity, QuantityFactory, StencilFactory, orchestrate
 from ndsl.constants import X_DIM, X_INTERFACE_DIM, Y_DIM, Y_INTERFACE_DIM, Z_DIM
@@ -668,7 +668,7 @@ def get_column_namelist(
     if config.d2_bg_k2 < 0:
         raise NotImplementedError("D_SW.column with d2_bg_k2 < 0 is not implemented")
 
-    col: Dict[str, Quantity] = {}
+    col: dict[str, Quantity] = {}
     for name in all_names:
         # TODO: fill units information
         col[name] = quantity_factory.zeros(

--- a/pyfv3/stencils/delnflux.py
+++ b/pyfv3/stencils/delnflux.py
@@ -1,4 +1,4 @@
-from __future__ import annotations
+from typing import Optional
 
 import dace
 
@@ -274,8 +274,8 @@ class DelnFlux:
         q: FloatField,
         fx: FloatField,
         fy: FloatField,
-        d2: FloatField | None = None,
-        mass: FloatField | None = None,
+        d2: Optional["FloatField"] = None,
+        mass: Optional["FloatField"] = None,
     ):
         """
         Del-n damping for fluxes, where n = 2 * nord + 2
@@ -396,20 +396,16 @@ class DelnFluxNoSG:
 
         self._d2_damp = stencil_factory.from_origin_domain(
             d2_damp_interval,
-            externals={
-                **preamble_ax_offsets,
-            },
             origin=origin_d2,
             domain=domain_d2,
+            externals={**preamble_ax_offsets},
         )
 
         self._copy_stencil_interval = stencil_factory.from_origin_domain(
             copy_stencil_interval,
-            externals={
-                **preamble_ax_offsets,
-            },
             origin=origin_d2,
             domain=domain_d2,
+            externals={**preamble_ax_offsets},
         )
 
         self._d2_stencil = get_stencils_with_varied_bounds(

--- a/pyfv3/stencils/delnflux.py
+++ b/pyfv3/stencils/delnflux.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import dace
 
 from ndsl import Quantity, QuantityFactory, StencilFactory, orchestrate

--- a/pyfv3/stencils/delnflux.py
+++ b/pyfv3/stencils/delnflux.py
@@ -1,5 +1,3 @@
-from typing import Optional
-
 import dace
 
 from ndsl import Quantity, QuantityFactory, StencilFactory, orchestrate
@@ -274,8 +272,8 @@ class DelnFlux:
         q: FloatField,
         fx: FloatField,
         fy: FloatField,
-        d2: Optional["FloatField"] = None,
-        mass: Optional["FloatField"] = None,
+        d2: FloatField | None = None,
+        mass: FloatField | None = None,
     ):
         """
         Del-n damping for fluxes, where n = 2 * nord + 2
@@ -331,7 +329,7 @@ class DelnFluxNoSG:
         damping_coefficients: DampingCoefficients,
         rarea: Quantity,
         nord: Quantity,
-        nk: Optional[int] = None,
+        nk: int | None = None,
     ):
         """
         nord sets the order of damping to apply:

--- a/pyfv3/stencils/dyn_core.py
+++ b/pyfv3/stencils/dyn_core.py
@@ -1,4 +1,4 @@
-from typing import Dict, Mapping, Optional
+from collections.abc import Mapping
 
 import numpy as np
 from dace.frontend.python.interface import nounroll as dace_nounroll
@@ -203,7 +203,7 @@ def get_nk_heat_dissipation(
 def dyncore_temporaries(
     quantity_factory: QuantityFactory,
 ) -> Mapping[str, Quantity]:
-    temporaries: Dict[str, Quantity] = {}
+    temporaries: dict[str, Quantity] = {}
     for name in ["ut", "vt", "gz", "zh", "pem", "pkc", "pk3", "heat_source", "cappa"]:
         # TODO: the dimensions of ut and vt may not be correct,
         #       because they are not used. double-check and correct as needed.
@@ -391,7 +391,7 @@ class AcousticDynamics:
         phis: FloatFieldIJ,
         wsd: FloatFieldIJ,
         state,  # [DaCe] hack to get around quantity as parameters for halo updates
-        checkpointer: Optional[Checkpointer] = None,
+        checkpointer: Checkpointer | None = None,
     ):
         """
         Args:

--- a/pyfv3/stencils/fillz.py
+++ b/pyfv3/stencils/fillz.py
@@ -1,5 +1,4 @@
 import typing
-from typing import Dict
 
 import ndsl.dsl.gt4py_utils as utils
 from ndsl import Quantity, QuantityFactory, StencilFactory, orchestrate
@@ -110,7 +109,7 @@ class FillNegativeTracerValues:
         stencil_factory: StencilFactory,
         quantity_factory: QuantityFactory,
         nq: int,
-        tracers: Dict[str, Quantity],
+        tracers: dict[str, Quantity],
     ):
         orchestrate(
             obj=self,
@@ -144,7 +143,7 @@ class FillNegativeTracerValues:
     def __call__(
         self,
         dp2: FloatField,
-        tracers: Dict[str, Quantity],
+        tracers: dict[str, Quantity],
     ):
         """
         Args:

--- a/pyfv3/stencils/fv_dynamics.py
+++ b/pyfv3/stencils/fv_dynamics.py
@@ -442,7 +442,7 @@ class DynamicalCore:
     def step_dynamics(
         self,
         state: DycoreState,
-        timer: Timer = NullTimer(),
+        timer: Timer | None = None,
     ):
         """
         Step the model state forward by one timestep.
@@ -451,6 +451,9 @@ class DynamicalCore:
             state: model prognostic state and inputs
             timer: keep time of model sections
         """
+        if timer is None:
+            timer = NullTimer()
+
         self._checkpoint_fvdynamics(state=state, tag="In")
         self._compute(state, timer)
         self._checkpoint_fvdynamics(state=state, tag="Out")

--- a/pyfv3/stencils/fv_dynamics.py
+++ b/pyfv3/stencils/fv_dynamics.py
@@ -1,5 +1,5 @@
+from collections.abc import Mapping
 from datetime import timedelta
-from typing import Mapping, Optional
 
 from dace.frontend.python.interface import nounroll as dace_no_unroll
 
@@ -99,7 +99,7 @@ class DynamicalCore:
         phis: Quantity,
         state: DycoreState,
         timestep: timedelta,
-        checkpointer: Optional[Checkpointer] = None,
+        checkpointer: Checkpointer | None = None,
     ):
         """
         Args:

--- a/pyfv3/stencils/fvtp2d.py
+++ b/pyfv3/stencils/fvtp2d.py
@@ -1,5 +1,3 @@
-from typing import Optional
-
 from ndsl import QuantityFactory, StencilFactory, orchestrate
 from ndsl.constants import X_DIM, Y_DIM, Z_DIM
 from ndsl.dsl.gt4py import PARALLEL, computation
@@ -165,7 +163,7 @@ class FiniteVolumeTransport:
             # [DaCe] Use _do_delnflux instead of a None function
             # to have DaCe parsing working
             self._do_delnflux = True
-            self.delnflux: Optional[DelnFlux] = DelnFlux(
+            self.delnflux: DelnFlux | None = DelnFlux(
                 stencil_factory=stencil_factory,
                 quantity_factory=quantity_factory,
                 damping_coefficients=damping_coefficients,

--- a/pyfv3/stencils/map_single.py
+++ b/pyfv3/stencils/map_single.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from collections.abc import Sequence
 
 from ndsl import QuantityFactory, StencilFactory, orchestrate

--- a/pyfv3/stencils/map_single.py
+++ b/pyfv3/stencils/map_single.py
@@ -1,6 +1,5 @@
-from __future__ import annotations
-
 from collections.abc import Sequence
+from typing import Optional
 
 from ndsl import QuantityFactory, StencilFactory, orchestrate
 from ndsl.constants import X_DIM, Y_DIM, Z_DIM
@@ -156,7 +155,7 @@ class MapSingle:
         q1: FloatField,
         pe1: FloatField,
         pe2: FloatField,
-        qs: FloatFieldIJ | None = None,
+        qs: Optional["FloatFieldIJ"] = None,
         qmin: Float = 0.0,
     ):
         """

--- a/pyfv3/stencils/map_single.py
+++ b/pyfv3/stencils/map_single.py
@@ -1,4 +1,4 @@
-from typing import Optional, Sequence
+from collections.abc import Sequence
 
 from ndsl import QuantityFactory, StencilFactory, orchestrate
 from ndsl.constants import X_DIM, Y_DIM, Z_DIM
@@ -154,7 +154,7 @@ class MapSingle:
         q1: FloatField,
         pe1: FloatField,
         pe2: FloatField,
-        qs: Optional["FloatFieldIJ"] = None,
+        qs: FloatFieldIJ | None = None,
         qmin: Float = 0.0,
     ):
         """

--- a/pyfv3/stencils/mapn_tracer.py
+++ b/pyfv3/stencils/mapn_tracer.py
@@ -1,5 +1,3 @@
-from typing import Dict
-
 import ndsl.dsl.gt4py_utils as utils
 from ndsl import Quantity, QuantityFactory, StencilFactory, orchestrate
 from ndsl.constants import X_DIM, Y_DIM, Z_DIM
@@ -20,7 +18,7 @@ class MapNTracer:
         kord: int,
         nq: int,
         fill: bool,
-        tracers: Dict[str, Quantity],
+        tracers: dict[str, Quantity],
     ):
         orchestrate(
             obj=self,
@@ -64,7 +62,7 @@ class MapNTracer:
         pe1: FloatField,
         pe2: FloatField,
         dp2: FloatField,
-        tracers: Dict[str, Quantity],
+        tracers: dict[str, Quantity],
     ):
         """
         Remaps the tracer species onto the Eulerian grid

--- a/pyfv3/stencils/remap_profile.py
+++ b/pyfv3/stencils/remap_profile.py
@@ -1,4 +1,4 @@
-from typing import Sequence
+from collections.abc import Sequence
 
 from ndsl import QuantityFactory, StencilFactory, orchestrate
 from ndsl.constants import X_DIM, Y_DIM, Z_DIM, Z_INTERFACE_DIM

--- a/pyfv3/stencils/remapping.py
+++ b/pyfv3/stencils/remapping.py
@@ -1,5 +1,3 @@
-from typing import Dict, Optional
-
 from ndsl import Quantity, QuantityFactory, StencilFactory, orchestrate
 from ndsl.constants import (
     X_DIM,
@@ -294,8 +292,8 @@ class LagrangianToEulerian:
         area_64,
         nq,
         pfull,
-        tracers: Dict[str, Quantity],
-        checkpointer: Optional[Checkpointer] = None,
+        tracers: dict[str, Quantity],
+        checkpointer: Checkpointer | None = None,
     ):
         orchestrate(
             obj=self,
@@ -518,7 +516,7 @@ class LagrangianToEulerian:
 
     def __call__(
         self,
-        tracers: Dict[str, Quantity],
+        tracers: dict[str, Quantity],
         pt: FloatField,
         delp: FloatField,
         delz: FloatField,

--- a/pyfv3/stencils/tracer_2d_1l.py
+++ b/pyfv3/stencils/tracer_2d_1l.py
@@ -1,5 +1,4 @@
 import math
-from typing import Dict
 
 from ndsl import (
     Quantity,
@@ -192,7 +191,7 @@ class TracerAdvection:
         transport: FiniteVolumeTransport,
         grid_data,
         comm: Communicator,
-        tracers: Dict[str, Quantity],
+        tracers: dict[str, Quantity],
     ):
         orchestrate(
             obj=self,
@@ -290,7 +289,7 @@ class TracerAdvection:
 
     def __call__(
         self,
-        tracers: Dict[str, Quantity],
+        tracers: dict[str, Quantity],
         dp1,
         x_mass_flux,
         y_mass_flux,

--- a/pyfv3/stencils/updatedzd.py
+++ b/pyfv3/stencils/updatedzd.py
@@ -1,5 +1,3 @@
-from typing import Tuple
-
 import ndsl.constants as constants
 from ndsl import Quantity, QuantityFactory, StencilFactory, orchestrate
 from ndsl.constants import (
@@ -122,7 +120,7 @@ def apply_height_fluxes(
 
 def cubic_spline_interpolation_constants(
     dp0: Quantity, quantity_factory: QuantityFactory
-) -> Tuple[Quantity, Quantity, Quantity]:
+) -> tuple[Quantity, Quantity, Quantity]:
     """
     Computes constants used in cubic spline interpolation
     from cell center to interface levels.

--- a/pyfv3/testing/map_single.py
+++ b/pyfv3/testing/map_single.py
@@ -1,4 +1,4 @@
-from typing import Dict, Tuple
+from typing import Any
 
 from ndsl import QuantityFactory, StencilFactory
 from ndsl.constants import X_INTERFACE_DIM, Y_INTERFACE_DIM, Z_DIM
@@ -6,14 +6,14 @@ from pyfv3.stencils.map_single import MapSingle
 
 
 class MapSingleFactory:
-    _object_pool: Dict[Tuple[int, int, Tuple[str, ...]], MapSingle] = {}
+    _object_pool: dict[tuple[int, int, tuple[str, ...]], MapSingle] = {}
     """Pool of MapSingle objects."""
 
     def __init__(
         self,
         stencil_factory: StencilFactory,
         quantity_factory: QuantityFactory,
-    ):
+    ) -> None:
         self.stencil_factory = stencil_factory
         self.quantity_factory = quantity_factory
 
@@ -21,9 +21,9 @@ class MapSingleFactory:
         self,
         kord: int,
         mode: int,
-        *args,
-        **kwargs,
-    ):
+        *args: Any,
+        **kwargs: dict,
+    ) -> None:
         key_tuple = (kord, mode, (X_INTERFACE_DIM, Y_INTERFACE_DIM, Z_DIM))
         if key_tuple not in self._object_pool:
             self._object_pool[key_tuple] = MapSingle(

--- a/pyfv3/testing/translate_data.py
+++ b/pyfv3/testing/translate_data.py
@@ -1,16 +1,16 @@
 from f90nml import Namelist
 
 from ndsl import StencilFactory
-from ndsl.stencils.testing import TranslateFortranData2Py
+from ndsl.stencils.testing import Grid, TranslateFortranData2Py
 from pyfv3._config import DynamicalCoreConfig
 
 
 class TranslateDycoreFortranData2Py(TranslateFortranData2Py):
     def __init__(
         self,
-        grid,
+        grid: Grid,
         namelist: Namelist,
         stencil_factory: StencilFactory,
-    ):
+    ) -> None:
         super().__init__(grid, stencil_factory)
         self.config = DynamicalCoreConfig.from_f90nml(namelist)

--- a/pyfv3/testing/translate_dyncore.py
+++ b/pyfv3/testing/translate_dyncore.py
@@ -2,8 +2,9 @@ from f90nml import Namelist
 
 import ndsl.dsl.gt4py_utils as utils
 from ndsl import Quantity, StencilFactory
+from ndsl.comm import Comm
 from ndsl.constants import X_DIM, X_INTERFACE_DIM, Y_DIM, Y_INTERFACE_DIM, Z_DIM
-from ndsl.stencils.testing import ParallelTranslate2PyState
+from ndsl.stencils.testing import Grid, ParallelTranslate2PyState
 from pyfv3._config import DynamicalCoreConfig
 from pyfv3.dycore_state import DycoreState
 from pyfv3.stencils import dyn_core
@@ -51,10 +52,10 @@ class TranslateDynCore(ParallelTranslate2PyState):
 
     def __init__(
         self,
-        grid,
+        grid: Grid,
         namelist: Namelist,
         stencil_factory: StencilFactory,
-    ):
+    ) -> None:
         super().__init__(grid, namelist, stencil_factory)
         self._base.in_vars["data_vars"] = {
             "cappa": {},
@@ -125,7 +126,7 @@ class TranslateDynCore(ParallelTranslate2PyState):
         self.stencil_factory = stencil_factory
         self.config = DynamicalCoreConfig.from_f90nml(namelist)
 
-    def compute_parallel(self, inputs, communicator):
+    def compute_parallel(self, inputs: dict, communicator: Comm) -> dict:
         # ak, bk, and phis are numpy arrays at this point and
         #   must be converted into gt4py storages
         for name in ("ak", "bk", "phis"):
@@ -176,7 +177,7 @@ class TranslateDynCore(ParallelTranslate2PyState):
         )
         acoustic_dynamics.cappa.data[:] = inputs["cappa"][:]
 
-        acoustic_dynamics(state, timestep=inputs["mdt"], n_map=state.n_map)
+        acoustic_dynamics(state, timestep=inputs["mdt"], n_map=state.n_map)  # type: ignore[attr-defined]
         # the "inputs" dict is not used to return, we construct a new dict based
         # on variables attached to `state`
         storages_only = {}

--- a/pyfv3/testing/translate_fvdynamics.py
+++ b/pyfv3/testing/translate_fvdynamics.py
@@ -341,7 +341,7 @@ class TranslateFVDynamics(ParallelTranslateBaseSlicing):
             return {}
         outputs = {}
         storages = {}
-        for name, properties in self.outputs.items():
+        for name, _properties in self.outputs.items():
             if isinstance(state[name], Quantity):
                 storages[name] = state[name].data
             elif len(self.outputs[name]["dims"]) > 0:

--- a/pyfv3/testing/translate_fvdynamics.py
+++ b/pyfv3/testing/translate_fvdynamics.py
@@ -1,12 +1,13 @@
 from dataclasses import fields
 from datetime import timedelta
-from typing import Any, Dict, Optional, Tuple
+from typing import Any
 
 import pytest
 from f90nml import Namelist
 
 import ndsl.dsl.gt4py_utils as utils
 from ndsl import Quantity, StencilFactory
+from ndsl.comm import Comm
 from ndsl.constants import (
     X_DIM,
     X_INTERFACE_DIM,
@@ -17,7 +18,7 @@ from ndsl.constants import (
 )
 from ndsl.grid import GridData
 from ndsl.performance import NullTimer
-from ndsl.stencils.testing import ParallelTranslateBaseSlicing
+from ndsl.stencils.testing import Grid, ParallelTranslateBaseSlicing
 from pyfv3._config import DynamicalCoreConfig
 from pyfv3.dycore_state import DycoreState
 from pyfv3.stencils import fv_dynamics
@@ -25,7 +26,7 @@ from pyfv3.stencils import fv_dynamics
 
 class TranslateFVDynamics(ParallelTranslateBaseSlicing):
     compute_grid_option = True
-    inputs: Dict[str, Any] = {
+    inputs: dict[str, Any] = {
         "q_con": {
             "name": "total_condensate_mixing_ratio",
             "dims": [X_DIM, Y_DIM, Z_DIM],
@@ -215,12 +216,12 @@ class TranslateFVDynamics(ParallelTranslateBaseSlicing):
 
     def __init__(
         self,
-        grid,
+        grid: Grid,
         namelist: Namelist,
         stencil_factory: StencilFactory,
-        *args,
-        **kwargs,
-    ):
+        *args: Any,
+        **kwargs: dict,
+    ) -> None:
         super().__init__(grid, namelist, stencil_factory, *args, **kwargs)
         fv_dynamics_vars = {
             "u": grid.y3d_domain_dict(),
@@ -283,11 +284,11 @@ class TranslateFVDynamics(ParallelTranslateBaseSlicing):
         for qvar in utils.tracer_variables:
             self.ignore_near_zero_errors[qvar] = True
         self.ignore_near_zero_errors["q_con"] = True
-        self.dycore: Optional[fv_dynamics.DynamicalCore] = None
+        self.dycore: fv_dynamics.DynamicalCore | None = None
         self.stencil_factory = stencil_factory
         self.config = DynamicalCoreConfig.from_f90nml(namelist)
 
-    def state_from_inputs(self, inputs):
+    def state_from_inputs(self, inputs: dict) -> DycoreState:
         input_storages = super().state_from_inputs(inputs)
         # making sure we init DycoreState with the exact set of variables
         accepted_keys = [_field.name for _field in fields(DycoreState)]
@@ -298,10 +299,9 @@ class TranslateFVDynamics(ParallelTranslateBaseSlicing):
         for name in to_delete:
             del input_storages[name]
 
-        state = DycoreState.init_from_storages(input_storages, sizer=self.grid.sizer)
-        return state
+        return DycoreState.init_from_storages(input_storages, sizer=self.grid.sizer)
 
-    def prepare_data(self, inputs) -> Tuple[DycoreState, GridData]:
+    def prepare_data(self, inputs: dict) -> tuple[DycoreState, GridData]:
         for name in ("ak", "bk"):
             inputs[name] = utils.make_storage_data(
                 inputs[name],
@@ -319,7 +319,7 @@ class TranslateFVDynamics(ParallelTranslateBaseSlicing):
         state = self.state_from_inputs(inputs)
         return state, grid_data
 
-    def compute_parallel(self, inputs, communicator):
+    def compute_parallel(self, inputs: dict, communicator: Comm) -> dict:
         state, grid_data = self.prepare_data(inputs)
         self.dycore = fv_dynamics.DynamicalCore(
             comm=communicator,
@@ -336,7 +336,7 @@ class TranslateFVDynamics(ParallelTranslateBaseSlicing):
         outputs = self.outputs_from_state(state)
         return outputs
 
-    def outputs_from_state(self, state: dict):
+    def outputs_from_state(self, state: DycoreState) -> dict:
         if len(self.outputs) == 0:
             return {}
         outputs = {}
@@ -351,7 +351,7 @@ class TranslateFVDynamics(ParallelTranslateBaseSlicing):
         outputs.update(self._base.slice_output(storages))
         return outputs
 
-    def compute_sequential(self, *args, **kwargs):
+    def compute_sequential(self, *args: Any, **kwargs: dict) -> None:
         pytest.skip(
             f"{self.__class__} only has a mpirun implementation, "
             "not running in mock-parallel"

--- a/pyfv3/testing/validation.py
+++ b/pyfv3/testing/validation.py
@@ -1,10 +1,9 @@
 import inspect
-from typing import Callable, Mapping, Tuple
+from collections.abc import Callable, Mapping
 
 import numpy as np
 
 import pyfv3.stencils.divergence_damping
-import pyfv3.stencils.updatedzd
 from ndsl import Quantity
 from ndsl.constants import X_DIM, X_INTERFACE_DIM, Y_DIM, Y_INTERFACE_DIM, Z_DIM
 
@@ -12,7 +11,7 @@ from ndsl.constants import X_DIM, X_INTERFACE_DIM, Y_DIM, Y_INTERFACE_DIM, Z_DIM
 def get_selective_class(
     cls: type,
     name_to_origin_domain_function: Mapping[
-        str, Callable[..., Tuple[Tuple[int, ...], Tuple[int, ...]]]
+        str, Callable[..., tuple[tuple[int, ...], tuple[int, ...]]]
     ],
 ):
     """
@@ -92,7 +91,7 @@ def get_selective_class(
 
 def get_selective_tracer_advection(
     cls: type,
-    origin_domain_func: Callable[..., Tuple[Tuple[int, ...], Tuple[int, ...]]],
+    origin_domain_func: Callable[..., tuple[tuple[int, ...], tuple[int, ...]]],
 ):
     class SelectivelyValidatedTracerAdvection:
         """
@@ -142,7 +141,7 @@ def get_selective_tracer_advection(
 
 def get_compute_domain_k_interfaces(
     instance,
-) -> Tuple[Tuple[int, ...], Tuple[int, ...]]:
+) -> tuple[tuple[int, ...], tuple[int, ...]]:
     try:
         origin = instance.grid_indexing.origin_compute()
         domain = instance.grid_indexing.domain_compute(add=(0, 0, 1))

--- a/pyfv3/utils/functional_validation.py
+++ b/pyfv3/utils/functional_validation.py
@@ -1,5 +1,5 @@
 import copy
-from typing import Callable, Sequence, Tuple
+from collections.abc import Callable, Sequence
 
 import numpy as np
 
@@ -9,7 +9,7 @@ from ndsl import GridIndexing
 def get_subset_func(
     grid_indexing: GridIndexing,
     dims: Sequence[str],
-    n_halo: Tuple[Tuple[int, int], Tuple[int, int]] = ((0, 0), (0, 0)),
+    n_halo: tuple[tuple[int, int], tuple[int, int]] = ((0, 0), (0, 0)),
 ) -> Callable[[np.ndarray], np.ndarray]:
     """
     Args:
@@ -26,15 +26,16 @@ def get_subset_func(
     j_start = origin[1] - n_halo[1][0]
     j_end = origin[1] + domain[1] + n_halo[1][1]
 
-    def subset(data):
+    def subset(data: np.ndarray) -> np.ndarray:
         if len(dims) == 3:
             return data[i_start:i_end, j_start:j_end, :]
-        elif len(dims) == 2:
+
+        if len(dims) == 2:
             return data[i_start:i_end, j_start:j_end]
-        else:
-            raise NotImplementedError(
-                "Only 2D and 3D subsets are supported, got dims: {}".format(dims)
-            )
+
+        raise NotImplementedError(
+            "Only 2D and 3D subsets are supported, got dims: {}".format(dims)
+        )
 
     return subset
 
@@ -42,11 +43,11 @@ def get_subset_func(
 def get_set_nan_func(
     grid_indexing: GridIndexing,
     dims: Sequence[str],
-    n_halo: Tuple[Tuple[int, int], Tuple[int, int]] = ((0, 0), (0, 0)),
+    n_halo: tuple[tuple[int, int], tuple[int, int]] = ((0, 0), (0, 0)),
 ) -> Callable[[np.ndarray], np.ndarray]:
     subset = get_subset_func(grid_indexing=grid_indexing, dims=dims, n_halo=n_halo)
 
-    def set_nans(data):
+    def set_nans(data: np.ndarray) -> np.ndarray:
         try:
             safe = copy.deepcopy(data)
             data[:] = np.nan

--- a/pyfv3/wrappers/geos_wrapper.py
+++ b/pyfv3/wrappers/geos_wrapper.py
@@ -2,7 +2,7 @@ import enum
 import logging
 import os
 from datetime import timedelta
-from typing import Dict, List, Tuple
+from types import TracebackType
 
 import f90nml
 import numpy as np
@@ -67,7 +67,7 @@ class StencilBackendCompilerOverride:
             gt_build_settings["extra_compile_args"]["cxx"].append("-w")
             gt_build_settings["extra_compile_args"]["cuda"].append("-w")
 
-    def __enter__(self):
+    def __enter__(self) -> None:
         if self.no_op:
             return
         if self.config.do_compile:
@@ -76,7 +76,12 @@ class StencilBackendCompilerOverride:
             ndsl_log.info(f"Stencil backend waits on {self.comm.Get_rank()}")
             self.comm.Barrier()
 
-    def __exit__(self, type, value, traceback):
+    def __exit__(
+        self,
+        type: type[BaseException] | None,
+        value: BaseException | None,
+        traceback: TracebackType | None,
+    ) -> None:
         if self.no_op:
             return
         if not self.config.do_compile:
@@ -105,7 +110,7 @@ class GeosDycoreWrapper:
         comm: Comm,
         backend: str,
         fortran_mem_space: MemorySpace = MemorySpace.HOST,
-    ):
+    ) -> None:
         # Look for an override to run on a single node
         gtfv3_single_rank_override = int(os.getenv("GTFV3_SINGLE_RANK_OVERRIDE", -1))
         if gtfv3_single_rank_override >= 0:
@@ -204,7 +209,7 @@ class GeosDycoreWrapper:
             MemorySpace.DEVICE if is_gpu_backend(backend) else MemorySpace.HOST
         )
 
-        self.output_dict: Dict[str, np.ndarray] = {}
+        self.output_dict: dict[str, np.ndarray] = {}
         self._allocate_output_dir()
 
         # Feedback information
@@ -232,7 +237,7 @@ class GeosDycoreWrapper:
             f"     Nvidia MPS : {MPS_is_on}"
         )
 
-    def _critical_path(self):
+    def _critical_path(self) -> None:
         """Top-level orchestration function"""
         with self.perf_collector.timestep_timer.clock("step_dynamics"):
             self.dynamical_core.step_dynamics(
@@ -242,7 +247,7 @@ class GeosDycoreWrapper:
 
     def __call__(
         self,
-        timings: Dict[str, List[float]],
+        timings: dict[str, list[float]],
         u: np.ndarray,
         v: np.ndarray,
         w: np.ndarray,
@@ -267,7 +272,7 @@ class GeosDycoreWrapper:
         cxd: np.ndarray,
         cyd: np.ndarray,
         diss_estd: np.ndarray,
-    ) -> Tuple[Dict[str, np.ndarray], Dict[str, List[float]]]:
+    ) -> tuple[dict[str, np.ndarray], dict[str, list[float]]]:
         with self.perf_collector.timestep_timer.clock("numpy-to-dycore"):
             self.dycore_state = self._put_fortran_data_in_dycore(
                 u,
@@ -387,7 +392,7 @@ class GeosDycoreWrapper:
 
         return state
 
-    def _prep_outputs_for_geos(self) -> Dict[str, np.ndarray]:
+    def _prep_outputs_for_geos(self) -> dict[str, np.ndarray]:
         output_dict = self.output_dict
         isc = self._grid_indexing.isc
         jsc = self._grid_indexing.jsc
@@ -521,7 +526,7 @@ class GeosDycoreWrapper:
 
         return output_dict
 
-    def _allocate_output_dir(self):
+    def _allocate_output_dir(self) -> None:
         if self._fortran_mem_space != self._pace_mem_space:
             nhalo = self._grid_indexing.n_halo
             shape_centered = self._grid_indexing.domain_full(add=(0, 0, 0))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,13 +83,27 @@ sections = "FUTURE,STDLIB,THIRDPARTY,FIRSTPARTY,LOCALFOLDER"
 use_parentheses = true
 
 [tool.mypy]
-exclude = ["pyfv3/stencils/fv_subgridz.py", "tests/conftest.py"]
-explicit_package_bases = true
-follow_imports = "normal"
+disallow_incomplete_defs = true
+disallow_untyped_defs = true
+# TODO: understand what's wrong with imports and fix
 ignore_missing_imports = true
-namespace_packages = true
-strict_optional = false
+strict_equality = true
+strict_optional = true
+warn_redundant_casts = true
 warn_unreachable = true
+warn_unused_configs = true
+warn_unused_ignores = true
+
+[[tool.mypy.overrides]]
+disallow_incomplete_defs = false
+disallow_untyped_defs = false
+module = [
+  # not sure if we can ever type all stencils
+  "pyfv3.stencils.*",
+  "pyfv3.initialization.test_cases.*",
+  "pyfv3.initialization.init_utils",
+  "pyfv3.testing.validation"
+]
 
 [tool.setuptools]
 include-package-data = true

--- a/tests/savepoint/translate/translate_init_case.py
+++ b/tests/savepoint/translate/translate_init_case.py
@@ -178,9 +178,9 @@ class TranslateInitCase(ParallelTranslateBaseSlicing):
     def outputs_from_state(self, state: dict):
         outputs = {}
         arrays = {}
-        for name, properties in self.outputs.items():
+        for name, _properties in self.outputs.items():
             if isinstance(state[name], dict):
-                for tracer, quantity in state[name].items():
+                for tracer, _quantity in state[name].items():
                     state[name][tracer] = state[name][tracer].data
                 arrays[name] = state[name]
             elif len(self.outputs[name]["dims"]) > 0:


### PR DESCRIPTION
**Description**

This PR suggests better defaults for the `mypy` configuration. The new rules apply don't apply within `pyfv3.stencils`. That would have been too much effort to start with. Types aren't less safe than before because before the exceptions were just made for the whole repo (now it's contained to `pyfv3.stencils` and select files that weren't typed before).

In addition, the PR includes

- update of the linting tools
- new tool: `flake8-bugbear`
- more modern type hints (e.g. `Dict[...]` -> dict[...])

Note that even this configuration doesn't catch, what is about to be fixed in https://github.com/NOAA-GFDL/PyFV3/pull/96 (for https://github.com/NOAA-GFDL/pace/pull/156).

/cc @twicki @FlorianDeconinck 

**How Has This Been Tested?**

Self testing with new checks by `mypy` and `flake8-bugbear`. All good as long as CI (in particular the linting job) is still green.

**Checklist:**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation: N/A
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules: N/A
- [x] New check tests, if applicable, are included
- [ ] Targeted model if this changed was triggered by a model need/shortcoming: N/A
