### PR TITLE
ci: change MPI implementation to openmpi

### DIFF
--- a/.github/workflows/translate.yaml
+++ b/.github/workflows/translate.yaml
@@ -41,8 +41,8 @@ jobs:
         with:
           python-version: ${{ inputs.python_version && inputs.python_version || env.python_default }}
 
-      - name: Install mpi (MPICH flavor)
-        run: pip3 install mpich
+      - name: Install mpi
+        run: pip install openmpi
 
       - name: External trigger Checkout pyFV3
         if: ${{inputs.component_name}}
@@ -60,9 +60,10 @@ jobs:
       - name: External trigger install NDSL packages
         if: ${{inputs.component_name}}
         run: |
+          cd ${GITHUB_WORKSPACE}/pyFV3/${{inputs.component_name}}
+          pip install .
           cd ${GITHUB_WORKSPACE}/pyFV3
-          cd NDSL && pip3 install . && cd ../
-          pip3 install .[test]
+          pip install .[test]
 
       - name: Install pyFV3 packages
         if: ${{ ! inputs.component_name }}
@@ -123,7 +124,7 @@ jobs:
           export NDSL_LITERAL_PRECISION=64
           export OMP_NUM_THREADS=1
           export NDSL_LOGLEVEL=Debug
-          mpiexec -np 6 coverage run --rcfile=pyproject.toml -m mpi4py -m pytest \
+          mpiexec -np 6 --oversubscribe coverage run --rcfile=pyproject.toml -m mpi4py -m pytest \
             -v -s --data_path=${{ env.DATA_PATH }} \
             --backend=orch:dace:cpu:KIJ \
             -m parallel \

--- a/.github/workflows/unit_tests.yaml
+++ b/.github/workflows/unit_tests.yaml
@@ -26,8 +26,8 @@ jobs:
         with:
           python-version: '3.12'
 
-      - name: Install mpi (MPICH flavor)
-        run: pip install mpich
+      - name: Install mpi
+        run: pip install openmpi
 
       - name: Install Python packages
         run: pip install .[ndsl,test]
@@ -38,7 +38,7 @@ jobs:
       - name: Run parallel-cpu tests
         env:
           NDSL_LOGLEVEL: Debug
-        run: mpiexec -np 9 coverage run --rcfile=pyproject.toml -m mpi4py -m pytest tests/mpi
+        run: mpiexec -np 9 --oversubscribe coverage run --rcfile=pyproject.toml -m mpi4py -m pytest tests/mpi
 
       - name: Output code coverage
         run: |


### PR DESCRIPTION
**Description**

We currently get the pip package `mpich` as MPI implementation. Recently, we've seen more and more MPI-related issues like

```none
[1786009074.556079] [runnervmvrwv9:4620 :0]        ib_iface.c:1316 UCX  ERROR mana_0: iface 0x55ea1aa0eeb0 failed to create UD QP TX wr:256 sge:6 inl:64 resp:0 RX wr:4096 sge:1 resp:0 failed: Operation not supported
[1786009074.556479] [runnervmvrwv9:4620 :0]      ucp_worker.c:1415 UCX  ERROR uct_iface_open(ud_verbs/mana_0:1) failed: Input/output error
Abort(606225807): Fatal error in internal_Init_thread: Other MPI error, error stack:
internal_Init_thread(71).: MPI_Init_thread(argc=(nil), argv=(nil), required=3, provided=0x7ffdf2bf20d0) failed
MPII_Init_thread(261)....:
MPID_Init(549)...........:
MPIDI_UCX_init_local(234):
MPIDI_UCX_init_worker(86):  ucx function returned with failed status(ucx_init.c 86 MPIDI_UCX_init_worker Input/output error)
```

where MPI fails to init because of a wonky IO error that get's triggered randomly, but more often if multiple PRs are created at the same time. Sometimes, it also shows as plain

```none
Error: Process completed with exit code 143.
```

In NDSL, we use the `openmpi` package and seem to have none of the above issues even with a relatively high load of PRs and merge requests.

This PR thus proses to switch from `mpich` to `openmpi` in an attempt to stabilize pyFV3 CI runs wrt to the above MPI failures.

**How Has This Been Tested?**

This is a hunch and I don't claim to understand what is going on here. The only evidence I have is that we aren't seeing the above issues in NDSL pipelines (where we happen to use `openmpi`).

**Checklist:**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas: N/A
- [ ] I have made corresponding changes to the documentation: N/A
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules: N/A
- [ ] New check tests, if applicable, are included: N/A
- [ ] Targeted model if this changed was triggered by a model need/shortcoming: N/A
