### PR TITLE
ci: expose python version for translate tests

### DIFF
--- a/.github/workflows/translate.yaml
+++ b/.github/workflows/translate.yaml
@@ -12,6 +12,10 @@ on:
         type: string
         default: ''
         required: false
+      python_version:
+        type: string
+        default: ''
+        required: false
   pull_request: # ... a PR is opened / updated
   merge_group: # ... the PR is added to the merge queue
   push:
@@ -29,18 +33,19 @@ jobs:
     env:
       DATA_PATH: ./test_data/8.1.3/c12_6ranks_standard/dycore
       DATA_URL: "https://portal.nccs.nasa.gov/datashare/astg/smt/pace-regression-data/8.1.3_c12_6ranks_standard.tar.gz"
+      python_default: '3.11'
 
     steps:
-      - name: Setup Python 3.11
+      - name: 'Setup Python ${{ inputs.python_version && inputs.python_version || env.python_default }}'
         uses: actions/setup-python@v6
         with:
-          python-version: '3.11'
+          python-version: ${{ inputs.python_version && inputs.python_version || env.python_default }}
 
       - name: Install mpi (MPICH flavor)
         run: pip3 install mpich
 
       - name: External trigger Checkout pyFV3
-        if: ${{inputs.component_trigger}}
+        if: ${{inputs.component_name}}
         uses: actions/checkout@v6
         with:
           submodules: 'recursive'
@@ -54,14 +59,14 @@ jobs:
           path: pyFV3/${{inputs.component_name}}
 
       - name: External trigger install NDSL packages
-        if: ${{inputs.component_trigger}}
+        if: ${{inputs.component_name}}
         run: |
           cd ${GITHUB_WORKSPACE}/pyFV3
           cd NDSL && pip3 install . && cd ../
           pip3 install .[test]
 
       - name: Install pyFV3 packages
-        if: ${{ ! inputs.component_trigger }}
+        if: ${{ ! inputs.component_name }}
         run: |
           cd ${GITHUB_WORKSPACE}/pyFV3
           pip install .[ndsl,test]


### PR DESCRIPTION
**Description**

With NDSL supporting more than one version of python, we'd like to have the possibility to run pyFV3 translate tests with different versions of python. This PR adds an optional input variable to the `workflow_call` which allows calling workflows to specify the python version.

The PR also removes usage of the `component_trigger` input variable. The input is redundant with `component_name`, which is a non-empty string whenever `component_trigger` is true. I keep the input around until we update all calling workflows to not set it anymore.

**How Has This Been Tested?**

By running the current CI. The `workflow_call`  was tested with https://github.com/NOAA-GFDL/NDSL/pull/376 requesting to run PyFV3 tests with python 3.12 and with the default python version.

**Checklist:**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas: N/A
- [ ] I have made corresponding changes to the documentation: N/A
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules: N/A
- [ ] New check tests, if applicable, are included: N/A
- [ ] Targeted model if this changed was triggered by a model need/shortcoming: N/A
