### PR TITLE
WIP: running translate test of `D_SW` in `st:dace:cpu:KJI` 

### DIFF
--- a/.github/workflows/scripts/convert_xppm_yppm.sh
+++ b/.github/workflows/scripts/convert_xppm_yppm.sh
@@ -53,6 +53,7 @@ sed -i 's/XPiecewise/YPiecewise/g' pyfv3/stencils/yppm.py
 sed -i 's/X Piecewise/Y Piecewise/g' pyfv3/stencils/yppm.py
 sed -i 's/xppm/yppm/g' pyfv3/stencils/yppm.py
 sed -i 's/u\*/v\*/g' pyfv3/stencils/yppm.py
+sed -i 's/svbgrid/subgrid/g' pyfv3/stencils/yppm.py
 
 sed -i 's/j_start - 1 : j_start + 1, j_start/i_start, j_start - 1 : j_start + 1/g' pyfv3/stencils/ytp_v.py
 sed -i 's/j_start - 1 : j_start + 1, j_end + 1/i_end + 1, j_start - 1 : j_start + 1/g' pyfv3/stencils/ytp_v.py

--- a/pyfv3/stencils/yppm.py
+++ b/pyfv3/stencils/yppm.py
@@ -385,7 +385,7 @@ class YPiecewiseParabolic(NDSLRuntime):
         """
         Determine the mean value per area of q_in to be advected along y-interfaces.
 
-        This is done by integrating a piecewise-parabolic svbgrid reconstruction
+        This is done by integrating a piecewise-parabolic subgrid reconstruction
         of q_in along the y-direction over the segment of gridcell which
         will be advected.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ extras = [
   "pyfv3[ndsl]",
   "pyfv3[test]"
 ]
-ndsl = ["ndsl @ git+https://github.com/FlorianDeconinck/NDSL.git@feature/data_dimnesion_fields"]
+ndsl = ["ndsl @ git+https://github.com/romanc/NDSL.git@romanc/translate-tests-without-interface-padding"]
 test = [
   "coverage",
   "pytest",

--- a/tests/savepoint/translate/translate_d_sw.py
+++ b/tests/savepoint/translate/translate_d_sw.py
@@ -3,7 +3,7 @@ from gt4py.cartesian.gtscript import PARALLEL, computation, interval
 
 import pyfv3.stencils.d_sw as d_sw
 from ndsl import StencilFactory
-from ndsl.constants import I_DIM, J_DIM, K_INTERFACE_DIM
+from ndsl.constants import I_DIM, J_DIM, K_DIM
 from ndsl.dsl.typing import Float, FloatField, FloatFieldIJ
 from pyfv3.testing import TranslateDycoreFortranData2Py
 
@@ -22,7 +22,7 @@ class TranslateD_SW(TranslateDycoreFortranData2Py):
             config=self.config.acoustic_dynamics.d_grid_shallow_water,
             quantity_factory=self.grid.quantity_factory,
         )
-        self.compute_func = d_sw.DGridShallowWaterLagrangianDynamics(  # type: ignore
+        self.compute_func = d_sw.DGridShallowWaterLagrangianDynamics(
             stencil_factory=self.stencil_factory,
             quantity_factory=self.grid.quantity_factory,
             grid_data=self.grid.grid_data,
@@ -67,25 +67,28 @@ class TranslateD_SW(TranslateDycoreFortranData2Py):
 
     def compute(self, inputs):
         self.make_storage_data_input_vars(inputs)
+
         # Convert relevant inputs to quantities:
         delp = self.grid.quantity_factory.zeros(
-            dims=[I_DIM, J_DIM, K_INTERFACE_DIM], units="unknown", dtype=Float
+            dims=[I_DIM, J_DIM, K_DIM], units="unknown", dtype=Float
         )
         delp.data[:] = delp.np.asarray(inputs.pop("delp"))
         inputs["delp"] = delp
+
         w = self.grid.quantity_factory.zeros(
-            dims=[I_DIM, J_DIM, K_INTERFACE_DIM], units="unknown", dtype=Float
+            dims=[I_DIM, J_DIM, K_DIM], units="unknown", dtype=Float
         )
         w.data[:] = delp.np.asarray(inputs.pop("w"))
         inputs["w"] = w
+
         q_con = self.grid.quantity_factory.zeros(
-            dims=[I_DIM, J_DIM, K_INTERFACE_DIM], units="unknown", dtype=Float
+            dims=[I_DIM, J_DIM, K_DIM], units="unknown", dtype=Float
         )
         q_con.data[:] = delp.np.asarray(inputs.pop("q_con"))
         inputs["q_con"] = q_con
 
         pt = self.grid.quantity_factory.zeros(
-            dims=[I_DIM, J_DIM, K_INTERFACE_DIM], units="unknown", dtype=Float
+            dims=[I_DIM, J_DIM, K_DIM], units="unknown", dtype=Float
         )
         pt.data[:] = delp.np.asarray(inputs.pop("pt"))
         inputs["pt"] = pt


### PR DESCRIPTION
**Description**

This PR started from running the translate test of `D_SW` in `st:dace:cpu:KJI`, i.e. without the padding of non-interface dimensions when allocating Quantities.

The PR builds on top of [`develop__GEOSv_11_4_2`](https://github.com/NOAA-GFDL/pyFV3/pull/63) and relies on [NDSL changes](https://github.com/romanc/NDSL/tree/romanc/translate-tests-without-interface-padding) to be able to run. Doing so, showcased multiple places where size mismatches occur.

In the current configuration, we fail in gt4py when calling the stencil `compute_y_flux` as part of `FiniteVolumeTransport` because the stencil would write out of bounds:

```none
E           ValueError: Compute domain too large for stencil compute_y_flux: 
E             Stencil domain is (31, 25, 73) but field indexation leads to read outside of bounds.
E             Check region/horizontal offsets or interval/vertical offsets, or stencil domain.
E             Offending fields (name, size with offset removed): [('q', Shape((30, 25, 72)))]
```

**How Has This Been Tested?**

Running translate test of D_SW.

**Checklist:**

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] New check tests, if applicable, are included
- [ ] Targeted model if this changed was triggered by a model need/shortcoming
