### PR TITLE
ci: fix file ending of called workflow

### DIFF
--- a/.github/workflows/create_cache.yaml
+++ b/.github/workflows/create_cache.yaml
@@ -89,4 +89,4 @@ jobs:
   pySHiELD-test-data:
     # Downstream calls may not need this. If so, they should fetch it explicitly.
     if: ${{!inputs.external-call}}
-    uses: NOAA-GFDL/pySHiELD/.github/workflows/create_cache.yml@develop
+    uses: NOAA-GFDL/pySHiELD/.github/workflows/create_cache.yaml@develop


### PR DESCRIPTION
**Description**

Fix file ending of called workflow. The workflow as renamed in https://github.com/NOAA-GFDL/PyFV3/pull/93 and calling it with the old ending thus [failed](https://github.com/NOAA-GFDL/PyFV3/actions/runs/18944442684). So we'll have to do one more PR for this. Sorry :/

**How Has This Been Tested?**

This time I've tested by running the workflow on this PR and it successfully built the cache.

**Checklist:**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas: N/A
- [ ] I have made corresponding changes to the documentation: N/A
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [ ] New check tests, if applicable, are included: N/A
- [ ] Targeted model if this changed was triggered by a model need/shortcoming: N/A
