### PR TITLE
build: keep pyFV3 at NDSL 2026.07.00

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ extras = [
   "pyfv3[ndsl]",
   "pyfv3[test]"
 ]
-ndsl = ["ndsl @ git+https://github.com/NOAA-GFDL/NDSL.git@develop"]
+ndsl = ["ndsl @ git+https://github.com/NOAA-GFDL/NDSL.git@2026.07.00"]
 test = [
   "coverage",
   "pytest",


### PR DESCRIPTION
**Description**

This PR keeps `pyFV3` at the July release of NDSL. 

**How Has This Been Tested?**

CI is our friend

**Checklist:**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas: N/A
- [ ] I have made corresponding changes to the documentation: N/A
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [ ] New check tests, if applicable, are included: N/A
- [ ] Targeted model if this changed was triggered by a model need/shortcoming: N/A
