### PR TITLE
refactor: avoid `quanitity.data` in favor direct setter/getter

### DIFF
--- a/examples/notebook/test_aq_init.ipynb
+++ b/examples/notebook/test_aq_init.ipynb
@@ -337,7 +337,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": null,
    "id": "ac2b3682-65b2-48b0-a6a9-a83da0713997",
    "metadata": {},
    "outputs": [
@@ -370,8 +370,8 @@
     }
    ],
    "source": [
-    "print(state.delp.data.shape)\n",
-    "plt.imshow(state.delz.data[:, :, -2])\n",
+    "print(state.delp.shape)\n",
+    "plt.imshow(state.delz[:, :, -2])\n",
     "plt.colorbar()"
    ]
   },

--- a/examples/notebook/test_functionality.ipynb
+++ b/examples/notebook/test_functionality.ipynb
@@ -195,7 +195,7 @@
             "source": [
                 "if mpi_rank in [0, 3]:\n",
                 "    copy_stencil(from_field, to_field)\n",
-                "    print (to_field.data[:,:,0])"
+                "    print (to_field[:,:,0])"
             ]
         },
         {
@@ -217,7 +217,7 @@
                 "# req.wait()\n",
                 "cs_communicator.halo_update(to_field, nhalo)\n",
                 "if mpi_rank == 1:\n",
-                "    print (to_field.data[:,:,0])"
+                "    print (to_field[:,:,0])"
             ]
         },
         {

--- a/pyfv3/dycore_state.py
+++ b/pyfv3/dycore_state.py
@@ -319,7 +319,7 @@ class DycoreState:
                     _field.metadata["dims"],
                     _field.metadata["units"],
                     dtype=Float,
-                ).data
+                )[:]
         return cls.init_from_storages(
             storages=initial_storages,
             sizer=quantity_factory.sizer,
@@ -454,7 +454,7 @@ class DycoreState:
                     f"{dim_name}_{name}" for dim_name in field_info.metadata["dims"]
                 ]
                 data_vars[name] = xr.DataArray(
-                    gt_utils.asarray(getattr(self, name).data),
+                    gt_utils.asarray(getattr(self, name)[:]),
                     dims=dims,
                     attrs={
                         "long_name": field_info.metadata["name"],

--- a/pyfv3/initialization/test_cases/initialize_aquaplanet.py
+++ b/pyfv3/initialization/test_cases/initialize_aquaplanet.py
@@ -21,8 +21,8 @@ def init_aquaplanet_state(
     comm: CubedSphereCommunicator,
 ) -> DycoreState:
     sample_quantity = grid_data.lat
-    field_shape = (*sample_quantity.field.shape[0:2], grid_data.ak.data.shape[0])
-    data_shape = (*sample_quantity.data.shape[0:2], grid_data.ak.data.shape[0])
+    field_shape = (*sample_quantity.field.shape[0:2], grid_data.ak.shape[0])
+    data_shape = (*sample_quantity.shape[0:2], grid_data.ak.shape[0])
     nx, ny, npz = init_utils.local_compute_size(data_shape)
     nz = npz - 1
     numpy_state = init_utils.empty_numpy_dycore_state(data_shape)
@@ -67,8 +67,8 @@ def init_aquaplanet_state(
         peln=numpy_state.peln[slice_3d],
         pk=numpy_state.pk[slice_3d],
         pkz=numpy_state.pkz[slice_3d],
-        ak=utils.asarray(grid_data.ak.data),
-        bk=utils.asarray(grid_data.bk.data),
+        ak=utils.asarray(grid_data.ak[:]),
+        bk=utils.asarray(grid_data.bk[:]),
         ptop=grid_data.ptop,
     )
     alpha = 0
@@ -99,11 +99,11 @@ def init_aquaplanet_state(
         numpy_state.phis[:],
         1.0e5,
         numpy_state.delp[:],
-        grid_data.ak.data[:],
-        grid_data.bk.data[:],
+        grid_data.ak[:],
+        grid_data.bk[:],
         numpy_state.pt[:],
         numpy_state.delz[:],
-        grid_data.area.data[:],
+        grid_data.area[:],
         NHALO,
         False,
         hydrostatic,

--- a/pyfv3/initialization/test_cases/initialize_baroclinic.py
+++ b/pyfv3/initialization/test_cases/initialize_baroclinic.py
@@ -285,7 +285,7 @@ def init_baroclinic_state(
     Williamson baroclinic test case perturbation applied to the cubed sphere grid.
     """
     sample_quantity = grid_data.lat
-    shape = (*sample_quantity.data.shape[0:2], grid_data.ak.data.shape[0])
+    shape = (*sample_quantity.shape[0:2], grid_data.ak.shape[0])
     nx, ny, nz = init_utils.local_compute_size(shape)
     numpy_state = init_utils.empty_numpy_dycore_state(shape)
     # Initializing to values the Fortran does for easy comparison
@@ -320,8 +320,8 @@ def init_baroclinic_state(
         peln=numpy_state.peln[slice_3d],
         pk=numpy_state.pk[slice_3d],
         pkz=numpy_state.pkz[slice_3d],
-        ak=utils.asarray(grid_data.ak.data),
-        bk=utils.asarray(grid_data.bk.data),
+        ak=utils.asarray(grid_data.ak[:]),
+        bk=utils.asarray(grid_data.bk[:]),
         ptop=grid_data.ptop,
     )
 
@@ -337,14 +337,14 @@ def init_baroclinic_state(
         phis=numpy_state.phis[slice_2d_buffer],
         delz=numpy_state.delz[slice_3d_buffer],
         w=numpy_state.w[slice_3d_buffer],
-        lon=utils.asarray(grid_data.lon.data[slice_2d_buffer]),
-        lat=utils.asarray(grid_data.lat.data[slice_2d_buffer]),
-        lon_agrid=utils.asarray(grid_data.lon_agrid.data[slice_2d_buffer]),
-        lat_agrid=utils.asarray(grid_data.lat_agrid.data[slice_2d_buffer]),
-        ee1=utils.asarray(grid_data.ee1.data[slice_3d_buffer]),
-        ee2=utils.asarray(grid_data.ee2.data[slice_3d_buffer]),
-        es1=utils.asarray(grid_data.es1.data[slice_3d_buffer]),
-        ew2=utils.asarray(grid_data.ew2.data[slice_3d_buffer]),
+        lon=utils.asarray(grid_data.lon[slice_2d_buffer]),
+        lat=utils.asarray(grid_data.lat[slice_2d_buffer]),
+        lon_agrid=utils.asarray(grid_data.lon_agrid[slice_2d_buffer]),
+        lat_agrid=utils.asarray(grid_data.lat_agrid[slice_2d_buffer]),
+        ee1=utils.asarray(grid_data.ee1[slice_3d_buffer]),
+        ee2=utils.asarray(grid_data.ee2[slice_3d_buffer]),
+        es1=utils.asarray(grid_data.es1[slice_3d_buffer]),
+        ew2=utils.asarray(grid_data.ew2[slice_3d_buffer]),
         ptop=grid_data.ptop,
         adiabatic=adiabatic,
         hydrostatic=hydrostatic,

--- a/pyfv3/initialization/test_cases/initialize_rossby.py
+++ b/pyfv3/initialization/test_cases/initialize_rossby.py
@@ -83,8 +83,8 @@ def _calc_rossby_delp(grid_data: GridData):
     Returns
         np.ndarray representing delp values
     """
-    agd0 = grid_data.lon_agrid.data[:]
-    agd1 = grid_data.lat_agrid.data[:]
+    agd0 = grid_data.lon_agrid[:]
+    agd1 = grid_data.lat_agrid[:]
 
     a = Float(0.5) * OMG * (2 * constants.OMEGA + OMG) * (np.cos(agd1) ** 2) + Float(
         0.25
@@ -134,7 +134,7 @@ def _init_for_rossby(numpy_state: SimpleNamespace, grid_data: GridData, shape):
 
     grid = np.transpose(
         np.stack(  # TODO: Refactor to non-protected _horizontal_data
-            [grid_data._horizontal_data.lon.data, grid_data._horizontal_data.lat.data]
+            [grid_data._horizontal_data.lon[:], grid_data._horizontal_data.lat[:]]
         ),
         [1, 2, 0],
     )
@@ -193,7 +193,7 @@ def init_rossby_state(
     #       May require a change to pass a config here in order to check.
 
     sample_quantity = grid_data.lat
-    shape = (*sample_quantity.data.shape[0:2], grid_data.ak.data.shape[0])
+    shape = (*sample_quantity.shape[0:2], grid_data.ak.shape[0])
     numpy_state = init_utils.empty_numpy_dycore_state(shape)
 
     _preinit_for_all_sw(numpy_state, shape)

--- a/pyfv3/initialization/test_cases/initialize_tc.py
+++ b/pyfv3/initialization/test_cases/initialize_tc.py
@@ -287,8 +287,8 @@ def _initialize_vortex_ps_phis(grid_data, shape, tc_properties, calc):
     grid = np.transpose(
         np.stack(
             [
-                grid_data._horizontal_data.lon_agrid.data,
-                grid_data._horizontal_data.lat_agrid.data,
+                grid_data._horizontal_data.lon_agrid[:],
+                grid_data._horizontal_data.lat_agrid[:],
             ]
         ),
         [1, 2, 0],
@@ -297,7 +297,7 @@ def _initialize_vortex_ps_phis(grid_data, shape, tc_properties, calc):
 
     grid = np.transpose(
         np.stack(
-            [grid_data._horizontal_data.lon.data, grid_data._horizontal_data.lat.data]
+            [grid_data._horizontal_data.lon[:], grid_data._horizontal_data.lat[:]]
         ),
         [1, 2, 0],
     )
@@ -336,8 +336,8 @@ def _initialize_qvapor_temperature(grid_data, pe, ps, tc_properties, calc, shape
     p2 = np.transpose(
         np.stack(
             [
-                grid_data._horizontal_data.lon_agrid.data,
-                grid_data._horizontal_data.lat_agrid.data,
+                grid_data._horizontal_data.lon_agrid[:],
+                grid_data._horizontal_data.lat_agrid[:],
             ]
         ),
         [1, 2, 0],
@@ -362,7 +362,7 @@ def _initialize_wind_dgrid(
 
     grid = np.transpose(
         np.stack(
-            [grid_data._horizontal_data.lon.data, grid_data._horizontal_data.lat.data]
+            [grid_data._horizontal_data.lon[:], grid_data._horizontal_data.lat[:]]
         ),
         [1, 2, 0],
     )
@@ -409,18 +409,18 @@ def _interpolate_winds_dgrid_agrid(grid_data, ud, vd, tc_properties, shape):
         ua[:, :-1, :] = (
             0.5
             * (
-                ud[:, :-1, :] * grid_data._horizontal_data.dx.data[:, :-1, None]
-                + ud[:, 1:, :] * grid_data._horizontal_data.dx.data[:, 1:, None]
+                ud[:, :-1, :] * grid_data._horizontal_data.dx[:, :-1, None]
+                + ud[:, 1:, :] * grid_data._horizontal_data.dx[:, 1:, None]
             )
-            / grid_data.dxa.data[:, :-1, None]
+            / grid_data.dxa[:, :-1, None]
         )
         va[:-1, :, :] = (
             0.5
             * (
-                vd[:-1, :, :] * grid_data._horizontal_data.dy.data[:-1, :, None]
-                + vd[1:, :, :] * grid_data._horizontal_data.dy.data[1:, :, None]
+                vd[:-1, :, :] * grid_data._horizontal_data.dy[:-1, :, None]
+                + vd[1:, :, :] * grid_data._horizontal_data.dy[1:, :, None]
             )
-            / grid_data._horizontal_data.dya.data[:-1, :, None]
+            / grid_data._horizontal_data.dya[:-1, :, None]
         )
     else:
         pass
@@ -496,7 +496,7 @@ def init_tc_state(
     """
 
     sample_quantity = grid_data.lat
-    shape = (*sample_quantity.data.shape[:2], grid_data.ak.data.shape[0])
+    shape = (*sample_quantity.shape[:2], grid_data.ak.shape[0])
     numpy_state = init_utils.empty_numpy_dycore_state(shape)
 
     tc_properties = {

--- a/pyfv3/stencils/copy_corners.py
+++ b/pyfv3/stencils/copy_corners.py
@@ -27,7 +27,7 @@ def _corner_copy_x_numpy(field_to_copy: np.ndarray):
 
 @corner_copy_x.register(Quantity)
 def _corner_copy_x_quantity(field_to_copy: Quantity):
-    _blind_copy_corners_x(field_to_copy.data)
+    _blind_copy_corners_x(field_to_copy._data)
 
 
 def _blind_copy_corners_x(field_to_copy):
@@ -112,7 +112,7 @@ def _corner_copy_y_nupy(field_to_copy: np.ndarray):
 
 @corner_copy_y.register(Quantity)
 def _corner_copy_y_quantity(field_to_copy: Quantity):
-    _blind_copy_corners_y(field_to_copy.data)
+    _blind_copy_corners_y(field_to_copy._data)
 
 
 def _blind_copy_corners_y(field_to_copy):
@@ -200,8 +200,8 @@ class CopyCornersX(NDSLRuntime):
         self._internal_corners_copy(field)
 
     def nord(self, field: FloatField, nord: Quantity):
-        for k in dace.map[0 : nord.data.shape[0]]:
-            if nord.data[k] > 0:
+        for k in dace.map[0 : nord.shape[0]]:
+            if nord[k] > 0:
                 self._internal_corners_copy(field[:, :, k])
 
 
@@ -228,6 +228,6 @@ class CopyCornersY(NDSLRuntime):
         self._internal_corners_copy(field)
 
     def nord(self, field: FloatField, nord: Quantity):
-        for k in dace.map[0 : nord.data.shape[0]]:
-            if nord.data[k] > 0:
+        for k in dace.map[0 : nord.shape[0]]:
+            if nord[k] > 0:
                 self._internal_corners_copy(field[:, :, k])

--- a/pyfv3/stencils/del2cubed.py
+++ b/pyfv3/stencils/del2cubed.py
@@ -186,12 +186,12 @@ class HyperdiffusionDamping:
             self._corner_fill(qdel, self._q)
 
             if nt > 0:
-                self._copy_corners_x(self._q.data)
+                self._copy_corners_x(self._q)
 
             self._compute_zonal_flux[n](self._fx, self._q, self._del6_v)
 
             if nt > 0:
-                self._copy_corners_y(self._q.data)
+                self._copy_corners_y(self._q)
 
             self._compute_meridional_flux[n](self._fy, self._q, self._del6_u)
 

--- a/pyfv3/stencils/delnflux.py
+++ b/pyfv3/stencils/delnflux.py
@@ -14,11 +14,11 @@ from pyfv3.stencils.copy_corners import CopyCornersX, CopyCornersY
 
 
 def calc_damp(damp_c: Quantity, da_min: Float, nord: Quantity) -> Quantity:
-    if damp_c.dims != nord.dims or damp_c.data.shape != nord.data.shape:
+    if damp_c.dims != nord.dims or damp_c.shape != nord.shape:
         raise NotImplementedError(
-            "current implementation requires damp_c and nord to have identical data shape and dims"
+            "Current implementation requires damp_c and nord to have identical data shape and dims."
         )
-    data = (damp_c.data * da_min) ** (nord.data + 1)
+    data = (damp_c[:] * da_min) ** (nord[:] + 1)
     return Quantity(
         data=data,
         dims=damp_c.dims,
@@ -445,11 +445,11 @@ class DelnFluxNoSG(NDSLRuntime):
         else:
             self._copy_stencil_interval(q_in=q, q_out=d2, nord=self._nord)
 
-        self.copy_corners_x.nord(d2.data, self._nord)
+        self.copy_corners_x.nord(d2, self._nord)
 
         self._fx_calc_stencil(q=d2, del6_v=self._del6_v, fx=fx2, nord=self._nord)
 
-        self.copy_corners_y.nord(d2.data, self._nord)
+        self.copy_corners_y.nord(d2, self._nord)
 
         self._fy_calc_stencil(q=d2, del6_u=self._del6_u, fy=fy2, nord=self._nord)
 
@@ -466,13 +466,13 @@ class DelnFluxNoSG(NDSLRuntime):
                 current_nord=n,
             )
 
-            self.copy_corners_x.nord(d2.data, self._nord)
+            self.copy_corners_x.nord(d2, self._nord)
 
             self._column_conditional_fx_calculation[n](
                 q=d2, del6_v=self._del6_v, fx=fx2, nord=self._nord, current_nord=n
             )
 
-            self.copy_corners_y.nord(d2.data, self._nord)
+            self.copy_corners_y.nord(d2, self._nord)
 
             self._column_conditional_fy_calculation[n](
                 q=d2, del6_u=self._del6_u, fy=fy2, nord=self._nord, current_nord=n

--- a/pyfv3/stencils/dyn_core.py
+++ b/pyfv3/stencils/dyn_core.py
@@ -502,7 +502,7 @@ class AcousticDynamics:
                 dtype=Float,
             )
             self._zs[:] = self._zs.np.asarray(
-                phis.data / constants.GRAV, dtype=self._zs.data.dtype
+                phis[:] / constants.GRAV, dtype=self._zs.dtype
             )
 
             self.update_height_on_d_grid = updatedzd.UpdateHeightOnDGrid(

--- a/pyfv3/testing/translate_dyncore.py
+++ b/pyfv3/testing/translate_dyncore.py
@@ -153,14 +153,14 @@ class TranslateDynCore(ParallelTranslate2PyState):
                 # the ndarray can have buffer points at the end, so value.shape
                 # is often not equal to state[name].shape
                 selection = tuple(slice(0, end) for end in value.shape)
-                state[name].data[selection] = value
+                state[name][selection] = value
             else:
                 setattr(state, name, value)
         phis: Quantity = self.grid.quantity_factory.zeros(
             dims=[I_DIM, J_DIM],
             units="m",
         )
-        phis.data[:] = phis.np.asarray(inputs["phis"])
+        phis[:] = phis.np.asarray(inputs["phis"])
         acoustic_dynamics = dyn_core.AcousticDynamics(
             comm=communicator,
             stencil_factory=self.stencil_factory,
@@ -172,10 +172,10 @@ class TranslateDynCore(ParallelTranslate2PyState):
             stretched_grid=self.grid.stretched_grid,
             config=self.config.acoustic_dynamics,
             phis=phis,
-            wsd=wsd.data,
+            wsd=wsd,
             state=state,
         )
-        acoustic_dynamics.cappa.data[:] = inputs["cappa"][:]
+        acoustic_dynamics.cappa[:] = inputs["cappa"][:]
 
         acoustic_dynamics(state, timestep=inputs["mdt"], n_map=state.n_map)  # type: ignore[attr-defined]
         # the "inputs" dict is not used to return, we construct a new dict based
@@ -183,9 +183,9 @@ class TranslateDynCore(ParallelTranslate2PyState):
         storages_only = {}
         for name, value in vars(state).items():
             if isinstance(value, Quantity):
-                storages_only[name] = value.data
+                storages_only[name] = value[:]
             else:
                 storages_only[name] = value
-        storages_only["wsd"] = wsd.data
-        storages_only["cappa"] = acoustic_dynamics.cappa.data
+        storages_only["wsd"] = wsd[:]
+        storages_only["cappa"] = acoustic_dynamics.cappa[:]
         return self._base.slice_output(storages_only)

--- a/pyfv3/testing/validation.py
+++ b/pyfv3/testing/validation.py
@@ -72,14 +72,9 @@ def get_selective_class(
             for name, validation_slice in self._validation_slice.items():
                 if name in kwargs.keys():
                     array = kwargs[name]
-                    try:
-                        validation_data = np.copy(array[validation_slice])
-                        array[:] = np.nan
-                        array[validation_slice] = validation_data
-                    except TypeError:
-                        validation_data = np.copy(array.data[validation_slice])
-                        array.data[:] = np.nan
-                        array.data[validation_slice] = validation_data
+                    validation_data = np.copy(array[validation_slice])
+                    array[:] = np.nan
+                    array[validation_slice] = validation_data
 
         def __getattr__(self, name):
             # if SelectivelyValidated doesn't have an attribute, this is called
@@ -132,9 +127,9 @@ def get_selective_tracer_advection(
         def _set_nans(self, tracers: Mapping[str, Quantity]):
             # tracers is a dict of Quantity for this routine
             for quantity in tracers.values():
-                validation_data = np.copy(quantity.data[self._validation_slice])
-                quantity.data[:] = np.nan
-                quantity.data[self._validation_slice] = validation_data
+                validation_data = np.copy(quantity[self._validation_slice])
+                quantity[:] = np.nan
+                quantity[self._validation_slice] = validation_data
 
     return SelectivelyValidatedTracerAdvection
 

--- a/pyfv3/utils/functional_validation.py
+++ b/pyfv3/utils/functional_validation.py
@@ -44,20 +44,14 @@ def get_set_nan_func(
     grid_indexing: GridIndexing,
     dims: Sequence[str],
     n_halo: tuple[tuple[int, int], tuple[int, int]] = ((0, 0), (0, 0)),
-) -> Callable[[np.ndarray], np.ndarray]:
+) -> Callable[[np.ndarray], None]:
     subset = get_subset_func(grid_indexing=grid_indexing, dims=dims, n_halo=n_halo)
 
-    def set_nans(data: np.ndarray) -> np.ndarray:
-        try:
-            safe = copy.deepcopy(data)
-            data[:] = np.nan
-            # data_subset is a view of data, so modifying data_subset modifies data
-            data_subset = subset(data)
-            data_subset[:] = subset(safe)
-        except TypeError:
-            safe = copy.deepcopy(data.data)
-            data.data[:] = np.nan
-            data_subset = subset(data.data)
-            data_subset[:] = subset(safe)
+    def set_nans(data: np.ndarray) -> None:
+        safe = copy.deepcopy(data)
+        data[:] = np.nan
+        # data_subset is a view of data, so modifying data_subset modifies data
+        data_subset = subset(data)
+        data_subset[:] = subset(safe)
 
     return set_nans

--- a/pyfv3/wrappers/geos_wrapper.py
+++ b/pyfv3/wrappers/geos_wrapper.py
@@ -376,7 +376,7 @@ class GeosDycoreWrapper:
         safe_assign_array(state.cyd.view[:], cyd[isc:iec, :, :])
 
         safe_assign_array(state.ps.view[:], ps[isc:iec, jsc:jec])
-        safe_assign_array(state.pe.data[isc - 1 : iec + 1, jsc - 1 : jec + 1, :], pe)
+        safe_assign_array(state.pe[isc - 1 : iec + 1, jsc - 1 : jec + 1, :], pe)
         safe_assign_array(state.pk.view[:], pk)
         safe_assign_array(state.peln.view[:], peln)
         safe_assign_array(state.pkz.view[:], pkz)
@@ -405,129 +405,117 @@ class GeosDycoreWrapper:
         jec = self._grid_indexing.jec + 1
 
         if self._fortran_mem_space != self._pace_mem_space:
-            safe_assign_array(output_dict["u"], self.dycore_state.u.data[:-1, :, :-1])
-            safe_assign_array(output_dict["v"], self.dycore_state.v.data[:, :-1, :-1])
-            safe_assign_array(output_dict["w"], self.dycore_state.w.data[:-1, :-1, :-1])
-            safe_assign_array(
-                output_dict["ua"], self.dycore_state.ua.data[:-1, :-1, :-1]
-            )
-            safe_assign_array(
-                output_dict["va"], self.dycore_state.va.data[:-1, :-1, :-1]
-            )
-            safe_assign_array(output_dict["uc"], self.dycore_state.uc.data[:, :-1, :-1])
-            safe_assign_array(output_dict["vc"], self.dycore_state.vc.data[:-1, :, :-1])
+            safe_assign_array(output_dict["u"], self.dycore_state.u[:-1, :, :-1])
+            safe_assign_array(output_dict["v"], self.dycore_state.v[:, :-1, :-1])
+            safe_assign_array(output_dict["w"], self.dycore_state.w[:-1, :-1, :-1])
+            safe_assign_array(output_dict["ua"], self.dycore_state.ua[:-1, :-1, :-1])
+            safe_assign_array(output_dict["va"], self.dycore_state.va[:-1, :-1, :-1])
+            safe_assign_array(output_dict["uc"], self.dycore_state.uc[:, :-1, :-1])
+            safe_assign_array(output_dict["vc"], self.dycore_state.vc[:-1, :, :-1])
 
             safe_assign_array(
-                output_dict["delz"], self.dycore_state.delz.data[:-1, :-1, :-1]
+                output_dict["delz"], self.dycore_state.delz[:-1, :-1, :-1]
             )
+            safe_assign_array(output_dict["pt"], self.dycore_state.pt[:-1, :-1, :-1])
             safe_assign_array(
-                output_dict["pt"], self.dycore_state.pt.data[:-1, :-1, :-1]
-            )
-            safe_assign_array(
-                output_dict["delp"], self.dycore_state.delp.data[:-1, :-1, :-1]
+                output_dict["delp"], self.dycore_state.delp[:-1, :-1, :-1]
             )
 
             safe_assign_array(
                 output_dict["mfxd"],
-                self.dycore_state.mfxd.data[isc : iec + 1, jsc:jec, :-1],
+                self.dycore_state.mfxd[isc : iec + 1, jsc:jec, :-1],
             )
             safe_assign_array(
                 output_dict["mfyd"],
-                self.dycore_state.mfyd.data[isc:iec, jsc : jec + 1, :-1],
+                self.dycore_state.mfyd[isc:iec, jsc : jec + 1, :-1],
             )
             safe_assign_array(
-                output_dict["cxd"], self.dycore_state.cxd.data[isc : iec + 1, :-1, :-1]
+                output_dict["cxd"], self.dycore_state.cxd[isc : iec + 1, :-1, :-1]
             )
             safe_assign_array(
-                output_dict["cyd"], self.dycore_state.cyd.data[:-1, jsc : jec + 1, :-1]
+                output_dict["cyd"], self.dycore_state.cyd[:-1, jsc : jec + 1, :-1]
             )
 
-            safe_assign_array(output_dict["ps"], self.dycore_state.ps.data[:-1, :-1])
+            safe_assign_array(output_dict["ps"], self.dycore_state.ps[:-1, :-1])
             safe_assign_array(
                 output_dict["pe"],
-                self.dycore_state.pe.data[isc - 1 : iec + 1, jsc - 1 : jec + 1, :],
+                self.dycore_state.pe[isc - 1 : iec + 1, jsc - 1 : jec + 1, :],
             )
             safe_assign_array(
-                output_dict["pk"], self.dycore_state.pk.data[isc:iec, jsc:jec, :]
+                output_dict["pk"], self.dycore_state.pk[isc:iec, jsc:jec, :]
             )
             safe_assign_array(
-                output_dict["peln"], self.dycore_state.peln.data[isc:iec, jsc:jec, :]
+                output_dict["peln"], self.dycore_state.peln[isc:iec, jsc:jec, :]
             )
             safe_assign_array(
-                output_dict["pkz"], self.dycore_state.pkz.data[isc:iec, jsc:jec, :-1]
+                output_dict["pkz"], self.dycore_state.pkz[isc:iec, jsc:jec, :-1]
+            )
+            safe_assign_array(output_dict["phis"], self.dycore_state.phis[:-1, :-1])
+            safe_assign_array(
+                output_dict["q_con"], self.dycore_state.q_con[:-1, :-1, :-1]
             )
             safe_assign_array(
-                output_dict["phis"], self.dycore_state.phis.data[:-1, :-1]
-            )
-            safe_assign_array(
-                output_dict["q_con"], self.dycore_state.q_con.data[:-1, :-1, :-1]
-            )
-            safe_assign_array(
-                output_dict["omga"], self.dycore_state.omga.data[:-1, :-1, :-1]
+                output_dict["omga"], self.dycore_state.omga[:-1, :-1, :-1]
             )
             safe_assign_array(
                 output_dict["diss_estd"],
-                self.dycore_state.diss_estd.data[:-1, :-1, :-1],
+                self.dycore_state.diss_estd[:-1, :-1, :-1],
             )
 
             safe_assign_array(
-                output_dict["qvapor"], self.dycore_state.qvapor.data[:-1, :-1, :-1]
+                output_dict["qvapor"], self.dycore_state.qvapor[:-1, :-1, :-1]
             )
             safe_assign_array(
-                output_dict["qliquid"], self.dycore_state.qliquid.data[:-1, :-1, :-1]
+                output_dict["qliquid"], self.dycore_state.qliquid[:-1, :-1, :-1]
             )
             safe_assign_array(
-                output_dict["qice"], self.dycore_state.qice.data[:-1, :-1, :-1]
+                output_dict["qice"], self.dycore_state.qice[:-1, :-1, :-1]
             )
             safe_assign_array(
-                output_dict["qrain"], self.dycore_state.qrain.data[:-1, :-1, :-1]
+                output_dict["qrain"], self.dycore_state.qrain[:-1, :-1, :-1]
             )
             safe_assign_array(
-                output_dict["qsnow"], self.dycore_state.qsnow.data[:-1, :-1, :-1]
+                output_dict["qsnow"], self.dycore_state.qsnow[:-1, :-1, :-1]
             )
             safe_assign_array(
-                output_dict["qgraupel"], self.dycore_state.qgraupel.data[:-1, :-1, :-1]
+                output_dict["qgraupel"], self.dycore_state.qgraupel[:-1, :-1, :-1]
             )
             safe_assign_array(
-                output_dict["qcld"], self.dycore_state.qcld.data[:-1, :-1, :-1]
+                output_dict["qcld"], self.dycore_state.qcld[:-1, :-1, :-1]
             )
         else:
-            output_dict["u"] = self.dycore_state.u.data[:-1, :, :-1]
-            output_dict["v"] = self.dycore_state.v.data[:, :-1, :-1]
-            output_dict["w"] = self.dycore_state.w.data[:-1, :-1, :-1]
-            output_dict["ua"] = self.dycore_state.ua.data[:-1, :-1, :-1]
-            output_dict["va"] = self.dycore_state.va.data[:-1, :-1, :-1]
-            output_dict["uc"] = self.dycore_state.uc.data[:, :-1, :-1]
-            output_dict["vc"] = self.dycore_state.vc.data[:-1, :, :-1]
-            output_dict["delz"] = self.dycore_state.delz.data[:-1, :-1, :-1]
-            output_dict["pt"] = self.dycore_state.pt.data[:-1, :-1, :-1]
-            output_dict["delp"] = self.dycore_state.delp.data[:-1, :-1, :-1]
-            output_dict["mfxd"] = self.dycore_state.mfxd.data[
-                isc : iec + 1, jsc:jec, :-1
-            ]
-            output_dict["mfyd"] = self.dycore_state.mfyd.data[
-                isc:iec, jsc : jec + 1, :-1
-            ]
-            output_dict["cxd"] = self.dycore_state.cxd.data[isc : iec + 1, :-1, :-1]
-            output_dict["cyd"] = self.dycore_state.cyd.data[:-1, jsc : jec + 1, :-1]
-            output_dict["ps"] = self.dycore_state.ps.data[:-1, :-1]
-            output_dict["pe"] = self.dycore_state.pe.data[
+            output_dict["u"] = self.dycore_state.u[:-1, :, :-1]
+            output_dict["v"] = self.dycore_state.v[:, :-1, :-1]
+            output_dict["w"] = self.dycore_state.w[:-1, :-1, :-1]
+            output_dict["ua"] = self.dycore_state.ua[:-1, :-1, :-1]
+            output_dict["va"] = self.dycore_state.va[:-1, :-1, :-1]
+            output_dict["uc"] = self.dycore_state.uc[:, :-1, :-1]
+            output_dict["vc"] = self.dycore_state.vc[:-1, :, :-1]
+            output_dict["delz"] = self.dycore_state.delz[:-1, :-1, :-1]
+            output_dict["pt"] = self.dycore_state.pt[:-1, :-1, :-1]
+            output_dict["delp"] = self.dycore_state.delp[:-1, :-1, :-1]
+            output_dict["mfxd"] = self.dycore_state.mfxd[isc : iec + 1, jsc:jec, :-1]
+            output_dict["mfyd"] = self.dycore_state.mfyd[isc:iec, jsc : jec + 1, :-1]
+            output_dict["cxd"] = self.dycore_state.cxd[isc : iec + 1, :-1, :-1]
+            output_dict["cyd"] = self.dycore_state.cyd[:-1, jsc : jec + 1, :-1]
+            output_dict["ps"] = self.dycore_state.ps[:-1, :-1]
+            output_dict["pe"] = self.dycore_state.pe[
                 isc - 1 : iec + 1, jsc - 1 : jec + 1, :
             ]
-            output_dict["pk"] = self.dycore_state.pk.data[isc:iec, jsc:jec, :]
-            output_dict["peln"] = self.dycore_state.peln.data[isc:iec, jsc:jec, :]
-            output_dict["pkz"] = self.dycore_state.pkz.data[isc:iec, jsc:jec, :-1]
-            output_dict["phis"] = self.dycore_state.phis.data[:-1, :-1]
-            output_dict["q_con"] = self.dycore_state.q_con.data[:-1, :-1, :-1]
-            output_dict["omga"] = self.dycore_state.omga.data[:-1, :-1, :-1]
-            output_dict["diss_estd"] = self.dycore_state.diss_estd.data[:-1, :-1, :-1]
-            output_dict["qvapor"] = self.dycore_state.qvapor.data[:-1, :-1, :-1]
-            output_dict["qliquid"] = self.dycore_state.qliquid.data[:-1, :-1, :-1]
-            output_dict["qice"] = self.dycore_state.qice.data[:-1, :-1, :-1]
-            output_dict["qrain"] = self.dycore_state.qrain.data[:-1, :-1, :-1]
-            output_dict["qsnow"] = self.dycore_state.qsnow.data[:-1, :-1, :-1]
-            output_dict["qgraupel"] = self.dycore_state.qgraupel.data[:-1, :-1, :-1]
-            output_dict["qcld"] = self.dycore_state.qcld.data[:-1, :-1, :-1]
+            output_dict["pk"] = self.dycore_state.pk[isc:iec, jsc:jec, :]
+            output_dict["peln"] = self.dycore_state.peln[isc:iec, jsc:jec, :]
+            output_dict["pkz"] = self.dycore_state.pkz[isc:iec, jsc:jec, :-1]
+            output_dict["phis"] = self.dycore_state.phis[:-1, :-1]
+            output_dict["q_con"] = self.dycore_state.q_con[:-1, :-1, :-1]
+            output_dict["omga"] = self.dycore_state.omga[:-1, :-1, :-1]
+            output_dict["diss_estd"] = self.dycore_state.diss_estd[:-1, :-1, :-1]
+            output_dict["qvapor"] = self.dycore_state.qvapor[:-1, :-1, :-1]
+            output_dict["qliquid"] = self.dycore_state.qliquid[:-1, :-1, :-1]
+            output_dict["qice"] = self.dycore_state.qice[:-1, :-1, :-1]
+            output_dict["qrain"] = self.dycore_state.qrain[:-1, :-1, :-1]
+            output_dict["qsnow"] = self.dycore_state.qsnow[:-1, :-1, :-1]
+            output_dict["qgraupel"] = self.dycore_state.qgraupel[:-1, :-1, :-1]
+            output_dict["qcld"] = self.dycore_state.qcld[:-1, :-1, :-1]
 
         return output_dict
 

--- a/tests/savepoint/translate/translate_a2b_ord4.py
+++ b/tests/savepoint/translate/translate_a2b_ord4.py
@@ -62,7 +62,7 @@ class TranslateA2B_Ord4(TranslateDycoreFortranData2Py):
 
     def compute_from_storage(self, inputs):
         nord_col = self.grid.quantity_factory.zeros(dims=[K_DIM], units="unknown")
-        nord_col.data[:] = nord_col.np.asarray(inputs.pop("nord_col"))
+        nord_col[:] = nord_col.np.asarray(inputs.pop("nord_col"))
         divdamp = DivergenceDamping(
             self.stencil_factory,
             self.grid.quantity_factory,

--- a/tests/savepoint/translate/translate_del6vtflux.py
+++ b/tests/savepoint/translate/translate_del6vtflux.py
@@ -40,7 +40,7 @@ class TranslateDel6VtFlux(TranslateDycoreFortranData2Py):
     def compute(self, inputs):
         self.make_storage_data_input_vars(inputs)
         nord_col = self.grid.quantity_factory.zeros(dims=[K_DIM], units="unknown")
-        nord_col.data[:] = nord_col.np.asarray(inputs.pop("nord_w"))
+        nord_col[:] = nord_col.np.asarray(inputs.pop("nord_w"))
         self.compute_func = delnflux.DelnFluxNoSG(  # type: ignore
             self.stencil_factory,
             self.grid.damping_coefficients,
@@ -52,7 +52,7 @@ class TranslateDel6VtFlux(TranslateDycoreFortranData2Py):
         d2 = self.grid.quantity_factory.zeros(
             dims=[I_DIM, J_DIM, K_INTERFACE_DIM], units="unknown", dtype=Float
         )
-        d2.data[:] = d2.np.asarray(inputs.pop("d2"))
+        d2[:] = d2.np.asarray(inputs.pop("d2"))
         inputs["d2"] = d2
 
         self.compute_func(**inputs)

--- a/tests/savepoint/translate/translate_delnflux.py
+++ b/tests/savepoint/translate/translate_delnflux.py
@@ -32,9 +32,9 @@ class TranslateDelnFlux(TranslateDycoreFortranData2Py):
             inputs["mass"] = None
         self.make_storage_data_input_vars(inputs)
         nord_col = self.grid.quantity_factory.zeros(dims=[K_DIM], units="unknown")
-        nord_col.data[:] = nord_col.np.asarray(inputs.pop("nord_column"))
+        nord_col[:] = nord_col.np.asarray(inputs.pop("nord_column"))
         damp_c = self.grid.quantity_factory.zeros(dims=[K_DIM], units="unknown")
-        damp_c.data[:] = damp_c.np.asarray(inputs.pop("damp_c"))
+        damp_c[:] = damp_c.np.asarray(inputs.pop("damp_c"))
         self.compute_func = delnflux.DelnFlux(  # type: ignore
             self.stencil_factory,
             quantity_factory=self.grid.quantity_factory,

--- a/tests/savepoint/translate/translate_divergencedamping.py
+++ b/tests/savepoint/translate/translate_divergencedamping.py
@@ -42,9 +42,9 @@ class TranslateDivergenceDamping(TranslateDycoreFortranData2Py):
 
     def compute_from_storage(self, inputs):
         nord_col = self.grid.quantity_factory.zeros(dims=[K_DIM], units="unknown")
-        nord_col.data[:] = nord_col.np.asarray(inputs.pop("nord_col"))
+        nord_col[:] = nord_col.np.asarray(inputs.pop("nord_col"))
         d2_bg = self.grid.quantity_factory.zeros(dims=[K_DIM], units="unknown")
-        d2_bg.data[:] = d2_bg.np.asarray(inputs.pop("d2_bg"))
+        d2_bg[:] = d2_bg.np.asarray(inputs.pop("d2_bg"))
         self.divdamp = DivergenceDamping(
             self.stencil_factory,
             self.grid.quantity_factory,

--- a/tests/savepoint/translate/translate_fillz.py
+++ b/tests/savepoint/translate/translate_fillz.py
@@ -73,7 +73,7 @@ class TranslateFillz(TranslateDycoreFortranData2Py):
         )
         for i_tracer, value in tuple(inputs["tracers"].items()):
             if hasattr(value, "shape") and len(value.shape) > 1 and value.shape[1] == 1:
-                quantity_tracers.data[:, :, :, i_tracer] = self.make_storage_data(
+                quantity_tracers[:, :, :, i_tracer] = self.make_storage_data(
                     pad_field_in_j(
                         value, self.grid.njd, backend=self.stencil_factory.backend
                     )
@@ -96,7 +96,7 @@ class TranslateFillz(TranslateDycoreFortranData2Py):
             offset = -1
 
         out = {
-            "q2tracers": quantity_tracers.data[
+            "q2tracers": quantity_tracers[
                 ds["istart"] : ds["iend"] + 1, ds["jstart"], : ds["kend"] + 1, :offset
             ]
         }

--- a/tests/savepoint/translate/translate_fvtp2d.py
+++ b/tests/savepoint/translate/translate_fvtp2d.py
@@ -56,16 +56,16 @@ class TranslateFvTp2d(TranslateDycoreFortranData2Py):
         nord_col = self.grid.quantity_factory.zeros(
             dims=[K_DIM], units="unknown", dtype=Float
         )
-        nord_col.data[:] = nord_col.np.asarray(inputs.pop("nord"))
+        nord_col[:] = nord_col.np.asarray(inputs.pop("nord"))
         damp_c = self.grid.quantity_factory.zeros(
             dims=[K_DIM], units="unknown", dtype=Float
         )
-        damp_c.data[:] = damp_c.np.asarray(inputs.pop("damp_c"))
+        damp_c[:] = damp_c.np.asarray(inputs.pop("damp_c"))
 
         q = self.grid.quantity_factory.zeros(
             dims=[I_DIM, J_DIM, K_DIM], units="unknown", dtype=Float
         )
-        q.data[:] = q.np.asarray(inputs.pop("q"))
+        q[:] = q.np.asarray(inputs.pop("q"))
         inputs["q"] = q
         for optional_arg in ["mass"]:
             if optional_arg not in inputs:

--- a/tests/savepoint/translate/translate_grid.py
+++ b/tests/savepoint/translate/translate_grid.py
@@ -228,8 +228,8 @@ class TranslateGridAreas(ParallelTranslateGrid):
         )
 
         in_state = self.state_from_inputs(inputs)
-        grid_generator._grid.data[:] = in_state["grid"].data[:]
-        grid_generator._agrid.data[:] = in_state["agrid"].data[:]
+        grid_generator._grid[:] = in_state["grid"][:]
+        grid_generator._agrid[:] = in_state["agrid"][:]
         state = {}
         for metric_term, metadata in self.outputs.items():
             state[metadata["name"]] = getattr(grid_generator, metric_term)
@@ -336,7 +336,7 @@ class TranslateDxDy(ParallelTranslateGrid):
         )
 
         in_state = self.state_from_inputs(inputs)
-        grid_generator._grid.data[:] = in_state["grid"].data[:]
+        grid_generator._grid[:] = in_state["grid"][:]
         state = {}
         for metric_term, metadata in self.outputs.items():
             state[metadata["name"]] = getattr(grid_generator, metric_term)
@@ -398,7 +398,7 @@ class TranslateAGrid(ParallelTranslateGrid):
         )
 
         in_state = self.state_from_inputs(inputs)
-        grid_generator._grid.data[:] = in_state["grid"].data[:]
+        grid_generator._grid[:] = in_state["grid"][:]
         grid_generator._init_agrid()
         state = {}
         for metric_term, metadata in self.outputs.items():
@@ -576,13 +576,9 @@ class TranslateSetEta(ParallelTranslateGrid):
         state = self.state_from_inputs(inputs)
         pressure_coefficients = set_hybrid_pressure_coefficients(state["npz"])
         state["ptop"] = pressure_coefficients.ptop
-        array_type = type(state["ak"].data[:])
-        state["ak"].data[:] = utils.asarray(
-            pressure_coefficients.ak, to_type=array_type
-        )
-        state["bk"].data[:] = utils.asarray(
-            pressure_coefficients.bk, to_type=array_type
-        )
+        array_type = type(state["ak"][:])
+        state["ak"][:] = utils.asarray(pressure_coefficients.ak, to_type=array_type)
+        state["bk"][:] = utils.asarray(pressure_coefficients.bk, to_type=array_type)
         return state
 
 
@@ -754,8 +750,8 @@ class TranslateUtilVectors(ParallelTranslateGrid):
         )
 
         in_state = self.state_from_inputs(inputs)
-        grid_generator._grid.data[:] = in_state["grid"].data[:]
-        grid_generator._agrid.data[:] = in_state["agrid"].data[:]
+        grid_generator._grid[:] = in_state["grid"][:]
+        grid_generator._agrid[:] = in_state["agrid"][:]
         state = {}
         for metric_term, metadata in self.outputs.items():
             state[metadata["name"]] = getattr(grid_generator, metric_term)
@@ -1019,8 +1015,8 @@ class TranslateTrigSg(ParallelTranslateGrid):
         )
 
         in_state = self.state_from_inputs(inputs)
-        grid_generator._grid.data[:] = in_state["grid"].data[:]
-        grid_generator._agrid.data[:] = in_state["agrid"].data[:]
+        grid_generator._grid[:] = in_state["grid"][:]
+        grid_generator._agrid[:] = in_state["agrid"][:]
         grid_generator._ec1 = in_state["ec1"]
         grid_generator._ec2 = in_state["ec2"]
         state = {}
@@ -1095,7 +1091,7 @@ class TranslateAAMCorrection(ParallelTranslateGrid):
         )
 
         in_state = self.state_from_inputs(inputs)
-        grid_generator._grid.data[:] = in_state["grid"].data[:]
+        grid_generator._grid[:] = in_state["grid"][:]
         state = {}
         for metric_term, metadata in self.outputs.items():
             state[metadata["name"]] = getattr(grid_generator, metric_term)
@@ -1388,7 +1384,7 @@ class TranslateDerivedTrig(ParallelTranslateGrid):
         )
 
         in_state = self.state_from_inputs(inputs)
-        grid_generator._grid.data[:] = in_state["grid"].data[:]
+        grid_generator._grid[:] = in_state["grid"][:]
         grid_generator._cos_sg1 = in_state["cos_sg1"]
         grid_generator._cos_sg2 = in_state["cos_sg2"]
         grid_generator._cos_sg3 = in_state["cos_sg3"]
@@ -1666,7 +1662,7 @@ class TranslateInitCubedtoLatLon(ParallelTranslateGrid):
 
         in_state = self.state_from_inputs(inputs)
         grid_generator._sin_sg5 = in_state["sin_sg5"]
-        grid_generator._agrid.data[:] = in_state["agrid"].data[:]
+        grid_generator._agrid[:] = in_state["agrid"][:]
         grid_generator._ec1 = in_state["ec1"]
         grid_generator._ec2 = in_state["ec2"]
         state = {}
@@ -1804,8 +1800,8 @@ class TranslateEdgeFactors(ParallelTranslateGrid):
         )
 
         in_state = self.state_from_inputs(inputs)
-        grid_generator._grid.data[:] = in_state["grid"].data[:]
-        grid_generator._agrid.data[:] = in_state["agrid"].data[:]
+        grid_generator._grid[:] = in_state["grid"][:]
+        grid_generator._agrid[:] = in_state["agrid"][:]
         state = {}
         for metric_term, metadata in self.outputs.items():
             state[metadata["name"]] = getattr(grid_generator, metric_term)

--- a/tests/savepoint/translate/translate_init_case.py
+++ b/tests/savepoint/translate/translate_init_case.py
@@ -188,10 +188,10 @@ class TranslateInitCase(ParallelTranslateBaseSlicing):
         for name, _properties in self.outputs.items():
             if isinstance(state[name], dict):
                 for tracer, _quantity in state[name].items():
-                    state[name][tracer] = state[name][tracer].data
+                    state[name][tracer] = state[name][tracer][:]
                 arrays[name] = state[name]
             elif len(self.outputs[name]["dims"]) > 0:
-                arrays[name] = state[name].data
+                arrays[name] = state[name][:]
             else:
                 outputs[name] = state[name]  # scalar
         outputs.update(self._base.slice_output(arrays))
@@ -291,7 +291,7 @@ class TranslateInitPreJab(TranslateDycoreFortranData2Py):
         self.make_storage_data_input_vars(inputs)
         for k, v in inputs.items():
             if k != "ptop":
-                inputs[k] = v.data
+                inputs[k] = v[:]
         full_shape = self.grid.domain_shape_full(add=(1, 1, 1))
         for variable in ["pe", "peln", "pk", "pkz"]:
             inputs[variable] = np.zeros(full_shape)
@@ -359,7 +359,7 @@ class TranslateJablonowskiBaroclinic(TranslateDycoreFortranData2Py):
         # testing just numpy arrays for this
         for k, v in inputs.items():
             if k != "ptop":
-                inputs[k] = v.data
+                inputs[k] = v[:]
         full_shape = self.grid.domain_shape_full(add=(1, 1, 1))
         for variable in ["u", "v", "pt", "delz", "w", "qvapor"]:
             inputs[variable] = np.zeros(full_shape)
@@ -443,7 +443,7 @@ class TranslatePVarAuxiliaryPressureVars(TranslateDycoreFortranData2Py):
         # testing just numpy arrays for this
         for k, v in inputs.items():
             if k != "ptop":
-                inputs[k] = v.data
+                inputs[k] = v[:]
 
         inputs["delz"][:] = 1.0e25
         sliced_inputs = make_sliced_inputs_dict(

--- a/tests/savepoint/translate/translate_remapping.py
+++ b/tests/savepoint/translate/translate_remapping.py
@@ -132,5 +132,5 @@ class TranslateRemapping(TranslateDycoreFortranData2Py):
         if not self.stencil_factory.backend.is_fortran_aligned():
             inputs["tracers"] = quantity_tracers[:-1, :-1, :-1, :]
         else:
-            inputs["tracers"] = quantity_tracers.data
+            inputs["tracers"] = quantity_tracers[:]
         return inputs


### PR DESCRIPTION
**Description**

Calling `.data` on a quanity is deprecated and the functionality is about to be removed in future versions of NDSL. This PR makes a pass over pyFV3 removing replacing references to `quantity.data` with direct getters and setters.

**How Has This Been Tested?**

Covered by CI, I guess - at least partly.

**Checklist:**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas: N/A
- [ ] I have made corresponding changes to the documentation: N/A
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [ ] New check tests, if applicable, are included: N/A
- [ ] Targeted model if this changed was triggered by a model need/shortcoming: N/A
