### PR TITLE
ci: don't pull inexistent submodules on checkout

### DIFF
--- a/.github/workflows/translate.yaml
+++ b/.github/workflows/translate.yaml
@@ -48,7 +48,6 @@ jobs:
         if: ${{inputs.component_name}}
         uses: actions/checkout@v7
         with:
-          submodules: 'recursive'
           repository: NOAA-GFDL/pyFV3
           path: pyFV3
 

--- a/.github/workflows/unit_tests.yaml
+++ b/.github/workflows/unit_tests.yaml
@@ -20,8 +20,6 @@ jobs:
 
       - name: Checkout repository
         uses: actions/checkout@v7
-        with:
-          submodules: 'recursive'
 
       - name: Setup Python 3.12
         uses: actions/setup-python@v6


### PR DESCRIPTION
**Description**

pyFV3 has no submodules. There's thus no need to configure checkout to pull submodules.

**How Has This Been Tested?**

All good as long as CI is still green.

**Checklist:**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas: N/A
- [ ] I have made corresponding changes to the documentation: N/A
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules: N/A
- [ ] New check tests, if applicable, are included: N/A
- [ ] Targeted model if this changed was triggered by a model need/shortcoming: N/A
