### PR TITLE
Pin pyFV3 to NDSL version 2026.01.00

### DIFF
--- a/examples/notebook/test_functionality.ipynb
+++ b/examples/notebook/test_functionality.ipynb
@@ -131,6 +131,7 @@
     "    layout=layout,\n",
     "    tile_partitioner=partitioner.tile,\n",
     "    tile_rank=cs_communicator.tile.rank,\n",
+    "    backend=backend,\n",
     ")\n",
     "\n",
     "# useful for easily allocating distributed data storages (fields)\n",

--- a/pyfv3/stencils/a2b_ord4.py
+++ b/pyfv3/stencils/a2b_ord4.py
@@ -5,7 +5,7 @@ from ndsl.dsl.gt4py import function as gtfunction
 from ndsl.dsl.gt4py import horizontal, interval, region, sin, sqrt
 from ndsl.dsl.typing import Float, FloatField, FloatFieldI, FloatFieldIJ
 from ndsl.grid import GridData
-from ndsl.stencils.basic_operations import copy_defn
+from ndsl.stencils.basic_operations import copy
 
 
 # compact 4-pt cubic interpolation
@@ -665,7 +665,7 @@ class AGrid2BGridFourthOrder:
                 a2b_interpolation, externals=ax_offsets, origin=origin, domain=domain
             )
             self._copy_stencil = stencil_factory.from_dims_halo(
-                copy_defn, compute_dims=[X_INTERFACE_DIM, Y_INTERFACE_DIM, z_dim]
+                copy, compute_dims=[X_INTERFACE_DIM, Y_INTERFACE_DIM, z_dim]
             )
 
         else:  # grid type >= 3:
@@ -675,7 +675,7 @@ class AGrid2BGridFourthOrder:
             )
             if self.replace:
                 self._copy_stencil = stencil_factory.from_dims_halo(
-                    copy_defn, compute_dims=[X_INTERFACE_DIM, Y_INTERFACE_DIM, z_dim]
+                    copy, compute_dims=[X_INTERFACE_DIM, Y_INTERFACE_DIM, z_dim]
                 )
 
     def _exclude_tile_edges(self, origin, domain, dims=("x", "y")):

--- a/pyfv3/stencils/del2cubed.py
+++ b/pyfv3/stencils/del2cubed.py
@@ -4,7 +4,7 @@ from ndsl.dsl.gt4py import PARALLEL, computation, horizontal, interval, region
 from ndsl.dsl.stencil import get_stencils_with_varied_bounds
 from ndsl.dsl.typing import Float, FloatField, FloatFieldIJ, cast_to_index3d
 from ndsl.grid import DampingCoefficients
-from ndsl.stencils.basic_operations import copy_defn
+from ndsl.stencils.basic_operations import copy
 from pyfv3.stencils.copy_corners import CopyCornersX, CopyCornersY
 
 
@@ -155,7 +155,7 @@ class HyperdiffusionDamping:
 
         """Stencil responsible for doing corners updates in x-direction."""
         self._copy_stencil = stencil_factory.from_dims_halo(
-            func=copy_defn,
+            func=copy,
             compute_dims=[X_DIM, Y_DIM, Z_DIM],
             compute_halos=(3, 3),
         )

--- a/pyfv3/stencils/divergence_damping.py
+++ b/pyfv3/stencils/divergence_damping.py
@@ -411,7 +411,7 @@ class DivergenceDamping:
         )
 
         self._copy_computeplus = high_k_stencil_factory.from_dims_halo(
-            func=basic.copy_defn,
+            func=basic.copy,
             compute_dims=[X_INTERFACE_DIM, Y_INTERFACE_DIM, Z_DIM],
             compute_halos=(0, 0),
         )
@@ -474,7 +474,7 @@ class DivergenceDamping:
         )
 
         self._set_value = high_k_stencil_factory.from_dims_halo(
-            func=basic.set_value_defn,
+            func=basic.set_value,
             compute_dims=[X_INTERFACE_DIM, Y_INTERFACE_DIM, Z_DIM],
             compute_halos=(self.grid_indexing.n_halo, self.grid_indexing.n_halo),
         )

--- a/pyfv3/stencils/dyn_core.py
+++ b/pyfv3/stencils/dyn_core.py
@@ -628,7 +628,7 @@ class AcousticDynamics:
         )
         self._pk3_halo = PK3Halo(stencil_factory, quantity_factory)
         self._copy_stencil = stencil_factory.from_origin_domain(
-            basic.copy_defn,
+            basic.copy,
             origin=grid_indexing.origin_full(),
             domain=grid_indexing.domain_full(add=(0, 0, 1)),
         )

