### PR TITLE
refactor: avoid direct gt4py imports whenever possible

### DIFF
--- a/pyfv3/stencils/c_sw.py
+++ b/pyfv3/stencils/c_sw.py
@@ -1,13 +1,17 @@
 from ndsl import Quantity, QuantityFactory, StencilFactory, orchestrate
 from ndsl.constants import I_DIM, I_INTERFACE_DIM, J_DIM, J_INTERFACE_DIM, K_DIM
-from ndsl.dsl.gt4py import PARALLEL, computation, horizontal, interval, region
+from ndsl.dsl.gt4py import (
+    __INLINED,
+    PARALLEL,
+    computation,
+    horizontal,
+    interval,
+    region,
+)
 from ndsl.dsl.typing import Float, FloatField, FloatFieldIJ
 from ndsl.grid import GridData
 from ndsl.stencils import corners
 from pyfv3.stencils.d2a2c_vect import DGrid2AGrid2CGridVectors
-
-
-from gt4py.cartesian.gtscript import __INLINED  # isort:skip
 
 
 def zero_delpc_ptc(delpc: FloatField, ptc: FloatField):

--- a/pyfv3/stencils/d_sw.py
+++ b/pyfv3/stencils/d_sw.py
@@ -2,7 +2,7 @@ from collections.abc import Mapping
 
 from ndsl import Quantity, QuantityFactory, StencilFactory, orchestrate
 from ndsl.constants import I_DIM, I_INTERFACE_DIM, J_DIM, J_INTERFACE_DIM, K_DIM
-from ndsl.dsl.gt4py import PARALLEL, computation
+from ndsl.dsl.gt4py import __INLINED, PARALLEL, computation
 from ndsl.dsl.gt4py import function as gtfunction
 from ndsl.dsl.gt4py import horizontal, interval, region
 from ndsl.dsl.typing import Float, FloatField, FloatFieldIJ, FloatFieldK
@@ -18,8 +18,6 @@ from pyfv3.stencils.xtp_u import advect_u_along_x
 from pyfv3.stencils.ytp_v import advect_v_along_y
 from pyfv3.version import IS_GEOS
 
-
-from gt4py.cartesian.gtscript import __INLINED  # isort:skip
 
 dcon_threshold = 1e-5
 

--- a/pyfv3/stencils/divergence_damping.py
+++ b/pyfv3/stencils/divergence_damping.py
@@ -6,7 +6,7 @@ import ndsl.stencils.corners as corners
 from ndsl import Quantity, QuantityFactory, StencilFactory
 from ndsl.constants import I_DIM, I_INTERFACE_DIM, J_DIM, J_INTERFACE_DIM, K_DIM
 from ndsl.dsl.dace.orchestration import dace_inhibitor, orchestrate
-from ndsl.dsl.gt4py import PARALLEL, computation
+from ndsl.dsl.gt4py import __INLINED, PARALLEL, computation
 from ndsl.dsl.gt4py import function as gtfunction
 from ndsl.dsl.gt4py import horizontal, interval, region, sqrt
 from ndsl.dsl.stencil import get_stencils_with_varied_bounds
@@ -14,9 +14,6 @@ from ndsl.dsl.typing import Float, FloatField, FloatFieldIJ, FloatFieldK
 from ndsl.grid import DampingCoefficients, GridData
 from pyfv3.stencils.a2b_ord4 import AGrid2BGridFourthOrder, doubly_periodic_a2b_ord4
 from pyfv3.stencils.d2a2c_vect import contravariant
-
-
-from gt4py.cartesian.gtscript import __INLINED  # isort:skip
 
 
 @gtfunction

