### PR TITLE
ci: restore to normal levels (after NDSL 2026.02.00 release)

### DIFF
--- a/.github/workflows/pace_tests.yaml
+++ b/.github/workflows/pace_tests.yaml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   pace_main_tests:
-    uses: romanc/pace/.github/workflows/main_unit_tests.yaml@noop
+    uses: NOAA-GFDL/pace/.github/workflows/main_unit_tests.yaml@develop
     with:
       component_trigger: true
       component_name: pyFV3

--- a/.github/workflows/pyshield_tests.yaml
+++ b/.github/workflows/pyshield_tests.yaml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   pyshield_translate_tests:
-    uses: romanc/PySHiELD/.github/workflows/translate.yaml@noop
+    uses: NOAA-GFDL/PySHiELD/.github/workflows/translate.yaml@develop
     with:
       component_trigger: true
       component_name: pyFV3


### PR DESCRIPTION
**Description**

The hooks for pySHiELD and pace were temporarily paused to propagate hard breaking changes from NDSL release 2026.02.00. This PR restores CI to normal levels.

**How Has This Been Tested?**

All good as long as CI is running again.

**Checklist:**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas: N/A
- [ ] I have made corresponding changes to the documentation: N/A
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules: N/A
- [ ] New check tests, if applicable, are included: N/A
- [ ] Targeted model if this changed was triggered by a model need/shortcoming: N/A
