### PR TITLE
refactor: don't use `is True` / `is False` in pyFV3

### DIFF
--- a/pyfv3/initialization/analytic_init.py
+++ b/pyfv3/initialization/analytic_init.py
@@ -90,7 +90,7 @@ def init_analytic_state(
 
     if analytic_init_case == AnalyticCase.rossby:
         # TODO sw_dynamics check is awkward here, and should be moved.
-        if sw_dynamics is False:
+        if not sw_dynamics:
             raise ValueError(
                 "Rossby initialization requires dynamical core config "
                 "sw_dynamics flag to be True."

--- a/pyfv3/initialization/test_cases/initialize_tc.py
+++ b/pyfv3/initialization/test_cases/initialize_tc.py
@@ -406,7 +406,7 @@ def _initialize_wind_dgrid(
 def _interpolate_winds_dgrid_agrid(grid_data, ud, vd, tc_properties, shape):
     ua = np.zeros(shape)
     va = np.zeros(shape)
-    if tc_properties["vort"] is True:
+    if tc_properties["vort"]:
         ua[:, :-1, :] = (
             0.5
             * (

--- a/pyfv3/stencils/c_sw.py
+++ b/pyfv3/stencils/c_sw.py
@@ -1,6 +1,6 @@
 from ndsl import Quantity, QuantityFactory, StencilFactory, orchestrate
 from ndsl.constants import I_DIM, I_INTERFACE_DIM, J_DIM, J_INTERFACE_DIM, K_DIM
-from ndsl.dsl.gt4py import PARALLEL, computation, horizontal, interval, region  # noqa
+from ndsl.dsl.gt4py import PARALLEL, computation, horizontal, interval, region
 from ndsl.dsl.typing import Float, FloatField, FloatFieldIJ
 from ndsl.grid import GridData
 from ndsl.stencils import corners

--- a/pyfv3/stencils/delnflux.py
+++ b/pyfv3/stencils/delnflux.py
@@ -285,7 +285,7 @@ class DelnFlux:
             d2: A damped copy of the q field (in)
             mass: Mass to weight the diffusive flux by (in)
         """
-        if self._no_compute is True:
+        if self._no_compute:
             return fx, fy
 
         # [DaCe] Optional d2 gets reduced to subset 0 in DaCe parsing leading to a

--- a/pyfv3/stencils/map_single.py
+++ b/pyfv3/stencils/map_single.py
@@ -4,7 +4,7 @@ from typing import Optional
 from ndsl import QuantityFactory, StencilFactory, orchestrate
 from ndsl.constants import I_DIM, J_DIM, K_DIM
 from ndsl.dsl.gt4py import FORWARD, PARALLEL, computation, interval
-from ndsl.dsl.typing import Float, FloatField, FloatFieldIJ, IntFieldIJ  # noqa: F401
+from ndsl.dsl.typing import Float, FloatField, FloatFieldIJ, IntFieldIJ
 from ndsl.stencils.basic_operations import copy
 from pyfv3.stencils.remap_profile import RemapProfile
 

--- a/pyfv3/stencils/mapn_tracer.py
+++ b/pyfv3/stencils/mapn_tracer.py
@@ -78,5 +78,5 @@ class MapNTracer:
         for i, q in enumerate(utils.tracer_variables[0 : self._nq]):
             self._list_of_remap_objects[i](tracers[q], pe1, pe2, self._qs)
 
-        if self._fill_negative_tracers is True:
+        if self._fill_negative_tracers:
             self._fillz(dp2, tracers)


### PR DESCRIPTION
**Description**

Using `x is True` or `x is False` in python is tricky because it not only requires the truth value of `x` to match, but also checks the type to be a python bool (it actually does a memory address comparison with the `True` / `False` singletons). This check will not only fail for truthy/falsy values, but also fails for numpy booleans (because they aren't the python `True` / `False` singleton).

Note that - as far as I could see - all changed cases all work as intended. I'm suggesting to change them because we had an issue in pyMoist recently where the type of the compared value changed from the python literals `True` / `False` to a numpy bool during integration work.

**How Has This Been Tested?**

Covered by existing translate tests.

**Checklist:**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas: N/A
- [ ] I have made corresponding changes to the documentation: N/A
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules: N/A
- [ ] New check tests, if applicable, are included: N/A
- [ ] Targeted model if this changed was triggered by a model need/shortcoming: N/A