--- a/pyfv3/stencils/dyn_core.py
+++ b/pyfv3/stencils/dyn_core.py
@@ -30,6 +30,7 @@ from ndsl.constants import (
 )
 from ndsl.dsl.dace.orchestration import dace_inhibitor
 from ndsl.dsl.gt4py import (
+    __INLINED,
     BACKWARD,
     FORWARD,
     PARALLEL,
@@ -49,8 +50,6 @@ from pyfv3.stencils.pk3_halo import PK3Halo
 from pyfv3.stencils.riem_solver3 import NonhydrostaticVerticalSolver
 from pyfv3.stencils.riem_solver_c import NonhydrostaticVerticalSolverCGrid
 
-
-from gt4py.cartesian.gtscript import __INLINED  # isort:skip
 
 if Float == np.float32:
     HUGE_R = Float(1.0e8)

--- a/pyfv3/stencils/fv_subgridz.py
+++ b/pyfv3/stencils/fv_subgridz.py
@@ -17,15 +17,13 @@ from ndsl.constants import (
     RDGAS,
     ZVIR,
 )
-from ndsl.dsl.gt4py import BACKWARD, PARALLEL, computation
+from ndsl.dsl.gt4py import __INLINED, BACKWARD, PARALLEL, computation
 from ndsl.dsl.gt4py import function as gtfunction
 from ndsl.dsl.gt4py import interval
 from ndsl.dsl.typing import Float, FloatField
 from ndsl.stencils.basic_operations import dim
 from pyfv3.dycore_state import DycoreState
 
-
-from gt4py.cartesian.gtscript import __INLINED  # isort:skip
 
 RK = CP_AIR / RDGAS + 1.0
 G2 = 0.5 * GRAV

--- a/pyfv3/stencils/fxadv.py
+++ b/pyfv3/stencils/fxadv.py
@@ -1,11 +1,15 @@
 from ndsl import StencilFactory, orchestrate
-from ndsl.dsl.gt4py import PARALLEL, computation, horizontal, interval, region
+from ndsl.dsl.gt4py import (
+    __INLINED,
+    PARALLEL,
+    computation,
+    horizontal,
+    interval,
+    region,
+)
 from ndsl.dsl.typing import Float, FloatField, FloatFieldIJ
 from ndsl.grid import GridData
 from pyfv3.stencils.d2a2c_vect import contravariant
-
-
-from gt4py.cartesian.gtscript import __INLINED  # isort:skip
 
 
 def main_uc_vc_contra(

--- a/pyfv3/stencils/moist_cv.py
+++ b/pyfv3/stencils/moist_cv.py
@@ -1,11 +1,8 @@
 import ndsl.constants as constants
-from ndsl.dsl.gt4py import PARALLEL, computation, exp
+from ndsl.dsl.gt4py import __INLINED, PARALLEL, computation, exp
 from ndsl.dsl.gt4py import function as gtfunction
 from ndsl.dsl.gt4py import interval, log
 from ndsl.dsl.typing import Float, FloatField
-
-
-from gt4py.cartesian.gtscript import __INLINED  # isort:skip
 
 
 @gtfunction

--- a/pyfv3/stencils/ray_fast.py
+++ b/pyfv3/stencils/ray_fast.py
@@ -1,13 +1,11 @@
 import ndsl.constants as constants
 from ndsl import StencilFactory, orchestrate
 from ndsl.constants import I_INTERFACE_DIM, J_INTERFACE_DIM, K_DIM
-from ndsl.dsl.gt4py import BACKWARD, FORWARD, PARALLEL, computation
+from ndsl.dsl.gt4py import __INLINED, BACKWARD, FORWARD, PARALLEL, computation
 from ndsl.dsl.gt4py import function as gtfunction
 from ndsl.dsl.gt4py import horizontal, interval, log, region, sin
 from ndsl.dsl.typing import Float, FloatField, FloatFieldK
 
-
-from gt4py.cartesian.gtscript import __INLINED  # isort:skip
 
 SDAY = 86400.0
 

--- a/pyfv3/stencils/remap_profile.py
+++ b/pyfv3/stencils/remap_profile.py
@@ -2,13 +2,10 @@ from collections.abc import Sequence
 
 from ndsl import NDSLRuntime, QuantityFactory, StencilFactory
 from ndsl.constants import I_DIM, J_DIM, K_DIM, K_INTERFACE_DIM
-from ndsl.dsl.gt4py import BACKWARD, FORWARD, PARALLEL, computation
+from ndsl.dsl.gt4py import __INLINED, BACKWARD, FORWARD, PARALLEL, computation
 from ndsl.dsl.gt4py import function as gtfunction
 from ndsl.dsl.gt4py import interval
 from ndsl.dsl.typing import BoolField, Float, FloatField, FloatFieldIJ
-
-
-from gt4py.cartesian.gtscript import __INLINED  # isort:skip
 
 
 @gtfunction

--- a/pyfv3/stencils/remapping.py
+++ b/pyfv3/stencils/remapping.py
@@ -8,6 +8,7 @@ from ndsl.constants import (
     K_INTERFACE_DIM,
 )
 from ndsl.dsl.gt4py import (
+    __INLINED,
     BACKWARD,
     FORWARD,
     PARALLEL,
@@ -28,8 +29,6 @@ from pyfv3.stencils.moist_cv import moist_pt_func, moist_pt_last_step
 from pyfv3.stencils.saturation_adjustment import SatAdjust3d
 from pyfv3.tracers import FVTracers
 
-
-from gt4py.cartesian.gtscript import __INLINED  # isort:skip
 
 # TODO: Should this be set here or in global_constants?
 CONSV_MIN = 0.001

--- a/pyfv3/stencils/riem_solver3.py
+++ b/pyfv3/stencils/riem_solver3.py
@@ -4,13 +4,19 @@ import typing
 import ndsl.constants as constants
 from ndsl import QuantityFactory, StencilFactory, orchestrate
 from ndsl.constants import I_DIM, J_DIM, K_DIM, K_INTERFACE_DIM
-from ndsl.dsl.gt4py import BACKWARD, FORWARD, PARALLEL, computation, exp, interval, log
+from ndsl.dsl.gt4py import (
+    __INLINED,
+    BACKWARD,
+    FORWARD,
+    PARALLEL,
+    computation,
+    exp,
+    interval,
+    log,
+)
 from ndsl.dsl.typing import Float, FloatField, FloatFieldIJ
 from pyfv3._config import RiemannConfig
 from pyfv3.stencils.sim1_solver import Sim1Solver
-
-
-from gt4py.cartesian.gtscript import __INLINED  # isort:skip
 
 
 @typing.no_type_check

--- a/pyfv3/stencils/saturation_adjustment.py
+++ b/pyfv3/stencils/saturation_adjustment.py
@@ -2,7 +2,7 @@ import math
 
 import ndsl.constants as constants
 from ndsl import StencilFactory
-from ndsl.dsl.gt4py import PARALLEL, computation, exp, floor
+from ndsl.dsl.gt4py import __INLINED, PARALLEL, computation, exp, floor
 from ndsl.dsl.gt4py import function as gtfunction
 from ndsl.dsl.gt4py import interval, log
 from ndsl.dsl.typing import Float, FloatField, FloatFieldIJ
@@ -10,8 +10,6 @@ from ndsl.stencils.basic_operations import dim
 from pyfv3._config import SatAdjustConfig
 from pyfv3.stencils.moist_cv import compute_pkz_func
 
-
-from gt4py.cartesian.gtscript import __INLINED  # isort:skip
 
 # TODO: This code could be reduced greatly with abstraction, but first gt4py
 # needs to support gtscript function calls of arbitrary depth embedded in

--- a/pyfv3/stencils/xppm.py
+++ b/pyfv3/stencils/xppm.py
@@ -1,13 +1,10 @@
 from ndsl import StencilFactory, orchestrate
-from ndsl.dsl.gt4py import PARALLEL, compile_assert, computation
+from ndsl.dsl.gt4py import __INLINED, PARALLEL, compile_assert, computation
 from ndsl.dsl.gt4py import function as gtfunction
 from ndsl.dsl.gt4py import horizontal, interval, region
 from ndsl.dsl.typing import FloatField, FloatFieldIJ, Index3D
 from ndsl.stencils.basic_operations import sign
 from pyfv3.stencils import ppm
-
-
-from gt4py.cartesian.gtscript import __INLINED  # isort:skip
 
 
 @gtfunction

--- a/pyfv3/stencils/xtp_u.py
+++ b/pyfv3/stencils/xtp_u.py
@@ -1,11 +1,8 @@
-from ndsl.dsl.gt4py import compile_assert
+from ndsl.dsl.gt4py import __INLINED, compile_assert
 from ndsl.dsl.gt4py import function as gtfunction
 from ndsl.dsl.gt4py import horizontal, region
 from ndsl.dsl.typing import Float, FloatField, FloatFieldIJ
 from pyfv3.stencils import ppm, xppm
-
-
-from gt4py.cartesian.gtscript import __INLINED  # isort:skip
 
 
 @gtfunction

--- a/pyfv3/stencils/yppm.py
+++ b/pyfv3/stencils/yppm.py
@@ -1,13 +1,10 @@
 from ndsl import StencilFactory, orchestrate
-from ndsl.dsl.gt4py import PARALLEL, compile_assert, computation
+from ndsl.dsl.gt4py import __INLINED, PARALLEL, compile_assert, computation
 from ndsl.dsl.gt4py import function as gtfunction
 from ndsl.dsl.gt4py import horizontal, interval, region
 from ndsl.dsl.typing import FloatField, FloatFieldIJ, Index3D
 from ndsl.stencils.basic_operations import sign
 from pyfv3.stencils import ppm
-
-
-from gt4py.cartesian.gtscript import __INLINED  # isort:skip
 
 
 @gtfunction

--- a/pyfv3/stencils/ytp_v.py
+++ b/pyfv3/stencils/ytp_v.py
@@ -1,11 +1,8 @@
-from ndsl.dsl.gt4py import compile_assert
+from ndsl.dsl.gt4py import __INLINED, compile_assert
 from ndsl.dsl.gt4py import function as gtfunction
 from ndsl.dsl.gt4py import horizontal, region
 from ndsl.dsl.typing import Float, FloatField, FloatFieldIJ
 from pyfv3.stencils import ppm, yppm
-
-
-from gt4py.cartesian.gtscript import __INLINED  # isort:skip
 
 
 @gtfunction

--- a/pyfv3/wrappers/geos_wrapper.py
+++ b/pyfv3/wrappers/geos_wrapper.py
@@ -6,7 +6,6 @@ from types import TracebackType
 
 import f90nml
 import numpy as np
-from gt4py.cartesian.config import build_settings as gt_build_settings
 from mpi4py import MPI
 
 import pyfv3
@@ -34,6 +33,11 @@ from ndsl.logging import ndsl_log
 from ndsl.optional_imports import cupy as cp
 from ndsl.utils import safe_assign_array
 from pyfv3.tracers import default_ai2_tracers
+
+
+# Direct GT4Py imports (if we have to) go after NDSL imports such that
+# NDSL has a chance to configure things like literal precision in GT4Py.
+from gt4py.cartesian.config import build_settings as gt_build_settings  # isort: skip
 
 
 class StencilBackendCompilerOverride:

--- a/tests/savepoint/translate/translate_d_sw.py
+++ b/tests/savepoint/translate/translate_d_sw.py
@@ -1,8 +1,8 @@
 from f90nml import Namelist
-from gt4py.cartesian.gtscript import PARALLEL, computation, interval
 
 import pyfv3.stencils.d_sw as d_sw
 from ndsl import StencilFactory
+from ndsl.dsl.gt4py import PARALLEL, computation, interval
 from ndsl.dsl.typing import FloatField, FloatFieldIJ
 from ndsl.stencils.testing.grid import Grid
 from pyfv3.testing import TranslateDycoreFortranData2Py

--- a/tests/savepoint/translate/translate_moistcvpluspt_2d.py
+++ b/tests/savepoint/translate/translate_moistcvpluspt_2d.py
@@ -1,6 +1,5 @@
-from gt4py.cartesian.gtscript import PARALLEL, computation, interval
-
 from ndsl import StencilFactory
+from ndsl.dsl.gt4py import PARALLEL, computation, interval
 from ndsl.dsl.typing import FloatField
 from ndsl.stencils.testing import pad_field_in_j
 from pyfv3.stencils import moist_cv

--- a/tests/savepoint/translate/translate_xtp_u.py
+++ b/tests/savepoint/translate/translate_xtp_u.py
@@ -1,7 +1,7 @@
 from f90nml import Namelist
-from gt4py.cartesian.gtscript import PARALLEL, computation, interval
 
 from ndsl import StencilFactory
+from ndsl.dsl.gt4py import PARALLEL, computation, interval
 from ndsl.dsl.typing import FloatField, FloatFieldIJ
 from ndsl.grid import GridData
 from pyfv3.stencils import xtp_u

--- a/tests/savepoint/translate/translate_ytp_v.py
+++ b/tests/savepoint/translate/translate_ytp_v.py
@@ -1,7 +1,7 @@
 from f90nml import Namelist
-from gt4py.cartesian.gtscript import PARALLEL, computation, interval
 
 from ndsl import StencilFactory
+from ndsl.dsl.gt4py import PARALLEL, computation, interval
 from ndsl.dsl.typing import FloatField, FloatFieldIJ
 from ndsl.grid import GridData
 from pyfv3.stencils import ytp_v


### PR DESCRIPTION
**Description**

NDSL re-exports (basically) everything that should be used via `ndsl.dsl.gt4py`. In the rare exception that we import something directly from gt4py, make sure to put it after the imports of NDSL such that NDSL has a chance to properly configure gt4py (e.g. things like literal precision).

**How Has This Been Tested?**

Should be covered by CI.

**Checklist:**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation: N/A
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules: N/A
- [ ] New check tests, if applicable, are included: N/A
- [ ] Targeted model if this changed was triggered by a model need/shortcoming: N/A
