### PR TITLE
refactor: use new constructor of `QuantityFactory`

### DIFF
--- a/examples/notebook/test_functionality.ipynb
+++ b/examples/notebook/test_functionality.ipynb
@@ -134,7 +134,7 @@
     ")\n",
     "\n",
     "# useful for easily allocating distributed data storages (fields)\n",
-    "quantity_factory = QuantityFactory.from_backend(sizer=sizer, backend=backend)\n",
+    "quantity_factory = QuantityFactory(sizer=sizer, backend=backend)\n",
     "\n",
     "compilation_config = CompilationConfig(backend=backend, communicator=cs_communicator)\n",
     "\n",

--- a/pyfv3/wrappers/geos_wrapper.py
+++ b/pyfv3/wrappers/geos_wrapper.py
@@ -143,7 +143,7 @@ class GeosDycoreWrapper:
         sizer = SubtileGridSizer.from_namelist(
             self.namelist, partitioner.tile, self.communicator.tile.rank
         )
-        quantity_factory = QuantityFactory.from_backend(sizer=sizer, backend=backend)
+        quantity_factory = QuantityFactory(sizer=sizer, backend=backend)
 
         # set up the metric terms and grid data
         metric_terms = MetricTerms(

--- a/tests/mpi/test_doubly_periodic.py
+++ b/tests/mpi/test_doubly_periodic.py
@@ -97,7 +97,7 @@ def test_dycore_runs_one_step() -> None:
     grid_indexing = GridIndexing.from_sizer_and_communicator(
         sizer=sizer, comm=communicator
     )
-    quantity_factory = QuantityFactory.from_backend(sizer=sizer, backend=backend)
+    quantity_factory = QuantityFactory(sizer=sizer, backend=backend)
     metric_terms = MetricTerms(
         quantity_factory=quantity_factory,
         communicator=communicator,

--- a/tests/savepoint/translate/translate_init_case.py
+++ b/tests/savepoint/translate/translate_init_case.py
@@ -225,12 +225,9 @@ class TranslateInitCase(ParallelTranslateBaseSlicing):
             tile_rank=communicator.tile.rank,
         )
 
-        quantity_factory = QuantityFactory.from_backend(
-            sizer, backend=self.stencil_factory.backend
-        )
+        quantity_factory = QuantityFactory(sizer, backend=self.stencil_factory.backend)
 
         grid_data = GridData.new_from_metric_terms(metric_terms)
-        quantity_factory = QuantityFactory()
 
         state = analytic_init.init_analytic_state(
             analytic_init_case="baroclinic",


### PR DESCRIPTION
**Description**

Prefer the new constructor of `QuantityFactory` over the deprecated call to `QuantityFactory.from_backend(...)`. This removes a bunch of deprecation warnings in tests.

See https://github.com/NOAA-GFDL/NDSL/pull/228 for context.

/cc @FlorianDeconinck

**How Has This Been Tested?**

Search and manual replace of `from_backend` within pyFV3. CI is still green.

**Checklist:**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas: N/A
- [ ] I have made corresponding changes to the documentation: N/A
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [ ] New check tests, if applicable, are included: N/A
- [ ] Targeted model if this changed was triggered by a model need/shortcoming: N/A
