### PR TITLE
[Update | Modernize] Move Remapping and sub-components to `NDSLRuntime`/`Locals`

### DIFF
--- a/pyfv3/stencils/fillz.py
+++ b/pyfv3/stencils/fillz.py
@@ -1,10 +1,11 @@
 import typing
 
-import ndsl.dsl.gt4py_utils as utils
-from ndsl import Quantity, QuantityFactory, StencilFactory, orchestrate
+import dace
+
+from ndsl import NDSLRuntime, Quantity, QuantityFactory, StencilFactory
 from ndsl.constants import I_DIM, J_DIM, K_DIM
 from ndsl.dsl.gt4py import BACKWARD, FORWARD, PARALLEL, computation, interval, max, min
-from ndsl.dsl.typing import Float, FloatField, FloatFieldIJ, IntFieldIJ
+from ndsl.dsl.typing import FloatField, FloatFieldIJ, Int, IntFieldIJ
 
 
 @typing.no_type_check
@@ -97,7 +98,7 @@ def fix_tracer(
             q = max(fac * dm / dp, 0.0)
 
 
-class FillNegativeTracerValues:
+class FillNegativeTracerValues(NDSLRuntime):
     """
     Fix tracer values to prevent negative masses.
 
@@ -111,11 +112,8 @@ class FillNegativeTracerValues:
         nq: int,
         tracers: dict[str, Quantity],
     ):
-        orchestrate(
-            obj=self,
-            config=stencil_factory.config.dace_config,
-            dace_compiletime_args=["tracers"],
-        )
+        super().__init__(stencil_factory)
+
         self._nq = int(nq)
         self._fix_tracer_stencil = stencil_factory.from_dims_halo(
             fix_tracer,
@@ -124,33 +122,24 @@ class FillNegativeTracerValues:
 
         # Setting initial value of upper_fix to zero is only needed for validation.
         # The values in the compute domain are set to zero in the stencil.
-        self._zfix = quantity_factory.zeros([I_DIM, J_DIM], units="unknown", dtype=int)
-        self._sum0 = quantity_factory.zeros(
-            [I_DIM, J_DIM],
-            units="unknown",
-            dtype=Float,
-        )
-        self._sum1 = quantity_factory.zeros(
-            [I_DIM, J_DIM],
-            units="unknown",
-            dtype=Float,
-        )
-
-        self._filtered_tracer_dict = {
-            name: tracers[name] for name in utils.tracer_variables[0 : self._nq]
-        }
+        self._zfix = self.make_local(quantity_factory, [I_DIM, J_DIM], dtype=Int)
+        self._zfix.data[:] = 0
+        self._sum0 = self.make_local(quantity_factory, [I_DIM, J_DIM])
+        self._sum0.data[:] = 0
+        self._sum1 = self.make_local(quantity_factory, [I_DIM, J_DIM])
+        self._sum1.data[:] = 0
 
     def __call__(
         self,
         dp2: FloatField,
-        tracers: dict[str, Quantity],
+        tracers: dace.compiletime, #dict[str, Quantity],
     ):
         """
         Args:
             dp2 (in): pressure thickness of atmospheric layer
             tracers (inout): tracers to fix negative masses in
         """
-        for tracer_name in self._filtered_tracer_dict.keys():
+        for tracer_name in tracers.keys():
             self._fix_tracer_stencil(
                 tracers[tracer_name],
                 dp2,

--- a/pyfv3/stencils/fillz.py
+++ b/pyfv3/stencils/fillz.py
@@ -132,7 +132,7 @@ class FillNegativeTracerValues(NDSLRuntime):
     def __call__(
         self,
         dp2: FloatField,
-        tracers: dace.compiletime, #dict[str, Quantity],
+        tracers: dace.compiletime,  # dict[str, Quantity],
     ):
         """
         Args:

--- a/pyfv3/stencils/fillz.py
+++ b/pyfv3/stencils/fillz.py
@@ -2,7 +2,7 @@ import typing
 
 import dace
 
-from ndsl import NDSLRuntime, Quantity, QuantityFactory, StencilFactory
+from ndsl import NDSLRuntime, QuantityFactory, StencilFactory
 from ndsl.constants import I_DIM, J_DIM, K_DIM
 from ndsl.dsl.gt4py import BACKWARD, FORWARD, PARALLEL, computation, interval, max, min
 from ndsl.dsl.typing import FloatField, FloatFieldIJ, Int, IntFieldIJ

--- a/pyfv3/stencils/fillz.py
+++ b/pyfv3/stencils/fillz.py
@@ -110,7 +110,6 @@ class FillNegativeTracerValues(NDSLRuntime):
         stencil_factory: StencilFactory,
         quantity_factory: QuantityFactory,
         nq: int,
-        tracers: dict[str, Quantity],
     ):
         super().__init__(stencil_factory)
 