--- a/pyfv3/stencils/fv_dynamics.py
+++ b/pyfv3/stencils/fv_dynamics.py
@@ -15,7 +15,7 @@ from ndsl.dsl.typing import Float, FloatField
 from ndsl.grid import DampingCoefficients, GridData
 from ndsl.logging import ndsl_log
 from ndsl.performance import NullTimer, Timer
-from ndsl.stencils.basic_operations import copy_defn
+from ndsl.stencils.basic_operations import copy
 from ndsl.stencils.c2l_ord import CubedToLatLon
 from ndsl.typing import Checkpointer, Communicator
 from pyfv3._config import DynamicalCoreConfig
@@ -258,7 +258,7 @@ class DynamicalCore:
             domain=grid_indexing.domain_compute(),
         )
         self._copy_stencil = stencil_factory.from_origin_domain(
-            copy_defn,
+            copy,
             origin=grid_indexing.origin_full(),
             domain=grid_indexing.domain_full(),
         )

--- a/pyfv3/stencils/map_single.py
+++ b/pyfv3/stencils/map_single.py
@@ -5,7 +5,7 @@ from ndsl import QuantityFactory, StencilFactory, orchestrate
 from ndsl.constants import X_DIM, Y_DIM, Z_DIM
 from ndsl.dsl.gt4py import FORWARD, PARALLEL, computation, interval
 from ndsl.dsl.typing import Float, FloatField, FloatFieldIJ, IntFieldIJ  # noqa: F401
-from ndsl.stencils.basic_operations import copy_defn
+from ndsl.stencils.basic_operations import copy
 from pyfv3.stencils.remap_profile import RemapProfile
 
 
@@ -120,7 +120,7 @@ class MapSingle:
         self._lev = quantity_factory.zeros([X_DIM, Y_DIM], units="", dtype=int)
 
         self._copy_stencil = stencil_factory.from_dims_halo(
-            copy_defn,
+            copy,
             compute_dims=dims,
         )
 

--- a/pyfv3/wrappers/geos_wrapper.py
+++ b/pyfv3/wrappers/geos_wrapper.py
@@ -143,7 +143,10 @@ class GeosDycoreWrapper:
         )
 
         sizer = SubtileGridSizer.from_namelist(
-            self.namelist, partitioner.tile, self.communicator.tile.rank
+            self.namelist,
+            partitioner.tile,
+            self.communicator.tile.rank,
+            backend=backend,
         )
         quantity_factory = QuantityFactory(sizer=sizer, backend=backend)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ extras = [
   "pyfv3[ndsl]",
   "pyfv3[test]"
 ]
-ndsl = ["ndsl @ git+https://github.com/NOAA-GFDL/NDSL.git@develop"]
+ndsl = ["ndsl @ git+https://github.com/NOAA-GFDL/NDSL.git@2026.01.00"]
 test = [
   "coverage",
   "pytest",

--- a/tests/mpi/test_doubly_periodic.py
+++ b/tests/mpi/test_doubly_periodic.py
@@ -93,6 +93,7 @@ def test_dycore_runs_one_step() -> None:
         layout=config.layout,
         tile_partitioner=partitioner,
         tile_rank=communicator.rank,
+        backend=backend,
     )
     grid_indexing = GridIndexing.from_sizer_and_communicator(
         sizer=sizer, comm=communicator

--- a/tests/savepoint/translate/translate_init_case.py
+++ b/tests/savepoint/translate/translate_init_case.py
@@ -206,6 +206,7 @@ class TranslateInitCase(ParallelTranslateBaseSlicing):
             layout=self.config.layout,
             tile_partitioner=communicator.partitioner.tile,
             tile_rank=communicator.tile.rank,
+            backend=self.stencil_factory.backend,
         )
 
         quantity_factory = QuantityFactory(sizer, backend=self.stencil_factory.backend)


### PR DESCRIPTION
**Description**

This PR pins pyFV3 to NDSL version 2026.01.00 (as discussed in the last NASA/NOAA NDSL sync) and updates code to remove any deprecation warnings.

**How Has This Been Tested?**

All good as long as CI is still green.

**Checklist:**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas: N/A
- [ ] I have made corresponding changes to the documentation: N/A
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [ ] New check tests, if applicable, are included: N/A
- [ ] Targeted model if this changed was triggered by a model need/shortcoming: N/A
