### PR TITLE
refactor: use 2d temporaries in FillNegativeTracerValues

### DIFF
--- a/pyfv3/stencils/fillz.py
+++ b/pyfv3/stencils/fillz.py
@@ -1,34 +1,24 @@
 import typing
 
-from ndsl import NDSLRuntime, QuantityFactory, StencilFactory
+from ndsl import NDSLRuntime, StencilFactory
 from ndsl.constants import I_DIM, J_DIM, K_DIM
 from ndsl.dsl.gt4py import BACKWARD, FORWARD, PARALLEL, computation, interval, max, min
-from ndsl.dsl.typing import FloatField, FloatFieldIJ, Int, IntFieldIJ
+from ndsl.dsl.typing import FloatField, FloatFieldIJ, IntFieldIJ
 from pyfv3.tracers import FVTracers
 
 
 @typing.no_type_check
-def fix_tracer(
-    q: FloatField,
-    dp: FloatField,
-    zfix: IntFieldIJ,
-    sum0: FloatFieldIJ,
-    sum1: FloatFieldIJ,
-):
+def fix_tracer(q: FloatField, dp: FloatField) -> None:
     """
     Args:
-        q (inout):
-        dp (in):
-        zfix (out):
-        sum0 (out):
-        sum1 (out):
+        q (inout): tracer to fix negative masses in
+        dp (in): pressure thickness of atmospheric layer
     """
-    # TODO: can we make everything except q and dp temporaries?
     # Reset 2D fields
     with computation(FORWARD), interval(0, 1):
-        zfix = 0
-        sum0 = 0.0
-        sum1 = 0.0
+        zfix: IntFieldIJ = 0
+        sum0: FloatFieldIJ = 0.0
+        sum1: FloatFieldIJ = 0.0
     # Reset 3D fields
     with computation(PARALLEL), interval(...):
         lower_fix = 0.0
@@ -107,9 +97,8 @@ class FillNegativeTracerValues(NDSLRuntime):
     def __init__(
         self,
         stencil_factory: StencilFactory,
-        quantity_factory: QuantityFactory,
         nq: int,
-    ):
+    ) -> None:
         super().__init__(stencil_factory)
 
         self._nq = int(nq)
@@ -118,30 +107,18 @@ class FillNegativeTracerValues(NDSLRuntime):
             compute_dims=[I_DIM, J_DIM, K_DIM],
         )
 
-        # Setting initial value of upper_fix to zero is only needed for validation.
-        # The values in the compute domain are set to zero in the stencil.
-        self._zfix = self.make_local(quantity_factory, [I_DIM, J_DIM], dtype=Int)
-        self._zfix[:] = 0
-        self._sum0 = self.make_local(quantity_factory, [I_DIM, J_DIM])
-        self._sum0[:] = 0
-        self._sum1 = self.make_local(quantity_factory, [I_DIM, J_DIM])
-        self._sum1[:] = 0
-
     def __call__(
         self,
         dp2: FloatField,
         tracers: FVTracers,
-    ):
+    ) -> None:
         """
         Args:
-            dp2 (in): pressure thickness of atmospheric layer
             tracers (inout): tracers to fix negative masses in
+            dp2 (in): pressure thickness of atmospheric layer
         """
         for i_tracer in range(0, self._nq):
             self._fix_tracer_stencil(
                 tracers[:, :, :, i_tracer],
                 dp2,
-                self._zfix,
-                self._sum0,
-                self._sum1,
             )

--- a/pyfv3/stencils/mapn_tracer.py
+++ b/pyfv3/stencils/mapn_tracer.py
@@ -40,9 +40,7 @@ class MapNTracer(NDSLRuntime):
 
         if fill:
             self._fill_negative_tracers = True
-            self._fillz = FillNegativeTracerValues(
-                stencil_factory, quantity_factory, self._nq
-            )
+            self._fillz = FillNegativeTracerValues(stencil_factory, self._nq)
         else:
             self._fill_negative_tracers = False
 

--- a/tests/savepoint/translate/translate_fillz.py
+++ b/tests/savepoint/translate/translate_fillz.py
@@ -73,7 +73,7 @@ class TranslateFillz(TranslateDycoreFortranData2Py):
         )
         for i_tracer, value in tuple(inputs["tracers"].items()):
             if hasattr(value, "shape") and len(value.shape) > 1 and value.shape[1] == 1:
-                quantity_tracers.data[:, :, :, i_tracer] = self.make_storage_data(
+                quantity_tracers[:, :, :, i_tracer] = self.make_storage_data(
                     pad_field_in_j(
                         value, self.grid.njd, backend=self.stencil_factory.backend
                     )
@@ -82,7 +82,6 @@ class TranslateFillz(TranslateDycoreFortranData2Py):
 
         run_fillz = fillz.FillNegativeTracerValues(
             self.stencil_factory,
-            self.grid.quantity_factory,
             inputs.pop("nq"),
         )
         run_fillz(**inputs)
@@ -96,7 +95,7 @@ class TranslateFillz(TranslateDycoreFortranData2Py):
             offset = -1
 
         out = {
-            "q2tracers": quantity_tracers.data[
+            "q2tracers": quantity_tracers[
                 ds["istart"] : ds["iend"] + 1, ds["jstart"], : ds["kend"] + 1, :offset
             ]
         }


### PR DESCRIPTION
**Description**

This PR refactors the `fix_tracers()` stencil to make use of 2d temporaries, which allows to remove all Locals in
`FillNegativeTracerValues`. This - in turn - removes the need for a `QuantityFactory`, which spreads to `map_ntracer` and the translate test. The resulting stencil is simpler (no need to pass 2d temporaries in) and allows us to remove a long-standing todo.

Also updates the translate test to avoid usage of `.data`, which is currently deprecated.

This refactor was highlighted by (and is blocking) PR https://github.com/NOAA-GFDL/NDSL/pull/509, which flagged the initialization `zfix`, `sum0`, and `sum1` in the `__init__()` function. This was never a problem because the stencil anyway always resets the 2d temporaries to zero first.

**How Has This Been Tested?**

Running translate test of `fillz` locally with backends `st:python:cpu:IJK`, `st:numpy:cpu:IJK`, `st:dace:cpu:IJK`, and `orch:dace:cpu:IJK`.

**Checklist:**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas: N/A
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules: N/A
- [ ] New check tests, if applicable, are included: N/A
- [ ] Targeted model if this changed was triggered by a model need/shortcoming: N/A
