### PR TITLE
[CI] Re-hook all `ci` to `develop`

### DIFF
--- a/.github/workflows/pace_tests.yaml
+++ b/.github/workflows/pace_tests.yaml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   pace_main_tests:
-    uses: FlorianDeconinck/pace/.github/workflows/main_unit_tests.yaml@feature/data_dimensions_field
+    uses: NOAA-GFDL/pace/.github/workflows/main_unit_tests.yaml@develop
     with:
       component_trigger: true
       component_name: pyFV3

--- a/.github/workflows/pyshield_tests.yaml
+++ b/.github/workflows/pyshield_tests.yaml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   pyshield_translate_tests:
-    uses: FlorianDeconinck/PySHiELD/.github/workflows/translate.yaml@update/ndsl_without_tracers_list
+    uses: NOAA-GFDL/PySHiELD/.github/workflows/translate.yaml@develop
     with:
       component_trigger: true
       component_name: pyFV3

--- a/.github/workflows/translate.yaml
+++ b/.github/workflows/translate.yaml
@@ -49,9 +49,8 @@ jobs:
         uses: actions/checkout@v6
         with:
           submodules: 'recursive'
-          repository: FlorianDeconinck/pyFV3
+          repository: NOAA-GFDL/pyFV3
           path: pyFV3
-          ref: feature/tracers_to_ddims_field
 
       - name: Checkout hash that triggered CI
         uses: actions/checkout@v6

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ extras = [
   "pyfv3[ndsl]",
   "pyfv3[test]"
 ]
-ndsl = ["ndsl @ git+https://github.com/FlorianDeconinck/NDSL.git@feature/data_dimnesion_fields"]
+ndsl = ["ndsl @ git+https://github.com/NOAA-GFDL/NDSL.git@develop"]
 test = [
   "coverage",
   "pytest",


### PR DESCRIPTION
Following https://github.com/NOAA-GFDL/NDSL/pull/416 we hook again upstream and dowstream repository to the `develop` branches.
