### PR TITLE
fix: DyCore orchestration without timer allocation

### DIFF
--- a/pyfv3/stencils/fv_dynamics.py
+++ b/pyfv3/stencils/fv_dynamics.py
@@ -14,7 +14,7 @@ from ndsl.dsl.gt4py import PARALLEL, computation, interval
 from ndsl.dsl.typing import Float, FloatField
 from ndsl.grid import DampingCoefficients, GridData
 from ndsl.logging import ndsl_log
-from ndsl.performance import NullTimer, Timer
+from ndsl.performance import Timer
 from ndsl.stencils.basic_operations import copy
 from ndsl.stencils.c2l_ord import CubedToLatLon
 from ndsl.typing import Checkpointer, Communicator
@@ -55,9 +55,7 @@ def omega_from_w(delp: FloatField, delz: FloatField, w: FloatField, omega: Float
         omega = delp / delz * w
 
 
-def fvdyn_temporaries(
-    quantity_factory: QuantityFactory,
-) -> Mapping[str, Quantity]:
+def fvdyn_temporaries(quantity_factory: QuantityFactory) -> Mapping[str, Quantity]:
     tmps = {}
     for name in ["te_2d", "te0_2d", "wsd"]:
         quantity = quantity_factory.zeros(
@@ -77,10 +75,10 @@ def fvdyn_temporaries(
 
 
 @dace_inhibitor
-def log_on_rank_0(msg: str):
+def log_on_rank_0(message: str) -> None:
     """Print when rank is 0 - outside of DaCe critical path"""
     if not MPI or MPI.COMM_WORLD.Get_rank() == 0:
-        ndsl_log.info(msg)
+        ndsl_log.info(message)
 
 
 class DynamicalCore:
@@ -100,7 +98,7 @@ class DynamicalCore:
         state: DycoreState,
         timestep: timedelta,
         checkpointer: Checkpointer | None = None,
-    ):
+    ) -> None:
         """
         Args:
             comm: object for cubed sphere or tile inter-process communication
@@ -127,7 +125,7 @@ class DynamicalCore:
             obj=self,
             config=stencil_factory.config.dace_config,
             method_to_orchestrate="compute_preamble",
-            dace_compiletime_args=["state", "is_root_rank"],
+            dace_compiletime_args=["state"],
         )
 
         orchestrate(
@@ -181,7 +179,7 @@ class DynamicalCore:
         # have not implemented, so they are hard-coded here.
         self.call_checkpointer = checkpointer is not None
         if checkpointer is None:
-            self.checkpointer: Checkpointer = NullCheckpointer()
+            self.checkpointer = NullCheckpointer()
         else:
             self.checkpointer = checkpointer
         nested = False
@@ -336,7 +334,7 @@ class DynamicalCore:
     def _get_da_min(self) -> float:
         return self._da_min
 
-    def _checkpoint_fvdynamics(self, state: DycoreState, tag: str):
+    def _checkpoint_fvdynamics(self, state: DycoreState, tag: str) -> None:
         if self.call_checkpointer:
             self.checkpointer(
                 f"FVDynamics-{tag}",
@@ -355,10 +353,7 @@ class DynamicalCore:
                 qvapor=state.qvapor,
             )
 
-    def _checkpoint_remapping_in(
-        self,
-        state: DycoreState,
-    ):
+    def _checkpoint_remapping_in(self, state: DycoreState) -> None:
         if self.call_checkpointer:
             self.checkpointer(
                 "Remapping-In",
@@ -386,10 +381,7 @@ class DynamicalCore:
                 dp1=self._dp_initial,
             )
 
-    def _checkpoint_remapping_out(
-        self,
-        state: DycoreState,
-    ):
+    def _checkpoint_remapping_out(self, state: DycoreState) -> None:
         if self.call_checkpointer:
             self.checkpointer(
                 "Remapping-Out",
@@ -411,10 +403,7 @@ class DynamicalCore:
                 dp1=self._dp_initial,
             )
 
-    def _checkpoint_tracer_advection_in(
-        self,
-        state: DycoreState,
-    ):
+    def _checkpoint_tracer_advection_in(self, state: DycoreState) -> None:
         if self.call_checkpointer:
             self.checkpointer(
                 "Tracer2D1L-In",
@@ -425,10 +414,7 @@ class DynamicalCore:
                 cyd=state.cyd,
             )
 
-    def _checkpoint_tracer_advection_out(
-        self,
-        state: DycoreState,
-    ):
+    def _checkpoint_tracer_advection_out(self, state: DycoreState) -> None:
         if self.call_checkpointer:
             self.checkpointer(
                 "Tracer2D1L-Out",
@@ -439,11 +425,7 @@ class DynamicalCore:
                 cyd=state.cyd,
             )
 
-    def step_dynamics(
-        self,
-        state: DycoreState,
-        timer: Timer | None = None,
-    ):
+    def step_dynamics(self, state: DycoreState, timer: Timer) -> None:
         """
         Step the model state forward by one timestep.
 
@@ -451,16 +433,14 @@ class DynamicalCore:
             state: model prognostic state and inputs
             timer: keep time of model sections
         """
-        if timer is None:
-            timer = NullTimer()
-
         self._checkpoint_fvdynamics(state=state, tag="In")
         self._compute(state, timer)
         self._checkpoint_fvdynamics(state=state, tag="Out")
 
-    def compute_preamble(self, state: DycoreState, is_root_rank: bool):
+    def compute_preamble(self, state: DycoreState) -> None:
         if self.config.hydrostatic:
             raise NotImplementedError("Hydrostatic is not implemented")
+
         if __debug__:
             log_on_rank_0("FV Setup")
 
@@ -497,25 +477,23 @@ class DynamicalCore:
                 "Dynamical Core (fv_dynamics): Adiabatic with positive kord_tm"
                 " is not implemented."
             )
-        else:
-            if __debug__:
-                log_on_rank_0("Adjust pt")
-            self._pt_to_potential_density_pt(
-                state.pkz,
-                self._dp_initial,
-                state.q_con,
-                state.pt,
-            )
 
-    def __call__(self, *args, **kwargs):
-        return self.step_dynamics(*args, **kwargs)
+        if __debug__:
+            log_on_rank_0("Adjust pt")
 
-    def _compute(self, state: DycoreState, timer: Timer):
-        last_step = False
-        self.compute_preamble(
-            state,
-            is_root_rank=self.comm_rank == 0,
+        self._pt_to_potential_density_pt(
+            state.pkz,
+            self._dp_initial,
+            state.q_con,
+            state.pt,
         )
+
+    def __call__(self, *args, **kwargs) -> None:
+        self.step_dynamics(*args, **kwargs)
+
+    def _compute(self, state: DycoreState, timer: Timer) -> None:
+        last_step = False
+        self.compute_preamble(state)
 
         for k_split in dace_no_unroll(range(self._k_split)):
             n_map = k_split + 1
@@ -525,30 +503,34 @@ class DynamicalCore:
                 state.delp,
                 self._dp_initial,
             )
+
             if __debug__:
                 log_on_rank_0("DynCore")
+
             with timer.clock("DynCore"):
                 self.acoustic_dynamics(
                     state,
                     timestep=self._timestep / self._k_split,
                     n_map=n_map,
                 )
-            if self.config.z_tracer:
-                if __debug__:
-                    log_on_rank_0("TracerAdvection")
-                with timer.clock("TracerAdvection"):
-                    self._checkpoint_tracer_advection_in(state)
-                    self.tracer_advection(
-                        self.tracers,
-                        self._dp_initial,
-                        state.mfxd,
-                        state.mfyd,
-                        state.cxd,
-                        state.cyd,
-                    )
-                    self._checkpoint_tracer_advection_out(state)
-            else:
+
+            if not self.config.z_tracer:
                 raise NotImplementedError("z_tracer=False is not implemented")
+
+            if __debug__:
+                log_on_rank_0("TracerAdvection")
+
+            with timer.clock("TracerAdvection"):
+                self._checkpoint_tracer_advection_in(state)
+                self.tracer_advection(
+                    self.tracers,
+                    self._dp_initial,
+                    state.mfxd,
+                    state.mfyd,
+                    state.cxd,
+                    state.cyd,
+                )
+                self._checkpoint_tracer_advection_out(state)
 
             # 1 is shallow water model, don't need vertical remapping
             # 2 and 3 are also simple baroclinic models that don't need
@@ -567,6 +549,7 @@ class DynamicalCore:
                 # "surface" array
                 if __debug__:
                     log_on_rank_0("Remapping")
+
                 with timer.clock("Remapping"):
                     self._checkpoint_remapping_in(state)
 

--- a/pyfv3/stencils/fv_dynamics.py
+++ b/pyfv3/stencils/fv_dynamics.py
@@ -514,23 +514,23 @@ class DynamicalCore:
                     n_map=n_map,
                 )
 
-            if not self.config.z_tracer:
+            if self.config.z_tracer:
+                if __debug__:
+                    log_on_rank_0("TracerAdvection")
+
+                with timer.clock("TracerAdvection"):
+                    self._checkpoint_tracer_advection_in(state)
+                    self.tracer_advection(
+                        self.tracers,
+                        self._dp_initial,
+                        state.mfxd,
+                        state.mfyd,
+                        state.cxd,
+                        state.cyd,
+                    )
+                    self._checkpoint_tracer_advection_out(state)
+            else:
                 raise NotImplementedError("z_tracer=False is not implemented")
-
-            if __debug__:
-                log_on_rank_0("TracerAdvection")
-
-            with timer.clock("TracerAdvection"):
-                self._checkpoint_tracer_advection_in(state)
-                self.tracer_advection(
-                    self.tracers,
-                    self._dp_initial,
-                    state.mfxd,
-                    state.mfyd,
-                    state.cxd,
-                    state.cyd,
-                )
-                self._checkpoint_tracer_advection_out(state)
 
             # 1 is shallow water model, don't need vertical remapping
             # 2 and 3 are also simple baroclinic models that don't need

--- a/tests/mpi/test_doubly_periodic.py
+++ b/tests/mpi/test_doubly_periodic.py
@@ -16,6 +16,7 @@ from ndsl import (
     TilePartitioner,
 )
 from ndsl.grid import DampingCoefficients, GridData, MetricTerms
+from ndsl.performance import NullTimer
 from pyfv3 import DynamicalCore, DynamicalCoreConfig
 
 
@@ -134,4 +135,4 @@ def test_dycore_runs_one_step() -> None:
     )
 
     # run one step
-    dycore.step_dynamics(state)
+    dycore.step_dynamics(state, NullTimer())


### PR DESCRIPTION
**Description**

We can't do any allocation in DaCe code (for good reasons). This PR fixes fallout from https://github.com/NOAA-GFDL/PyFV3/pull/97 where we accidentally introduced the allocaiton of `NullTimer()` in DaCe-owned code. This PR moves the construction of the `Timer` up to calling code.

**How Has This Been Tested?**

To be tested locally by running the `FVDynamics` translate test in stencil mode and orchestrated. Both translate tests were still passing.

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas: N/A
- [ ] I have made corresponding changes to the documentation: N/A
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules: N/A
- [ ] New check tests, if applicable, are included: N/A
- [ ] Targeted model if this changed was triggered by a model need/shortcoming: N/A
