### PR TITLE
fix: update backend names in translate test overrides

### DIFF
--- a/tests/savepoint/translate/overrides/standard.yaml
+++ b/tests/savepoint/translate/overrides/standard.yaml
@@ -27,7 +27,7 @@ MapN_Tracer_2d:
     near_zero: 1e-17
     ignore_near_zero_errors:
       - qtracers
-  - backend: numpy
+  - backend: st:numpy:cpu:IJK
     max_error: 9e-9 # 48_6ranks
 
 NH_P_Grad:
@@ -36,7 +36,7 @@ NH_P_Grad:
 Riem_Solver3:
   - backend: st:gt:gpu:KJI
     max_error: 5e-6
-  - backend: gt:cpu_ifirst
+  - backend: st:gt:cpu:KJI
     max_error: 5e-6
   - backend: st:dace:gpu:KJI
     max_error: 5e-6
@@ -109,7 +109,7 @@ Tracer2D1L:
   - backend: st:dace:gpu:KJI
     ignore_near_zero_errors:
       tracers: 1e-9
-  - backend: gt:cpu_ifirst
+  - backend: st:gt:cpu:KJI
     ignore_near_zero_errors:
       tracers: 1e-15
 


### PR DESCRIPTION
**Description**

With NDSL 2026.02.00 (see PR https://github.com/NOAA-GFDL/pyFV3/pull/120) we've changed the backend names as we've added a `Backend` class to hold the gt4py backend together with other information. This PR updates the standard overrides file with the last remaining "old" backend names. Discovered while trying to revive the pyFV3 hook in dace.

**How Has This Been Tested?**

Riemann solver is now not crashing anymore in the revived DaCe CI (on the schedule tree branch).

**Checklist:**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas: N/A
- [ ] I have made corresponding changes to the documentation: N/A
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [ ] New check tests, if applicable, are included: N/A
- [ ] Targeted model if this changed was triggered by a model need/shortcoming: N/A