--- a/pyfv3/stencils/fv_dynamics.py
+++ b/pyfv3/stencils/fv_dynamics.py
@@ -306,7 +306,6 @@ class DynamicalCore:
             area_64=grid_data.area_64,
             nq=NQ,
             pfull=self._pfull,
-            tracers=self.tracers,
         )
 
         full_xyz_spec = quantity_factory.get_quantity_halo_spec(

--- a/pyfv3/stencils/map_single.py
+++ b/pyfv3/stencils/map_single.py
@@ -1,10 +1,10 @@
 from collections.abc import Sequence
 from typing import Optional
 
-from ndsl import QuantityFactory, StencilFactory, orchestrate
+from ndsl import NDSLRuntime, QuantityFactory, StencilFactory
 from ndsl.constants import I_DIM, J_DIM, K_DIM
 from ndsl.dsl.gt4py import FORWARD, PARALLEL, computation, interval
-from ndsl.dsl.typing import Float, FloatField, FloatFieldIJ, IntFieldIJ
+from ndsl.dsl.typing import Float, FloatField, FloatFieldIJ, Int, IntFieldIJ
 from ndsl.stencils.basic_operations import copy
 from pyfv3.stencils.remap_profile import RemapProfile
 
@@ -79,7 +79,7 @@ def lagrangian_contributions(
         lev = lev - 1
 
 
-class MapSingle:
+class MapSingle(NDSLRuntime):
     """
     Fortran name is map_single, test classes are Map1_PPM_2d, Map_Scalar_2d
     """
@@ -92,10 +92,7 @@ class MapSingle:
         mode: int,
         dims: Sequence[str],
     ) -> None:
-        orchestrate(
-            obj=self,
-            config=stencil_factory.config.dace_config,
-        )
+        super().__init__(stencil_factory)
 
         def make_quantity():
             return quantity_factory.zeros(
@@ -104,17 +101,17 @@ class MapSingle:
                 dtype=Float,
             )
 
-        self._dp1 = make_quantity()
-        self._q4_1 = make_quantity()
-        self._q4_2 = make_quantity()
-        self._q4_3 = make_quantity()
-        self._q4_4 = make_quantity()
-        self._tmp_qs = quantity_factory.zeros(
-            [I_DIM, J_DIM],
-            units="unknown",
-            dtype=Float,
-        )
-        self._lev = quantity_factory.zeros([I_DIM, J_DIM], units="", dtype=int)
+        # All locals will be initialized in code before being read
+        self._dp1 = self.make_local(quantity_factory, [I_DIM, J_DIM, K_DIM])
+        self._q4_1 = self.make_local(quantity_factory, [I_DIM, J_DIM, K_DIM])
+        self._q4_2 = self.make_local(quantity_factory, [I_DIM, J_DIM, K_DIM])
+        self._q4_3 = self.make_local(quantity_factory, [I_DIM, J_DIM, K_DIM])
+        self._q4_4 = self.make_local(quantity_factory, [I_DIM, J_DIM, K_DIM])
+        self._lev = self.make_local(quantity_factory, [I_DIM, J_DIM], dtype=Int)
+
+        # If the boundary condition is not given as an input, we use use a zero-reference
+        self._zero_qs = self.make_local(quantity_factory, [I_DIM, J_DIM])
+        self._zero_qs.data[:] = 0
 
         self._copy_stencil = stencil_factory.from_dims_halo(
             copy,
@@ -144,7 +141,7 @@ class MapSingle:
         q1: FloatField,
         pe1: FloatField,
         pe2: FloatField,
-        qs: Optional["FloatFieldIJ"] = None,
+        qs: Optional[FloatFieldIJ] = None,
         qmin: Float = 0.0,
     ) -> None:
         """
@@ -163,7 +160,7 @@ class MapSingle:
 
         if qs is None:
             self._remap_profile(
-                self._tmp_qs,
+                self._zero_qs,
                 self._q4_1,
                 self._q4_2,
                 self._q4_3,

--- a/pyfv3/stencils/mapn_tracer.py
+++ b/pyfv3/stencils/mapn_tracer.py
@@ -1,12 +1,14 @@
+import dace
+
 import ndsl.dsl.gt4py_utils as utils
-from ndsl import Quantity, QuantityFactory, StencilFactory, orchestrate
+from ndsl import NDSLRuntime, QuantityFactory, StencilFactory
 from ndsl.constants import I_DIM, J_DIM, K_DIM
 from ndsl.dsl.typing import Float, FloatField
 from pyfv3.stencils.fillz import FillNegativeTracerValues
 from pyfv3.stencils.map_single import MapSingle
 
 
-class MapNTracer:
+class MapNTracer(NDSLRuntime):
     """
     Fortran code is mapn_tracer, test class is MapN_Tracer_2d
     """
@@ -18,13 +20,8 @@ class MapNTracer:
         kord: int,
         nq: int,
         fill: bool,
-        tracers: dict[str, Quantity],
     ):
-        orchestrate(
-            obj=self,
-            config=stencil_factory.config.dace_config,
-            dace_compiletime_args=["tracers"],
-        )
+        super().__init__(stencil_factory)
         self._nq = int(nq)
         self._qs = quantity_factory.zeros(
             [I_DIM, J_DIM, K_DIM],
@@ -32,19 +29,21 @@ class MapNTracer:
             dtype=Float,
         )
 
-        kord_tracer = [kord] * self._nq
-        kord_tracer[5] = 9  # qcld
+        self._map_single_parametrized_kord = MapSingle(
+            stencil_factory,
+            quantity_factory,
+            kord,
+            0,
+            dims=[I_DIM, J_DIM, K_DIM],
+        )
 
-        self._list_of_remap_objects = [
-            MapSingle(
-                stencil_factory,
-                quantity_factory,
-                kord_tracer[i],
-                0,
-                dims=[I_DIM, J_DIM, K_DIM],
-            )
-            for i in range(len(kord_tracer))
-        ]
+        self._map_single_kord9 = MapSingle(
+            stencil_factory,
+            quantity_factory,
+            9,
+            0,
+            dims=[I_DIM, J_DIM, K_DIM],
+        )
 
         if fill:
             self._fill_negative_tracers = True
@@ -52,17 +51,18 @@ class MapNTracer:
                 stencil_factory,
                 quantity_factory,
                 self._nq,
-                tracers,
             )
         else:
             self._fill_negative_tracers = False
+
+        self._index_graupel = utils.tracer_variables.index("qgraupel")
 
     def __call__(
         self,
         pe1: FloatField,
         pe2: FloatField,
         dp2: FloatField,
-        tracers: dict[str, Quantity],
+        tracers: dace.compiletime,  # dict[str, Quantity]
     ):
         """
         Remaps the tracer species onto the Eulerian grid
@@ -75,8 +75,11 @@ class MapNTracer:
             dp2 (in): Difference in pressure between Eulerian levels
             tracers (inout): tracers to be remapped
         """
-        for i, q in enumerate(utils.tracer_variables[0 : self._nq]):
-            self._list_of_remap_objects[i](tracers[q], pe1, pe2, self._qs)
+        for i, q in enumerate(tracers.keys()):
+            if i != self._index_graupel:
+                self._map_single_parametrized_kord(tracers[q], pe1, pe2, self._qs)
+
+        self._map_single_kord9(tracers["qgraupel"], pe1, pe2, self._qs)
 
         if self._fill_negative_tracers:
             self._fillz(dp2, tracers)

--- a/pyfv3/stencils/mapn_tracer.py
+++ b/pyfv3/stencils/mapn_tracer.py
@@ -3,7 +3,7 @@ import dace
 import ndsl.dsl.gt4py_utils as utils
 from ndsl import NDSLRuntime, QuantityFactory, StencilFactory
 from ndsl.constants import I_DIM, J_DIM, K_DIM
-from ndsl.dsl.typing import Float, FloatField
+from ndsl.dsl.typing import FloatField
 from pyfv3.stencils.fillz import FillNegativeTracerValues
 from pyfv3.stencils.map_single import MapSingle
 
@@ -23,11 +23,8 @@ class MapNTracer(NDSLRuntime):
     ):
         super().__init__(stencil_factory)
         self._nq = int(nq)
-        self._qs = quantity_factory.zeros(
-            [I_DIM, J_DIM, K_DIM],
-            units="unknown",
-            dtype=Float,
-        )
+        self._qs = self.make_local(quantity_factory, [I_DIM, J_DIM, K_DIM])
+        self._qs.data[:] = 0  # low boundary condition for RemapProfile
 
         self._map_single_parametrized_kord = MapSingle(
             stencil_factory,

--- a/pyfv3/stencils/remap_profile.py
+++ b/pyfv3/stencils/remap_profile.py
@@ -1,6 +1,6 @@
 from collections.abc import Sequence
 
-from ndsl import QuantityFactory, StencilFactory, orchestrate
+from ndsl import NDSLRuntime, QuantityFactory, StencilFactory
 from ndsl.constants import I_DIM, J_DIM, K_DIM, K_INTERFACE_DIM
 from ndsl.dsl.gt4py import BACKWARD, FORWARD, PARALLEL, computation
 from ndsl.dsl.gt4py import function as gtfunction
@@ -535,7 +535,7 @@ def set_interpolation_coefficients(
             a4_1, a4_2, a4_3, a4_4 = posdef_constraint_iv1(a4_1, a4_2, a4_3, a4_4)
 
 
-class RemapProfile:
+class RemapProfile(NDSLRuntime):
     """
     This corresponds to the cs_profile routine in FV3
     """
@@ -558,10 +558,7 @@ class RemapProfile:
             iv: ???
             dims: dimensions on which to operate on inputs
         """
-        orchestrate(
-            obj=self,
-            config=stencil_factory.config.dace_config,
-        )
+        super().__init__(stencil_factory)
 
         if kord > 10:
             raise NotImplementedError(
@@ -570,24 +567,19 @@ class RemapProfile:
 
         self._kord = kord
 
-        self._gam = quantity_factory.zeros(
-            [I_DIM, J_DIM, K_DIM],
-            units="unknown",
-            dtype=Float,
+        self._gam = self.make_local(quantity_factory, [I_DIM, J_DIM, K_DIM])
+        self._q = self.make_local(quantity_factory, [I_DIM, J_DIM, K_DIM])
+        self._q_bot = self.make_local(quantity_factory, [I_DIM, J_DIM, K_DIM])
+
+        self._extm = self.make_local(
+            quantity_factory, [I_DIM, J_DIM, K_DIM], dtype=bool
         )
-        self._q = quantity_factory.zeros(
-            [I_DIM, J_DIM, K_DIM],
-            units="unknown",
-            dtype=Float,
+        self._ext5 = self.make_local(
+            quantity_factory, [I_DIM, J_DIM, K_DIM], dtype=bool
         )
-        self._q_bot = quantity_factory.zeros(
-            [I_DIM, J_DIM, K_DIM],
-            units="unknown",
-            dtype=Float,
+        self._ext6 = self.make_local(
+            quantity_factory, [I_DIM, J_DIM, K_DIM], dtype=bool
         )
-        self._extm = quantity_factory.zeros([I_DIM, J_DIM, K_DIM], units="", dtype=bool)
-        self._ext5 = quantity_factory.zeros([I_DIM, J_DIM, K_DIM], units="", dtype=bool)
-        self._ext6 = quantity_factory.zeros([I_DIM, J_DIM, K_DIM], units="", dtype=bool)
 
         self._set_initial_values = stencil_factory.from_dims_halo(
             func=set_initial_vals,

--- a/pyfv3/stencils/remapping.py
+++ b/pyfv3/stencils/remapping.py
@@ -1,4 +1,6 @@
-from ndsl import Quantity, QuantityFactory, StencilFactory, orchestrate
+import dace
+
+from ndsl import NDSLRuntime, QuantityFactory, StencilFactory
 from ndsl.constants import (
     I_DIM,
     I_INTERFACE_DIM,
@@ -278,7 +280,7 @@ def copy_from_below(a: FloatField, b: FloatField):
         b = a[0, 0, -1]
 
 
-class LagrangianToEulerian:
+class LagrangianToEulerian(NDSLRuntime):
     """
     Fortran name is Lagrangian_to_Eulerian
     """
@@ -292,11 +294,8 @@ class LagrangianToEulerian:
         nq,
         pfull,
     ):
-        orchestrate(
-            obj=self,
-            config=stencil_factory.config.dace_config,
-            dace_compiletime_args=["tracers"],
-        )
+        super().__init__(stencil_factory)
+
         grid_indexing = stencil_factory.grid_indexing
         if config.kord_tm >= 0:
             raise NotImplementedError("map ppm, untested mode where kord_tm >= 0")
@@ -314,48 +313,57 @@ class LagrangianToEulerian:
             grid_indexing.domain[2] + 1,
         )
 
-        self._pe1 = quantity_factory.zeros(
+        self._pe1 = self.make_local(
+            quantity_factory,
             [I_DIM, J_DIM, K_INTERFACE_DIM],
             units="Pa",
             dtype=Float,
         )
-        self._pe2 = quantity_factory.zeros(
+        self._pe2 = self.make_local(
+            quantity_factory,
             [I_DIM, J_DIM, K_INTERFACE_DIM],
             units="Pa",
             dtype=Float,
         )
-        self._pe3 = quantity_factory.zeros(
+        self._pe3 = self.make_local(
+            quantity_factory,
             [I_DIM, J_DIM, K_INTERFACE_DIM],
             units="Pa",
             dtype=Float,
         )
-        self._dp2 = quantity_factory.zeros(
+        self._dp2 = self.make_local(
+            quantity_factory,
             [I_DIM, J_DIM, K_DIM],
             units="Pa",
             dtype=Float,
         )
-        self._pn2 = quantity_factory.zeros(
+        self._pn2 = self.make_local(
+            quantity_factory,
             [I_DIM, J_DIM, K_DIM],
             units="Pa",
             dtype=Float,
         )
-        self._pe0 = quantity_factory.zeros(
+        self._pe0 = self.make_local(
+            quantity_factory,
             [I_DIM, J_DIM, K_INTERFACE_DIM],
             units="Pa",
             dtype=Float,
         )
-        self._pe3 = quantity_factory.zeros(
+        self._pe3 = self.make_local(
+            quantity_factory,
             [I_DIM, J_DIM, K_INTERFACE_DIM],
             units="Pa",
             dtype=Float,
         )
 
-        self._gz = quantity_factory.zeros(
+        self._gz = self.make_local(
+            quantity_factory,
             [I_DIM, J_DIM, K_DIM],
             units="m^2 s^-2",
             dtype=Float,
         )
-        self._cvm = quantity_factory.zeros(
+        self._cvm = self.make_local(
+            quantity_factory,
             [I_DIM, J_DIM, K_DIM],
             units="unknown",
             dtype=Float,
@@ -509,7 +517,7 @@ class LagrangianToEulerian:
 
     def __call__(
         self,
-        tracers: dict[str, Quantity],
+        tracers: dace.compiletime,  # dict[str, Quantity],
         pt: FloatField,
         delp: FloatField,
         delz: FloatField,

--- a/pyfv3/stencils/remapping.py
+++ b/pyfv3/stencils/remapping.py
@@ -291,7 +291,6 @@ class LagrangianToEulerian:
         area_64,
         nq,
         pfull,
-        tracers: dict[str, Quantity],
     ):
         orchestrate(
             obj=self,
@@ -405,7 +404,6 @@ class LagrangianToEulerian:
             abs(config.kord_tr),
             nq,
             fill=config.fill,
-            tracers=tracers,
         )
 
         self._map_single_w = MapSingle(

--- a/tests/savepoint/translate/translate_remapping.py
+++ b/tests/savepoint/translate/translate_remapping.py
@@ -116,7 +116,6 @@ class TranslateRemapping(TranslateDycoreFortranData2Py):
             area_64=self.grid.area_64,
             nq=inputs.pop("nq"),
             pfull=pfull,
-            tracers=inputs["tracers"],
         )
         lagrangian_to_eulerian(**inputs)
         inputs.pop("q_cld")


### PR DESCRIPTION
**Description**

Recent changes to NDSL have brought tools to describe local memory and ease writing orchestration-ready code. We bring those tools to bear on the Remapping as a first step to a deeper refactor that will remove the need for tracers to be described as a dictionary.

The changes are mostly at init time, but two main changes are brought on the science side:

- `Fillz` was filtering the tracers to be filled. But checking the current code on NOAA and the GEOS-modified code yielded none of this pre-filtering. We removed the `self._filtered_tracer_dict` and are now filling all tracers the same (poke @oelbert  and the GFDL FV crew to check on my conclusions)

- `MapNTracers` was building a list of remapping objects to allow for maximum flexibility for `kord`. But the reality of the code shows that _all_ tracers but `graupel` are remapped with the same `kord`. We reflect that logic at runtime for ease of reading.

**Not addressed in this PR**

The tracers as a dict of Quantity is both unyielding for the users and orchestration alike. We flag them here as a `dace.compiletime` to allow the PR to merge. In a subsequent PR we will rely on the yet-to-be-merged `DataDimensionField` to convert this to a proper natively-orchestratable type which will know how to query it's tracer by name.

**How Has This Been Tested?**

CI covers a `numpy` version of the translate test. I ran orchestrated & stencil DaCe locally.

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] New check tests, if applicable, are included
- [ ] Targeted model if this changed was triggered by a model need/shortcoming
