### PR TITLE
cleanup: remove unused things from `MapSingle`

### DIFF
--- a/pyfv3/stencils/map_single.py
+++ b/pyfv3/stencils/map_single.py
@@ -91,14 +91,11 @@ class MapSingle:
         kord: int,
         mode: int,
         dims: Sequence[str],
-    ):
+    ) -> None:
         orchestrate(
             obj=self,
             config=stencil_factory.config.dace_config,
         )
-
-        # TODO: consider refactoring to take in origin and domain
-        grid_indexing = stencil_factory.grid_indexing
 
         def make_quantity():
             return quantity_factory.zeros(
@@ -142,14 +139,6 @@ class MapSingle:
             compute_dims=dims,
         )
 
-    @property
-    def i_extent(self):
-        return self._extents[0]
-
-    @property
-    def j_extent(self):
-        return self._extents[1]
-
     def __call__(
         self,
         q1: FloatField,
@@ -157,7 +146,7 @@ class MapSingle:
         pe2: FloatField,
         qs: Optional["FloatFieldIJ"] = None,
         qmin: Float = 0.0,
-    ):
+    ) -> None:
         """
         Compute x-flux using the PPM method.
 
@@ -203,4 +192,3 @@ class MapSingle:
             self._dp1,
             self._lev,
         )
-        return q1


### PR DESCRIPTION
**Description**

Simple cleanups in `MapSingle` stencil. Looks like dead code to me. Could not find any trace of  `self._extents` in `MapSingle`. Also no usage of `grid_indexing`.

**How Has This Been Tested?**

All good as long as existing translate tests are still green.

**Checklist:**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas: N/A
- [ ] I have made corresponding changes to the documentation: N/A
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules: N/A
- [ ] New check tests, if applicable, are included: N/A
- [ ] Targeted model if this changed was triggered by a model need/shortcoming: N/A
