### PR TITLE
refactor: read NDSL global precision

### DIFF
--- a/pyfv3/wrappers/geos_wrapper.py
+++ b/pyfv3/wrappers/geos_wrapper.py
@@ -27,8 +27,8 @@ from ndsl import (
     orchestrate,
 )
 from ndsl.comm.comm_abc import Comm
+from ndsl.dsl import NDSL_GLOBAL_PRECISION
 from ndsl.dsl.dace.build import set_distributed_caches
-from ndsl.dsl.typing import get_precision
 from ndsl.grid import DampingCoefficients, GridData, MetricTerms
 from ndsl.logging import ndsl_log
 from ndsl.optional_imports import cupy as cp
@@ -232,7 +232,7 @@ class GeosDycoreWrapper:
             f"             dt : {self.dycore_state.bdt}\n"
             f"         bridge : {self._fortran_mem_space} > {self._pace_mem_space}\n"
             f"        backend : {backend}\n"
-            f"          float : {get_precision()}bit"
+            f"          float : {NDSL_GLOBAL_PRECISION}bit"
             f"  orchestration : {self._is_orchestrated}\n"
             f"          sizer : {sizer.nx}x{sizer.ny}x{sizer.nz}"
             f"(halo: {sizer.n_halo})\n"


### PR DESCRIPTION
**Description**

This small PR refactors the way how pyFV3 reads the global precision from NDSL. The function `get_precision()` from `ndsl.dsl.typing` will be deprecated, see https://github.com/NOAA-GFDL/NDSL/pull/433. Instead, this PR reads `NDSL_GLOBAL_PRECISION` directly from `ndsl.dsl`.

**How Has This Been Tested?**

All good as long as CI is still green.

**Checklist:**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas: N/A
- [ ] I have made corresponding changes to the documentation: N/A
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [ ] New check tests, if applicable, are included: N/A
- [ ] Targeted model if this changed was triggered by a model need/shortcoming: N/A
