### PR TITLE
PyFV3: Removing --no_legacy_namelist flag

### DIFF
--- a/.github/workflows/translate.yaml
+++ b/.github/workflows/translate.yaml
@@ -90,7 +90,6 @@ jobs:
               --backend=numpy \
               --which_modules=FvTp2d \
               --threshold_overrides_file=./tests/savepoint/translate/overrides/standard.yaml \
-              --no_legacy_namelist \
               ./tests/savepoint
 
       - name: Numpy D_SW
@@ -101,7 +100,6 @@ jobs:
                --backend=numpy \
                --which_modules=D_SW \
                --threshold_overrides_file=./tests/savepoint/translate/overrides/standard.yaml \
-               --no_legacy_namelist \
                ./tests/savepoint
 
       - name: Numpy Remapping
@@ -112,7 +110,6 @@ jobs:
               --backend=numpy \
               --which_modules=Remapping \
               --threshold_overrides_file=./tests/savepoint/translate/overrides/standard.yaml \
-              --no_legacy_namelist \
               ./tests/savepoint
 
       - name: Orchestrated dace-cpu Acoustics
@@ -129,5 +126,4 @@ jobs:
             --which_rank=0 \
             --which_modules=DynCore \
             --threshold_overrides_file=./tests/savepoint/translate/overrides/standard.yaml \
-            --no_legacy_namelist \
             ./tests/savepoint


### PR DESCRIPTION
**Description**
This is a follow-up (clean-up) from PR https://github.com/NOAA-GFDL/NDSL/pull/297.

It removes the flag --no_legacy_namelist flag from the github workflows.

**How Has This Been Tested?**
It passes CI

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [ ] New check tests, if applicable, are included
- [ ] Targeted model if this changed was triggered by a model need/shortcoming
