### PR TITLE
cleanup: remove unused checkpointer from remapping translate test

### DIFF
--- a/pyfv3/stencils/fv_dynamics.py
+++ b/pyfv3/stencils/fv_dynamics.py
@@ -307,7 +307,6 @@ class DynamicalCore:
             nq=NQ,
             pfull=self._pfull,
             tracers=self.tracers,
-            checkpointer=checkpointer,
         )
 
         full_xyz_spec = quantity_factory.get_quantity_halo_spec(

--- a/pyfv3/stencils/remapping.py
+++ b/pyfv3/stencils/remapping.py
@@ -20,7 +20,6 @@ from ndsl.dsl.gt4py import (
 )
 from ndsl.dsl.typing import Float, FloatField, FloatFieldIJ, FloatFieldK
 from ndsl.stencils.basic_operations import adjust_divide_stencil
-from ndsl.typing import Checkpointer
 from pyfv3._config import RemappingConfig
 from pyfv3.stencils import moist_cv
 from pyfv3.stencils.map_single import MapSingle
@@ -293,20 +292,16 @@ class LagrangianToEulerian:
         nq,
         pfull,
         tracers: dict[str, Quantity],
-        checkpointer: Checkpointer | None = None,
     ):
         orchestrate(
             obj=self,
             config=stencil_factory.config.dace_config,
             dace_compiletime_args=["tracers"],
         )
-        self._checkpointer = checkpointer
-        # this is only computed in init because Dace does not yet support
-        # this operation
-        self._call_checkpointer = checkpointer is not None
         grid_indexing = stencil_factory.grid_indexing
         if config.kord_tm >= 0:
             raise NotImplementedError("map ppm, untested mode where kord_tm >= 0")
+
         hydrostatic = config.hydrostatic
         if hydrostatic:
             raise NotImplementedError("Hydrostatic is not implemented")

--- a/tests/savepoint/translate/translate_remapping.py
+++ b/tests/savepoint/translate/translate_remapping.py
@@ -3,6 +3,7 @@ from f90nml import Namelist
 import ndsl.dsl.gt4py_utils as utils
 from ndsl import StencilFactory
 from ndsl.constants import K_DIM
+from ndsl.stencils.testing import Grid
 from pyfv3.stencils import LagrangianToEulerian
 from pyfv3.testing import TranslateDycoreFortranData2Py
 
@@ -10,7 +11,7 @@ from pyfv3.testing import TranslateDycoreFortranData2Py
 class TranslateRemapping(TranslateDycoreFortranData2Py):
     def __init__(
         self,
-        grid,
+        grid: Grid,
         namelist: Namelist,
         stencil_factory: StencilFactory,
     ):
@@ -108,7 +109,7 @@ class TranslateRemapping(TranslateDycoreFortranData2Py):
         inputs["last_step"] = bool(inputs["last_step"])
         pfull = self.grid.quantity_factory.zeros([K_DIM], units="Pa")
         pfull.data[:] = pfull.np.asarray(inputs.pop("pfull"))
-        l_to_e_obj = LagrangianToEulerian(
+        lagrangian_to_eulerian = LagrangianToEulerian(
             self.stencil_factory,
             quantity_factory=self.grid.quantity_factory,
             config=self.config.remapping,
@@ -117,6 +118,6 @@ class TranslateRemapping(TranslateDycoreFortranData2Py):
             pfull=pfull,
             tracers=inputs["tracers"],
         )
-        l_to_e_obj(**inputs)
+        lagrangian_to_eulerian(**inputs)
         inputs.pop("q_cld")
         return inputs


### PR DESCRIPTION
**Description**

Remapping doesn't have any `checkpointer` calls. No need to pass them down (in case they exist). 

**How Has This Been Tested?**

All good as long as translate tests are still running green.

**Checklist:**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas: N/A
- [ ] I have made corresponding changes to the documentation: N/A
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules: N/A
- [ ] New check tests, if applicable, are included: N/A
- [ ] Targeted model if this changed was triggered by a model need/shortcoming: N/A
