### PR TITLE
update data dimensions field registration to use kwargs

### DIFF
--- a/pyfv3/tracers.py
+++ b/pyfv3/tracers.py
@@ -43,7 +43,11 @@ def setup_fvtracers(
 
     if not DataDimensionsField.exists("FVTracers"):
         DataDimensionsField.register(
-            FVTracers, quantity_factory, [FVTracersAxisName], name_mapping, dtype=Float
+            FVTracers,
+            quantity_factory,
+            data_dimensions_names=[FVTracersAxisName],
+            name_mapping=name_mapping,
+            dtype=Float,
         )
 
 


### PR DESCRIPTION
**Description**

Usage without kwargs was deprecated in PR https://github.com/NOAA-GFDL/NDSL/pull/503 and kwargs are now being erforced. This thus needs to change.

**How Has This Been Tested?**

All good as long as CI is still green. PR https://github.com/NOAA-GFDL/NDSL/pull/535 will enforce kwargs usage.

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [ ] New check tests, if applicable, are included
- [ ] Targeted model if this changed was triggered by a model need/shortcoming
