### PR TITLE
refactor: prefer `backend` over `gt4py_backend` on quantities

### DIFF
--- a/pyfv3/dycore_state.py
+++ b/pyfv3/dycore_state.py
@@ -344,7 +344,7 @@ class DycoreState:
                     _field.metadata["units"],
                     origin=sizer.get_origin(dims),
                     extent=sizer.get_extent(dims),
-                    gt4py_backend=backend,
+                    backend=backend,
                 )
         state = cls(**dict_state)
         return state

--- a/pyfv3/initialization/test_cases/initialize_baroclinic.py
+++ b/pyfv3/initialization/test_cases/initialize_baroclinic.py
@@ -369,7 +369,7 @@ def init_baroclinic_state(
     state = DycoreState.init_from_numpy_arrays(
         numpy_state.__dict__,
         sizer=quantity_factory.sizer,
-        backend=sample_quantity.metadata.gt4py_backend,
+        backend=sample_quantity.metadata.backend,
     )
 
     comm.halo_update(state.phis, n_points=NHALO)

--- a/pyfv3/initialization/test_cases/initialize_rossby.py
+++ b/pyfv3/initialization/test_cases/initialize_rossby.py
@@ -203,7 +203,7 @@ def init_rossby_state(
     state = DycoreState.init_from_numpy_arrays(
         numpy_state.__dict__,
         sizer=quantity_factory.sizer,
-        backend=sample_quantity.metadata.gt4py_backend,
+        backend=sample_quantity.metadata.backend,
     )
 
     comm.halo_update(state.phis, n_points=NHALO)

--- a/pyfv3/initialization/test_cases/initialize_tc.py
+++ b/pyfv3/initialization/test_cases/initialize_tc.py
@@ -570,7 +570,7 @@ def init_tc_state(
     state = DycoreState.init_from_numpy_arrays(
         numpy_state.__dict__,
         sizer=quantity_factory.sizer,
-        backend=sample_quantity.metadata.gt4py_backend,
+        backend=sample_quantity.metadata.backend,
     )
 
     return state

--- a/pyfv3/stencils/delnflux.py
+++ b/pyfv3/stencils/delnflux.py
@@ -27,7 +27,7 @@ def calc_damp(damp_c: Quantity, da_min: Float, nord: Quantity) -> Quantity:
         units="unknown",
         origin=damp_c.origin,
         extent=damp_c.extent,
-        gt4py_backend=damp_c.gt4py_backend,
+        backend=damp_c.backend,
     )
 
 

--- a/tests/savepoint/translate/translate_init_case.py
+++ b/tests/savepoint/translate/translate_init_case.py
@@ -204,7 +204,7 @@ class TranslateInitCase(ParallelTranslateBaseSlicing):
                 properties["units"],
                 origin=self.grid.sizer.get_origin(dims),
                 extent=self.grid.sizer.get_extent(dims),
-                gt4py_backend=self.stencil_factory.backend,
+                backend=self.stencil_factory.backend,
             )
 
         metric_terms = MetricTerms.from_tile_sizing(


### PR DESCRIPTION
**Description**

On `Quantities`, we have currently allow both `backend` and `gt4py_backend` where the later is deprecated and about to be removed.

See https://github.com/NOAA-GFDL/NDSL/pull/312 and https://github.com/NOAA-GFDL/NDSL/pull/314 for context.

/cc @FlorianDeconinck 

**How Has This Been Tested?**

Search and manual replace of `gt4py_backend` with just `backend`. CI is still green.

**Checklist:**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas: N/A
- [ ] I have made corresponding changes to the documentation: N/A
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [ ] New check tests, if applicable, are included: N/A
- [ ] Targeted model if this changed was triggered by a model need/shortcoming: N/A
